### PR TITLE
feat: add workout time editing for active and completed workouts

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -26,6 +26,7 @@ import type * as exercises from "../exercises.js";
 import type * as feedback from "../feedback.js";
 import type * as http from "../http.js";
 import type * as lib_equipment from "../lib/equipment.js";
+import type * as lib_logger from "../lib/logger.js";
 import type * as lib_rateLimit from "../lib/rateLimit.js";
 import type * as routines from "../routines.js";
 import type * as seed from "../seed.js";
@@ -58,6 +59,7 @@ declare const fullApi: ApiFromModules<{
   feedback: typeof feedback;
   http: typeof http;
   "lib/equipment": typeof lib_equipment;
+  "lib/logger": typeof lib_logger;
   "lib/rateLimit": typeof lib_rateLimit;
   routines: typeof routines;
   seed: typeof seed;

--- a/convex/workouts.ts
+++ b/convex/workouts.ts
@@ -1,7 +1,114 @@
 import { v } from "convex/values";
+import type { Doc, Id } from "./_generated/dataModel";
+import type { MutationCtx } from "./_generated/server";
 import { mutation, query } from "./_generated/server";
 import { getCurrentUser } from "./auth";
 import { createConvexLogger, truncateId } from "./lib/logger";
+
+type WorkoutSummary = NonNullable<Doc<"workouts">["summary"]>;
+
+async function getWorkoutEntries(
+  ctx: MutationCtx,
+  workoutId: Id<"workouts">
+): Promise<Doc<"entries">[]> {
+  return ctx.db
+    .query("entries")
+    .withIndex("by_workout_created", (q) => q.eq("workoutId", workoutId))
+    .collect();
+}
+
+function buildWorkoutSummary(
+  entries: Doc<"entries">[],
+  startedAt: number,
+  completedAt: number
+): WorkoutSummary {
+  let totalVolume = 0;
+  let totalSets = 0;
+  let totalCardioDurationSeconds = 0;
+  let totalDistanceKm = 0;
+  let hasCardio = false;
+  let hasMobility = false;
+  const exerciseNames = new Set<string>();
+
+  for (const entry of entries) {
+    exerciseNames.add(entry.exerciseName);
+
+    if (entry.kind === "lifting" && entry.lifting) {
+      totalSets++;
+      if (entry.lifting.weight && entry.lifting.reps) {
+        totalVolume += entry.lifting.weight * entry.lifting.reps;
+      }
+      continue;
+    }
+
+    if (entry.kind === "cardio" && entry.cardio) {
+      hasCardio = true;
+      totalCardioDurationSeconds += entry.cardio.durationSeconds;
+      if (entry.cardio.distance && entry.cardio.distanceUnit) {
+        const distanceKm =
+          entry.cardio.distanceUnit === "km"
+            ? entry.cardio.distance
+            : entry.cardio.distanceUnit === "mi"
+              ? entry.cardio.distance * 1.60934
+              : entry.cardio.distance / 1000;
+        totalDistanceKm += distanceKm;
+      }
+      continue;
+    }
+
+    if (entry.kind === "mobility") {
+      hasMobility = true;
+    }
+  }
+
+  const totalDurationMinutes = Math.round((completedAt - startedAt) / 60000);
+
+  return {
+    totalVolume,
+    totalSets,
+    totalDurationMinutes,
+    exerciseCount: exerciseNames.size,
+    totalCardioDurationSeconds: hasCardio ? totalCardioDurationSeconds : undefined,
+    totalDistanceKm: totalDistanceKm > 0 ? totalDistanceKm : undefined,
+    hasCardio: hasCardio || undefined,
+    hasMobility: hasMobility || undefined,
+  };
+}
+
+function validateWorkoutTimeRange({
+  entries,
+  startedAt,
+  completedAt,
+  now,
+}: {
+  entries: Doc<"entries">[];
+  startedAt: number;
+  completedAt: number;
+  now: number;
+}) {
+  if (startedAt >= completedAt) {
+    throw new Error("End time must be after start time");
+  }
+
+  if (startedAt > now || completedAt > now) {
+    throw new Error("Times can't be in the future");
+  }
+
+  if (entries.length === 0) {
+    return;
+  }
+
+  const earliestEntry = entries[0]?.createdAt;
+  const latestEntry = entries[entries.length - 1]?.createdAt;
+
+  if (earliestEntry !== undefined && startedAt > earliestEntry) {
+    throw new Error("Workout can't start after logged entries");
+  }
+
+  if (latestEntry !== undefined && completedAt < latestEntry) {
+    throw new Error("Workout can't end before logged entries");
+  }
+}
 
 export const createWorkout = mutation({
   args: {
@@ -93,6 +200,8 @@ export const completeWorkout = mutation({
   args: {
     workoutId: v.id("workouts"),
     notes: v.optional(v.string()),
+    startedAtOverride: v.optional(v.number()),
+    completedAtOverride: v.optional(v.number()),
   },
   handler: async (ctx, args) => {
     const logger = createConvexLogger("workouts.completeWorkout");
@@ -123,69 +232,108 @@ export const completeWorkout = mutation({
       throw new Error("Workout is not in progress");
     }
 
-    const entries = await ctx.db
-      .query("entries")
-      .withIndex("by_workout", (q) => q.eq("workoutId", args.workoutId))
-      .collect();
+    const entries = await getWorkoutEntries(ctx, args.workoutId);
+    const startedAt = args.startedAtOverride ?? workout.startedAt;
+    const completedAt = args.completedAtOverride ?? Date.now();
 
-    let totalVolume = 0;
-    let totalSets = 0;
-    let totalCardioDurationSeconds = 0;
-    let totalDistanceKm = 0;
-    let hasCardio = false;
-    let hasMobility = false;
-    const exerciseNames = new Set<string>();
+    validateWorkoutTimeRange({
+      entries,
+      startedAt,
+      completedAt,
+      now: Date.now(),
+    });
 
-    for (const entry of entries) {
-      exerciseNames.add(entry.exerciseName);
-      if (entry.kind === "lifting" && entry.lifting) {
-        totalSets++;
-        if (entry.lifting.weight && entry.lifting.reps) {
-          totalVolume += entry.lifting.weight * entry.lifting.reps;
-        }
-      } else if (entry.kind === "cardio" && entry.cardio) {
-        hasCardio = true;
-        totalCardioDurationSeconds += entry.cardio.durationSeconds;
-        if (entry.cardio.distance && entry.cardio.distanceUnit) {
-          const distanceKm = entry.cardio.distanceUnit === "km" 
-            ? entry.cardio.distance 
-            : entry.cardio.distanceUnit === "mi" 
-              ? entry.cardio.distance * 1.60934 
-              : entry.cardio.distance / 1000;
-          totalDistanceKm += distanceKm;
-        }
-      } else if (entry.kind === "mobility") {
-        hasMobility = true;
-      }
-    }
-
-    const completedAt = Date.now();
-    const totalDurationMinutes = Math.round((completedAt - workout.startedAt) / 60000);
+    const summary = buildWorkoutSummary(entries, startedAt, completedAt);
 
     await ctx.db.patch(args.workoutId, {
       status: "completed",
+      startedAt,
       completedAt,
       notes: args.notes,
-      summary: {
-        totalVolume,
-        totalSets,
-        totalDurationMinutes,
-        exerciseCount: exerciseNames.size,
-        totalCardioDurationSeconds: hasCardio ? totalCardioDurationSeconds : undefined,
-        totalDistanceKm: totalDistanceKm > 0 ? totalDistanceKm : undefined,
-        hasCardio: hasCardio || undefined,
-        hasMobility: hasMobility || undefined,
-      },
+      summary,
     });
 
     logger.success({
       workout: {
         id: truncateId(args.workoutId),
         status: "completed",
-        exerciseCount: exerciseNames.size,
-        totalSets,
-        totalVolume,
-        durationMinutes: totalDurationMinutes,
+        exerciseCount: summary.exerciseCount,
+        totalSets: summary.totalSets,
+        totalVolume: summary.totalVolume,
+        durationMinutes: summary.totalDurationMinutes,
+        usedTimeOverride:
+          args.startedAtOverride !== undefined || args.completedAtOverride !== undefined,
+      },
+    });
+
+    return args.workoutId;
+  },
+});
+
+export const updateWorkoutTimes = mutation({
+  args: {
+    workoutId: v.id("workouts"),
+    startedAt: v.number(),
+    completedAt: v.number(),
+  },
+  handler: async (ctx, args) => {
+    const logger = createConvexLogger("workouts.updateWorkoutTimes");
+
+    const user = await getCurrentUser(ctx);
+    if (!user) {
+      logger.fail(new Error("User not found"));
+      throw new Error("User not found");
+    }
+
+    logger.set({ user: { id: truncateId(user._id), tier: user.tier } });
+
+    const workout = await ctx.db.get(args.workoutId);
+    if (!workout) {
+      logger.fail(new Error("Workout not found"));
+      throw new Error("Workout not found");
+    }
+
+    if (workout.userId !== user._id) {
+      logger.fail(new Error("Not authorized"));
+      throw new Error("Not authorized");
+    }
+
+    if (workout.status === "cancelled") {
+      logger.fail(new Error("Cancelled workouts can't be edited"), {
+        workout: { id: truncateId(args.workoutId), status: workout.status },
+      });
+      throw new Error("Cancelled workouts can't be edited");
+    }
+
+    if (workout.status !== "completed") {
+      logger.fail(new Error("Only completed workouts can be edited"), {
+        workout: { id: truncateId(args.workoutId), status: workout.status },
+      });
+      throw new Error("Only completed workouts can be edited");
+    }
+
+    const entries = await getWorkoutEntries(ctx, args.workoutId);
+
+    validateWorkoutTimeRange({
+      entries,
+      startedAt: args.startedAt,
+      completedAt: args.completedAt,
+      now: Date.now(),
+    });
+
+    const summary = buildWorkoutSummary(entries, args.startedAt, args.completedAt);
+
+    await ctx.db.patch(args.workoutId, {
+      startedAt: args.startedAt,
+      completedAt: args.completedAt,
+      summary,
+    });
+
+    logger.success({
+      workout: {
+        id: truncateId(args.workoutId),
+        status: workout.status,
+        durationMinutes: summary.totalDurationMinutes,
       },
     });
 

--- a/src/app/history/page.tsx
+++ b/src/app/history/page.tsx
@@ -32,9 +32,9 @@ type Workout = {
 
 export default function HistoryPage() {
   const [showStartSheet, setShowStartSheet] = useState(false);
-  const workouts = useQuery(api.workouts.getWorkoutHistory, { 
+  const workouts = useQuery(api.workouts.getWorkoutHistory, {
     limit: 100,
-    status: "all" 
+    status: "completed"
   });
 
   const formatDate = (timestamp: number) => {

--- a/src/app/workout/[id]/page.tsx
+++ b/src/app/workout/[id]/page.tsx
@@ -2,7 +2,7 @@
 
 import { useState } from "react";
 import { useParams, useRouter } from "next/navigation";
-import { useQuery } from "convex/react";
+import { useMutation, useQuery } from "convex/react";
 import { api } from "../../../../convex/_generated/api";
 import { Id } from "../../../../convex/_generated/dataModel";
 import { Card } from "@/components/ui/card";
@@ -12,6 +12,9 @@ import { Badge } from "@/components/ui/badge";
 import { ArrowLeft, Clock, Download, Dumbbell, MessageSquare, Route, Timer, Weight } from "lucide-react";
 import Link from "next/link";
 import { ExportWorkoutDialog } from "@/components/workout/export-workout-dialog";
+import { WorkoutTimeEditorDialog } from "@/components/workout/workout-time-editor-dialog";
+import { toast } from "sonner";
+import posthog from "posthog-js";
 
 type LiftingEntry = {
   _id: string;
@@ -52,9 +55,12 @@ export default function WorkoutDetailsPage() {
   const router = useRouter();
   const workoutId = params.id as Id<"workouts">;
   const [showExportDialog, setShowExportDialog] = useState(false);
+  const [showTimeEditor, setShowTimeEditor] = useState(false);
+  const [isUpdatingTimes, setIsUpdatingTimes] = useState(false);
 
   const workout = useQuery(api.workouts.getWorkoutWithEntries, { workoutId });
   const user = useQuery(api.users.getCurrentUser);
+  const updateWorkoutTimes = useMutation(api.workouts.updateWorkoutTimes);
   const isPro = user?.tier === "pro";
 
   const formatDate = (timestamp: number) => {
@@ -157,6 +163,34 @@ export default function WorkoutDetailsPage() {
   }
 
   const groupedExercises = groupEntriesByExercise(workout.entries as Entry[]);
+  const editableCompletedAt =
+    workout.completedAt ??
+    workout.startedAt + Math.max(workout.summary?.totalDurationMinutes ?? 60, 1) * 60000;
+
+  const handleUpdateTimes = async (startedAt: number, completedAt: number) => {
+    setIsUpdatingTimes(true);
+    try {
+      await updateWorkoutTimes({
+        workoutId,
+        startedAt,
+        completedAt,
+      });
+      posthog.capture("workout_times_edited", {
+        workout_id: workoutId,
+        from_started_at: workout.startedAt,
+        to_started_at: startedAt,
+        from_completed_at: workout.completedAt ?? editableCompletedAt,
+        to_completed_at: completedAt,
+      });
+      toast.success("Workout times updated");
+    } catch (error) {
+      toast.error("Failed to update workout times");
+      console.error(error);
+      throw error;
+    } finally {
+      setIsUpdatingTimes(false);
+    }
+  };
 
   return (
     <div className="flex min-h-screen flex-col">
@@ -189,6 +223,17 @@ export default function WorkoutDetailsPage() {
 
       <main className="flex-1 p-4">
         <Card className="mb-6 p-4">
+          {workout.status === "completed" && (
+            <div className="mb-4 flex justify-end">
+              <Button
+                variant="outline"
+                size="sm"
+                onClick={() => setShowTimeEditor(true)}
+              >
+                Edit times
+              </Button>
+            </div>
+          )}
           <div className="grid grid-cols-2 gap-4 text-sm">
             <div>
               <p className="text-muted-foreground">Date</p>
@@ -347,6 +392,18 @@ export default function WorkoutDetailsPage() {
         onOpenChange={setShowExportDialog}
         workoutId={workoutId}
       />
+
+      {workout.status === "completed" && showTimeEditor && (
+        <WorkoutTimeEditorDialog
+          open={showTimeEditor}
+          onOpenChange={setShowTimeEditor}
+          initialStartedAt={workout.startedAt}
+          initialCompletedAt={editableCompletedAt}
+          mode="edit"
+          onSubmit={handleUpdateTimes}
+          isSubmitting={isUpdatingTimes}
+        />
+      )}
     </div >
   );
 }

--- a/src/app/workout/[id]/page.tsx
+++ b/src/app/workout/[id]/page.tsx
@@ -184,7 +184,6 @@ export default function WorkoutDetailsPage() {
       });
       toast.success("Workout times updated");
     } catch (error) {
-      toast.error("Failed to update workout times");
       console.error(error);
       throw error;
     } finally {

--- a/src/app/workout/active/page.tsx
+++ b/src/app/workout/active/page.tsx
@@ -527,7 +527,6 @@ export default function ActiveWorkoutPage() {
 			});
 			handleCompletionSuccess(true);
 		} catch (error) {
-			toast.error("Failed to complete workout");
 			posthog.captureException(error);
 			console.error(error);
 			throw error;

--- a/src/app/workout/active/page.tsx
+++ b/src/app/workout/active/page.tsx
@@ -16,6 +16,7 @@ import { SaveAsRoutineDialog } from "@/components/workout/save-as-routine-dialog
 import { SmartSwapSheet } from "@/components/workout/smart-swap-sheet";
 import { SwapFollowUpDialog } from "@/components/workout/swap-followup-dialog";
 import { EditSetSheet, EditableSet } from "@/components/workout/edit-set-sheet";
+import { WorkoutTimeEditorDialog } from "@/components/workout/workout-time-editor-dialog";
 import {
 	Dialog,
 	DialogContent,
@@ -137,6 +138,12 @@ export default function ActiveWorkoutPage() {
 	const [manualNavigation, setManualNavigation] = useState(false);
 	const [showCancelDialog, setShowCancelDialog] = useState(false);
 	const [isCancelling, setIsCancelling] = useState(false);
+	const [showTimeEditor, setShowTimeEditor] = useState(false);
+	const [timeEditorInitialEnd, setTimeEditorInitialEnd] = useState<number | null>(
+		null
+	);
+	const [isCompletingWithEditedTime, setIsCompletingWithEditedTime] =
+		useState(false);
 	const exerciseRefs = useRef<Map<string, HTMLDivElement>>(new Map());
 
 	const workout = useQuery(api.workouts.getActiveWorkout);
@@ -466,32 +473,66 @@ export default function ActiveWorkoutPage() {
 		setSwapExercise(null);
 	};
 
+	const handleCompletionSuccess = (usedTimeOverride: boolean) => {
+		posthog.capture("workout_completed", {
+			workout_id: workout._id,
+			is_from_routine: !!workout.routineId,
+			exercise_count: exerciseGroups.size,
+			total_sets: Array.from(exerciseGroups.values()).reduce(
+				(acc, { entries }) =>
+					acc + entries.filter((e) => e.kind === "lifting").length,
+				0
+			),
+			used_time_override: usedTimeOverride,
+		});
+		toast.success("Workout completed!");
+
+		const hasSwapsNeedingFollowUp = pendingSwaps && pendingSwaps.length > 0;
+
+		if (hasSwapsNeedingFollowUp) {
+			setShowSwapFollowUp(true);
+		} else {
+			handlePostWorkoutFlow();
+		}
+	};
+
 	const handleComplete = async () => {
 		vibrate("success");
 		try {
 			await completeWorkout({ workoutId: workout._id });
-			posthog.capture("workout_completed", {
-				workout_id: workout._id,
-				is_from_routine: !!workout.routineId,
-				exercise_count: exerciseGroups.size,
-				total_sets: Array.from(exerciseGroups.values()).reduce(
-					(acc, { entries }) => acc + entries.filter((e) => e.kind === "lifting").length,
-					0
-				),
-			});
-			toast.success("Workout completed!");
-
-			const hasSwapsNeedingFollowUp = pendingSwaps && pendingSwaps.length > 0;
-
-			if (hasSwapsNeedingFollowUp) {
-				setShowSwapFollowUp(true);
-			} else {
-				handlePostWorkoutFlow();
-			}
+			handleCompletionSuccess(false);
 		} catch (error) {
 			toast.error("Failed to complete workout");
 			posthog.captureException(error);
 			console.error(error);
+		}
+	};
+
+	const handleOpenTimeEditor = () => {
+		setTimeEditorInitialEnd(Date.now());
+		setShowTimeEditor(true);
+	};
+
+	const handleCompleteWithEditedTime = async (
+		startedAt: number,
+		completedAt: number
+	) => {
+		setIsCompletingWithEditedTime(true);
+		vibrate("success");
+		try {
+			await completeWorkout({
+				workoutId: workout._id,
+				startedAtOverride: startedAt,
+				completedAtOverride: completedAt,
+			});
+			handleCompletionSuccess(true);
+		} catch (error) {
+			toast.error("Failed to complete workout");
+			posthog.captureException(error);
+			console.error(error);
+			throw error;
+		} finally {
+			setIsCompletingWithEditedTime(false);
 		}
 	};
 
@@ -613,9 +654,19 @@ export default function ActiveWorkoutPage() {
 						<h1 className="truncate font-semibold">
 							{workout.title ?? "Workout"}
 						</h1>
-						<p className="text-xs text-muted-foreground font-mono tabular-nums">
-							{duration}
-						</p>
+						<div className="flex items-center gap-2">
+							<p className="text-xs text-muted-foreground font-mono tabular-nums">
+								{duration}
+							</p>
+							<Button
+								variant="ghost"
+								size="sm"
+								className="h-auto px-1.5 py-0 text-xs text-muted-foreground"
+								onClick={handleOpenTimeEditor}
+							>
+								Edit time
+							</Button>
+						</div>
 					</div>
 					<div className="flex shrink-0 gap-2">
 						<Button
@@ -794,6 +845,18 @@ export default function ActiveWorkoutPage() {
 				onSave={handleUpdateSet}
 				onDelete={handleDeleteSet}
 			/>
+
+			{showTimeEditor && (
+				<WorkoutTimeEditorDialog
+					open={showTimeEditor}
+					onOpenChange={setShowTimeEditor}
+					initialStartedAt={workout.startedAt}
+					initialCompletedAt={timeEditorInitialEnd ?? Date.now()}
+					mode="finish"
+					onSubmit={handleCompleteWithEditedTime}
+					isSubmitting={isCompletingWithEditedTime}
+				/>
+			)}
 
 			<Dialog
 				open={showCancelDialog}

--- a/src/components/workout/workout-time-editor-dialog.tsx
+++ b/src/components/workout/workout-time-editor-dialog.tsx
@@ -117,7 +117,7 @@ export function WorkoutTimeEditorDialog({
     startedAtValue
   );
   const parsedCompletedAt = buildTimestampForWorkoutDate(
-    initialStartedAt,
+    initialCompletedAt,
     completedAtValue
   );
   const validationError = validateValues(parsedStartedAt, parsedCompletedAt);

--- a/src/components/workout/workout-time-editor-dialog.tsx
+++ b/src/components/workout/workout-time-editor-dialog.tsx
@@ -1,0 +1,239 @@
+"use client";
+
+import { useState } from "react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+
+interface WorkoutTimeEditorDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  initialStartedAt: number;
+  initialCompletedAt: number;
+  mode: "finish" | "edit";
+  onSubmit: (startedAt: number, completedAt: number) => Promise<void>;
+  isSubmitting: boolean;
+}
+
+function toTimeValue(timestamp: number) {
+  return new Date(timestamp).toLocaleTimeString("en-GB", {
+    hour: "2-digit",
+    minute: "2-digit",
+    hour12: false,
+  });
+}
+
+function buildTimestampForWorkoutDate(baseTimestamp: number, timeValue: string) {
+  if (!timeValue) return null;
+
+  const [hoursString, minutesString] = timeValue.split(":");
+  const hours = Number(hoursString);
+  const minutes = Number(minutesString);
+
+  if (
+    Number.isNaN(hours) ||
+    Number.isNaN(minutes) ||
+    hours < 0 ||
+    hours > 23 ||
+    minutes < 0 ||
+    minutes > 59
+  ) {
+    return null;
+  }
+
+  const date = new Date(baseTimestamp);
+  date.setHours(hours, minutes, 0, 0);
+  return date.getTime();
+}
+
+function formatDuration(startedAt: number, completedAt: number) {
+  const totalMinutes = Math.round((completedAt - startedAt) / 60000);
+  const hours = Math.floor(totalMinutes / 60);
+  const minutes = totalMinutes % 60;
+
+  if (hours > 0) {
+    return minutes > 0 ? `${hours}h ${minutes}m` : `${hours}h`;
+  }
+
+  return `${minutes}m`;
+}
+
+function formatWorkoutDate(timestamp: number) {
+  return new Date(timestamp).toLocaleDateString("en-US", {
+    month: "short",
+    day: "numeric",
+    year: "numeric",
+  });
+}
+
+function validateValues(startedAt: number | null, completedAt: number | null) {
+  if (startedAt === null) {
+    return "Choose a start time";
+  }
+
+  if (completedAt === null) {
+    return "Choose an end time";
+  }
+
+  if (startedAt >= completedAt) {
+    return "End time must be after start time";
+  }
+
+  const now = Date.now();
+  if (startedAt > now || completedAt > now) {
+    return "Times can't be in the future";
+  }
+
+  return null;
+}
+
+export function WorkoutTimeEditorDialog({
+  open,
+  onOpenChange,
+  initialStartedAt,
+  initialCompletedAt,
+  mode,
+  onSubmit,
+  isSubmitting,
+}: WorkoutTimeEditorDialogProps) {
+  const [startedAtValue, setStartedAtValue] = useState(() =>
+    toTimeValue(initialStartedAt)
+  );
+  const [completedAtValue, setCompletedAtValue] = useState(() =>
+    toTimeValue(initialCompletedAt)
+  );
+  const [submitError, setSubmitError] = useState<string | null>(null);
+  const workoutDateLabel = formatWorkoutDate(initialStartedAt);
+  const parsedStartedAt = buildTimestampForWorkoutDate(
+    initialStartedAt,
+    startedAtValue
+  );
+  const parsedCompletedAt = buildTimestampForWorkoutDate(
+    initialStartedAt,
+    completedAtValue
+  );
+  const validationError = validateValues(parsedStartedAt, parsedCompletedAt);
+
+  const durationPreview =
+    parsedStartedAt !== null &&
+    parsedCompletedAt !== null &&
+    parsedCompletedAt > parsedStartedAt
+      ? formatDuration(parsedStartedAt, parsedCompletedAt)
+      : null;
+
+  const title = mode === "finish" ? "Edit workout time" : "Edit workout times";
+  const description =
+    mode === "finish"
+      ? "Fix the start and end time before finishing this workout."
+      : "Correct the workout start and end time.";
+  const submitLabel = mode === "finish" ? "Finish Workout" : "Save";
+
+  const handleSubmit = async () => {
+    if (validationError) {
+      setSubmitError(validationError);
+      return;
+    }
+
+    if (parsedStartedAt === null || parsedCompletedAt === null) {
+      setSubmitError("Choose a valid start and end time");
+      return;
+    }
+
+    setSubmitError(null);
+
+    try {
+      await onSubmit(parsedStartedAt, parsedCompletedAt);
+      onOpenChange(false);
+    } catch (error) {
+      setSubmitError(
+        error instanceof Error ? error.message : "Failed to update workout times"
+      );
+    }
+  };
+
+  const errorMessage = submitError ?? validationError;
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="max-w-md">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+
+        <div className="space-y-4">
+          <div className="rounded-md border bg-muted/30 px-3 py-2 text-sm">
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-muted-foreground">Date</span>
+              <span className="font-medium font-mono">{workoutDateLabel}</span>
+            </div>
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="workout-start-time">Start</Label>
+            <Input
+              id="workout-start-time"
+              type="time"
+              value={startedAtValue}
+              onChange={(event) => {
+                setStartedAtValue(event.target.value);
+                setSubmitError(null);
+              }}
+              aria-invalid={errorMessage ? true : undefined}
+              disabled={isSubmitting}
+            />
+          </div>
+
+          <div className="space-y-2">
+            <Label htmlFor="workout-end-time">End</Label>
+            <Input
+              id="workout-end-time"
+              type="time"
+              value={completedAtValue}
+              onChange={(event) => {
+                setCompletedAtValue(event.target.value);
+                setSubmitError(null);
+              }}
+              aria-invalid={errorMessage ? true : undefined}
+              disabled={isSubmitting}
+            />
+          </div>
+
+          <div className="rounded-md border bg-muted/30 px-3 py-2 text-sm">
+            <div className="flex items-center justify-between gap-2">
+              <span className="text-muted-foreground">Duration</span>
+              <span className="font-medium font-mono tabular-nums">
+                {durationPreview ?? "--"}
+              </span>
+            </div>
+          </div>
+
+          {errorMessage && (
+            <p className="text-sm text-destructive">{errorMessage}</p>
+          )}
+        </div>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={() => onOpenChange(false)}
+            disabled={isSubmitting}
+          >
+            Cancel
+          </Button>
+          <Button onClick={handleSubmit} disabled={isSubmitting}>
+            {isSubmitting ? "Saving..." : submitLabel}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/workout/workout-time-editor-dialog.tsx
+++ b/src/components/workout/workout-time-editor-dialog.tsx
@@ -173,10 +173,8 @@ export function WorkoutTimeEditorDialog({
   };
 
   const errorMessage = submitError ?? validationState.message;
-  const startInputInvalid =
-    submitError === null && validationState.startInvalid ? true : undefined;
-  const endInputInvalid =
-    submitError === null && validationState.endInvalid ? true : undefined;
+  const startInputInvalid = validationState.startInvalid ? true : undefined;
+  const endInputInvalid = validationState.endInvalid ? true : undefined;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>

--- a/src/components/workout/workout-time-editor-dialog.tsx
+++ b/src/components/workout/workout-time-editor-dialog.tsx
@@ -74,25 +74,38 @@ function formatWorkoutDate(timestamp: number) {
   });
 }
 
-function validateValues(startedAt: number | null, completedAt: number | null) {
+type ValidationState = {
+  message: string | null;
+  startInvalid?: boolean;
+  endInvalid?: boolean;
+};
+
+function validateValues(
+  startedAt: number | null,
+  completedAt: number | null
+): ValidationState {
   if (startedAt === null) {
-    return "Choose a start time";
+    return { message: "Choose a start time", startInvalid: true };
   }
 
   if (completedAt === null) {
-    return "Choose an end time";
+    return { message: "Choose an end time", endInvalid: true };
   }
 
   if (startedAt >= completedAt) {
-    return "End time must be after start time";
+    return { message: "End time must be after start time", endInvalid: true };
   }
 
   const now = Date.now();
   if (startedAt > now || completedAt > now) {
-    return "Times can't be in the future";
+    return {
+      message: "Times can't be in the future",
+      startInvalid: startedAt > now,
+      endInvalid: completedAt > now,
+    };
   }
 
-  return null;
+  return { message: null };
 }
 
 export function WorkoutTimeEditorDialog({
@@ -120,7 +133,7 @@ export function WorkoutTimeEditorDialog({
     initialCompletedAt,
     completedAtValue
   );
-  const validationError = validateValues(parsedStartedAt, parsedCompletedAt);
+  const validationState = validateValues(parsedStartedAt, parsedCompletedAt);
 
   const durationPreview =
     parsedStartedAt !== null &&
@@ -137,8 +150,8 @@ export function WorkoutTimeEditorDialog({
   const submitLabel = mode === "finish" ? "Finish Workout" : "Save";
 
   const handleSubmit = async () => {
-    if (validationError) {
-      setSubmitError(validationError);
+    if (validationState.message) {
+      setSubmitError(validationState.message);
       return;
     }
 
@@ -159,7 +172,11 @@ export function WorkoutTimeEditorDialog({
     }
   };
 
-  const errorMessage = submitError ?? validationError;
+  const errorMessage = submitError ?? validationState.message;
+  const startInputInvalid =
+    submitError === null && validationState.startInvalid ? true : undefined;
+  const endInputInvalid =
+    submitError === null && validationState.endInvalid ? true : undefined;
 
   return (
     <Dialog open={open} onOpenChange={onOpenChange}>
@@ -187,7 +204,7 @@ export function WorkoutTimeEditorDialog({
                 setStartedAtValue(event.target.value);
                 setSubmitError(null);
               }}
-              aria-invalid={errorMessage ? true : undefined}
+              aria-invalid={startInputInvalid}
               disabled={isSubmitting}
             />
           </div>
@@ -202,7 +219,7 @@ export function WorkoutTimeEditorDialog({
                 setCompletedAtValue(event.target.value);
                 setSubmitError(null);
               }}
-              aria-invalid={errorMessage ? true : undefined}
+              aria-invalid={endInputInvalid}
               disabled={isSubmitting}
             />
           </div>


### PR DESCRIPTION
## What does this PR do?

Adds editable workout start/end times for active and completed workouts. Active workouts can now be finished with corrected times from a shared time-only dialog, completed workouts can be corrected from the workout detail page, backend validation rebuilds workout summaries from the edited range, and history now hides cancelled workouts by default.

## Related issue

N/A

## How to test

Steps to verify this works:
1. Start a workout, log at least one entry, open `Edit time`, choose corrected same-day times, finish the workout, and verify the updated duration appears in the workout detail page, history, and dashboard.
2. Open a completed workout, click `Edit times`, change the start/end time, save, and verify the summary card updates immediately.
3. Confirm cancelled workouts no longer appear on `/history`, and cancelled workout detail pages do not show the edit affordance.

## Checklist

- [x] I've tested this locally
- [x] `bun run lint` passes
- [x] I've updated docs if needed
