### PR TITLE
Add workout deletion flow

### DIFF
--- a/convex/workouts.ts
+++ b/convex/workouts.ts
@@ -413,10 +413,8 @@ export const deleteWorkout = mutation({
 
     let swapsDeleted = 0;
     for (const swap of swaps) {
-      if (swap.userId === user._id) {
-        await ctx.db.delete(swap._id);
-        swapsDeleted++;
-      }
+      await ctx.db.delete(swap._id);
+      swapsDeleted++;
     }
 
     const assessments = await ctx.db
@@ -429,10 +427,6 @@ export const deleteWorkout = mutation({
     let assessmentDetailsDeleted = 0;
     let assessmentsDeleted = 0;
     for (const assessment of assessments) {
-      if (assessment.userId !== user._id) {
-        continue;
-      }
-
       const details = await ctx.db
         .query("assessmentDetails")
         .withIndex("by_assessment", (q) => q.eq("assessmentId", assessment._id))
@@ -447,6 +441,19 @@ export const deleteWorkout = mutation({
       assessmentsDeleted++;
     }
 
+    const feedback = await ctx.db
+      .query("feedback")
+      .withIndex("by_user", (q) => q.eq("userId", user._id))
+      .collect();
+
+    let feedbackDeleted = 0;
+    for (const item of feedback) {
+      if (item.context?.workoutId === args.workoutId) {
+        await ctx.db.delete(item._id);
+        feedbackDeleted++;
+      }
+    }
+
     await ctx.db.delete(args.workoutId);
 
     logger.success({
@@ -459,6 +466,7 @@ export const deleteWorkout = mutation({
         swaps: swapsDeleted,
         assessments: assessmentsDeleted,
         assessmentDetails: assessmentDetailsDeleted,
+        feedback: feedbackDeleted,
       },
     });
 

--- a/convex/workouts.ts
+++ b/convex/workouts.ts
@@ -371,6 +371,101 @@ export const cancelWorkout = mutation({
   },
 });
 
+export const deleteWorkout = mutation({
+  args: {
+    workoutId: v.id("workouts"),
+  },
+  handler: async (ctx, args) => {
+    const logger = createConvexLogger("workouts.deleteWorkout");
+
+    const user = await getCurrentUser(ctx);
+    if (!user) {
+      logger.fail(new Error("User not found"));
+      throw new Error("User not found");
+    }
+
+    logger.set({ user: { id: truncateId(user._id), tier: user.tier } });
+
+    const workout = await ctx.db.get(args.workoutId);
+    if (!workout) {
+      logger.fail(new Error("Workout not found"));
+      throw new Error("Workout not found");
+    }
+
+    if (workout.userId !== user._id) {
+      logger.fail(new Error("Not authorized"));
+      throw new Error("Not authorized");
+    }
+
+    const entries = await ctx.db
+      .query("entries")
+      .withIndex("by_workout", (q) => q.eq("workoutId", args.workoutId))
+      .collect();
+
+    for (const entry of entries) {
+      await ctx.db.delete(entry._id);
+    }
+
+    const swaps = await ctx.db
+      .query("exerciseSwaps")
+      .withIndex("by_workout", (q) => q.eq("workoutId", args.workoutId))
+      .collect();
+
+    let swapsDeleted = 0;
+    for (const swap of swaps) {
+      if (swap.userId === user._id) {
+        await ctx.db.delete(swap._id);
+        swapsDeleted++;
+      }
+    }
+
+    const assessments = await ctx.db
+      .query("assessments")
+      .withIndex("by_subject", (q) =>
+        q.eq("subjectType", "workout").eq("subjectId", args.workoutId)
+      )
+      .collect();
+
+    let assessmentDetailsDeleted = 0;
+    let assessmentsDeleted = 0;
+    for (const assessment of assessments) {
+      if (assessment.userId !== user._id) {
+        continue;
+      }
+
+      const details = await ctx.db
+        .query("assessmentDetails")
+        .withIndex("by_assessment", (q) => q.eq("assessmentId", assessment._id))
+        .collect();
+
+      for (const detail of details) {
+        await ctx.db.delete(detail._id);
+        assessmentDetailsDeleted++;
+      }
+
+      await ctx.db.delete(assessment._id);
+      assessmentsDeleted++;
+    }
+
+    await ctx.db.delete(args.workoutId);
+
+    logger.success({
+      workout: {
+        id: truncateId(args.workoutId),
+        status: workout.status,
+      },
+      deleted: {
+        entries: entries.length,
+        swaps: swapsDeleted,
+        assessments: assessmentsDeleted,
+        assessmentDetails: assessmentDetailsDeleted,
+      },
+    });
+
+    return args.workoutId;
+  },
+});
+
 export const getWorkoutHistory = query({
   args: {
     limit: v.optional(v.number()),

--- a/src/app/workout/[id]/page.tsx
+++ b/src/app/workout/[id]/page.tsx
@@ -9,7 +9,25 @@ import { Card } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
-import { ArrowLeft, Clock, Download, Dumbbell, MessageSquare, Route, Timer, Weight } from "lucide-react";
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import {
+  ArrowLeft,
+  Clock,
+  Download,
+  Dumbbell,
+  MessageSquare,
+  Route,
+  Timer,
+  Trash2,
+  Weight,
+} from "lucide-react";
 import Link from "next/link";
 import { ExportWorkoutDialog } from "@/components/workout/export-workout-dialog";
 import { WorkoutTimeEditorDialog } from "@/components/workout/workout-time-editor-dialog";
@@ -56,11 +74,14 @@ export default function WorkoutDetailsPage() {
   const workoutId = params.id as Id<"workouts">;
   const [showExportDialog, setShowExportDialog] = useState(false);
   const [showTimeEditor, setShowTimeEditor] = useState(false);
+  const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [isUpdatingTimes, setIsUpdatingTimes] = useState(false);
+  const [isDeleting, setIsDeleting] = useState(false);
 
   const workout = useQuery(api.workouts.getWorkoutWithEntries, { workoutId });
   const user = useQuery(api.users.getCurrentUser);
   const updateWorkoutTimes = useMutation(api.workouts.updateWorkoutTimes);
+  const deleteWorkout = useMutation(api.workouts.deleteWorkout);
   const isPro = user?.tier === "pro";
 
   const formatDate = (timestamp: number) => {
@@ -191,6 +212,25 @@ export default function WorkoutDetailsPage() {
     }
   };
 
+  const handleDeleteWorkout = async () => {
+    setIsDeleting(true);
+    try {
+      await deleteWorkout({ workoutId });
+      posthog.capture("workout_deleted", {
+        workout_id: workoutId,
+        status: workout.status,
+        entry_count: workout.entries.length,
+      });
+      toast.success("Workout deleted");
+      router.replace("/history");
+    } catch (error) {
+      console.error(error);
+      toast.error("Failed to delete workout");
+    } finally {
+      setIsDeleting(false);
+    }
+  };
+
   return (
     <div className="flex min-h-screen flex-col">
       <header className="sticky top-0 z-40 border-b bg-background/95 backdrop-blur">
@@ -222,15 +262,25 @@ export default function WorkoutDetailsPage() {
 
       <main className="flex-1 p-4">
         <Card className="mb-6 p-4">
-          {workout.status === "completed" && (
-            <div className="mb-4 flex justify-end">
+          {workout.status !== "in_progress" && (
+            <div className="mb-4 flex justify-end gap-2">
               <Button
-                variant="outline"
+                variant="destructive"
                 size="sm"
-                onClick={() => setShowTimeEditor(true)}
+                onClick={() => setShowDeleteConfirm(true)}
               >
-                Edit times
+                <Trash2 data-icon="inline-start" />
+                Delete workout
               </Button>
+              {workout.status === "completed" && (
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => setShowTimeEditor(true)}
+                >
+                  Edit times
+                </Button>
+              )}
             </div>
           )}
           <div className="grid grid-cols-2 gap-4 text-sm">
@@ -403,6 +453,33 @@ export default function WorkoutDetailsPage() {
           isSubmitting={isUpdatingTimes}
         />
       )}
-    </div >
+
+      <Dialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
+        <DialogContent>
+          <DialogHeader>
+            <DialogTitle>Delete workout?</DialogTitle>
+            <DialogDescription>
+              This will permanently delete this workout and all logged sets, notes, and related workout analysis.
+            </DialogDescription>
+          </DialogHeader>
+          <DialogFooter>
+            <Button
+              variant="outline"
+              onClick={() => setShowDeleteConfirm(false)}
+              disabled={isDeleting}
+            >
+              Cancel
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={handleDeleteWorkout}
+              disabled={isDeleting}
+            >
+              {isDeleting ? "Deleting..." : "Delete workout"}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- Add a Convex mutation to permanently delete a workout after validating ownership
- Cascade deletion to logged entries, workout swaps, and workout-specific AI assessment details
- Add a delete action and confirmation dialog on the workout detail screen

## Verification
- bunx tsc --noEmit
- bun run build
- git diff --check
- bun run lint (passes with existing warnings in generated/demo files)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/house-of-giants/codesmith/opentrainer/pr/40"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-light.svg"><img alt="View in Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-in-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith</code> with what you need.</sup>

- [ ] Let Codesmith autofix CI failures and bot reviews
<!-- /codesmith:footer -->