### PR TITLE
Update Training Lab components to use 'recoveryBalance' instead of 'r…

### DIFF
--- a/src/app/training-lab/page.tsx
+++ b/src/app/training-lab/page.tsx
@@ -377,7 +377,7 @@ export default function TrainingLabPage() {
                     />
                     <ScoreCard
                       label="Recovery"
-                      score={latestReport.scores.recoverySignals}
+                      score={latestReport.scores.recoveryBalance}
                       description="Fatigue signals"
                     />
                   </div>

--- a/src/components/training-lab/charts/score-radial-chart.tsx
+++ b/src/components/training-lab/charts/score-radial-chart.tsx
@@ -12,7 +12,7 @@ interface Scores {
   volumeAdherence: number;
   intensityManagement: number;
   muscleBalance: number;
-  recoverySignals: number;
+  recoveryBalance: number;
 }
 
 interface ScoreRadialChartProps {
@@ -32,7 +32,7 @@ export function ScoreRadialChart({ scores, className }: ScoreRadialChartProps) {
     { category: "Volume", score: scores.volumeAdherence, fullMark: 100 },
     { category: "Intensity", score: scores.intensityManagement, fullMark: 100 },
     { category: "Balance", score: scores.muscleBalance, fullMark: 100 },
-    { category: "Recovery", score: scores.recoverySignals, fullMark: 100 },
+    { category: "Recovery", score: scores.recoveryBalance, fullMark: 100 },
   ];
 
   return (


### PR DESCRIPTION
…ecoverySignals'

- Modified the `ScoreCard` and `ScoreRadialChart` components to reflect the updated score property name for consistency.
- Ensured all references to recovery scores are aligned with the new schema.