### PR TITLE
Add integrated training flow

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ Most workout apps are bloated. You're between sets, sweaty, 45 seconds on the cl
 
 OpenTrainer is different:
 - **2 taps per set.** Log and get back to lifting.
+- **Session brief on the dashboard.** Surfaces your next workout action and weekly progress at a glance — no speculative readiness scores.
+- **Focused workout mode.** Active sessions show what to log next, sets remaining, elapsed time, and total volume without burying the set controls.
 - **AI that knows your gym.** Tell it what equipment you have. Get a program that actually uses it.
 - **Your data, your rules.** Full JSON export. No lock-in. Leave anytime.
 - **No tracking pixels.** We don't sell your data.

--- a/src/app/dashboard/page.tsx
+++ b/src/app/dashboard/page.tsx
@@ -4,17 +4,16 @@ import { useEffect, useState } from "react";
 import { useRouter } from "next/navigation";
 import { useQuery, useMutation } from "convex/react";
 import { api } from "../../../convex/_generated/api";
-import { Button } from "@/components/ui/button";
-import { Card } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { UserButton, useUser } from "@clerk/nextjs";
 import Link from "next/link";
 import { BottomNav } from "@/components/navigation/bottom-nav";
 import { StartWorkoutSheet } from "@/components/workout/start-workout-sheet";
-import { Play, Plus } from "lucide-react";
 import { WeeklyStatsGrid, GoalSettingDialog } from "@/components/dashboard";
+import { DashboardBriefCard } from "@/components/dashboard/dashboard-brief-card";
 import { TrainingLabCard } from "@/components/training-lab/training-lab-card";
 import { AsciiLogo } from "@/components/ui/ascii-logo";
+import { formatDuration } from "@/lib/utils";
 import posthog from "posthog-js";
 
 export default function DashboardPage() {
@@ -97,13 +96,6 @@ export default function DashboardPage() {
 		});
 	};
 
-	const formatDuration = (minutes?: number) => {
-		if (!minutes) return "—";
-		const hours = Math.floor(minutes / 60);
-		const mins = minutes % 60;
-		return hours > 0 ? `${hours}h ${mins}m` : `${mins}m`;
-	};
-
 	const formatCardioDuration = (seconds: number) => {
 		const hours = Math.floor(seconds / 3600);
 		const mins = Math.floor((seconds % 3600) / 60);
@@ -136,37 +128,21 @@ export default function DashboardPage() {
 			</header>
 
 			<main className="flex-1 space-y-4 p-4 pb-24">
-				<div>
-					<h1 className="text-2xl font-bold">
-						Hey{user?.name ? `, ${user.name.split(" ")[0]}` : ""}!
-					</h1>
-					<p className="text-muted-foreground">Ready to train?</p>
-				</div>
+				<h1 className="sr-only">Dashboard</h1>
 
-				{activeWorkout ? (
-					<Card className="border-primary/50 bg-primary/5 p-4">
-						<div className="flex items-center justify-between">
-							<div>
-								<h2 className="font-semibold">Workout In Progress</h2>
-								<p className="text-sm text-muted-foreground">
-									Started {formatDate(activeWorkout.startedAt)}
-								</p>
-							</div>
-							<Button onClick={() => router.push("/workout/active")}>
-								<Play className="mr-2 h-4 w-4" />
-								Continue
-							</Button>
-						</div>
-					</Card>
+				{dashboardStats && activeWorkout !== undefined && workoutHistory !== undefined ? (
+					<DashboardBriefCard
+						weeklyWorkoutCount={dashboardStats.weeklyWorkoutCount}
+						weeklyGoal={dashboardStats.weeklyGoal}
+						weeklyTotalSets={dashboardStats.weeklyTotalSets}
+						weeklyTotalDuration={dashboardStats.weeklyTotalDuration}
+						hasActiveWorkout={!!activeWorkout}
+						hasHistory={(workoutHistory?.length ?? 0) > 0}
+						onStartWorkout={() => setShowStartSheet(true)}
+						onContinueWorkout={() => router.push("/workout/active")}
+					/>
 				) : (
-					<Button
-						size="lg"
-						className="w-full"
-						onClick={() => setShowStartSheet(true)}
-					>
-						<Plus className="mr-2 h-5 w-5" />
-						Start Workout
-					</Button>
+					<Skeleton className="h-36 w-full rounded-lg" />
 				)}
 
 				{dashboardStats ? (
@@ -231,7 +207,8 @@ export default function DashboardPage() {
 												</p>
 												<p className="font-mono font-medium">
 													{formatDuration(
-														workout.summary?.totalDurationMinutes
+														workout.summary?.totalDurationMinutes,
+														"—"
 													)}
 												</p>
 											</div>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -71,9 +71,9 @@ export default function Home() {
                   <span className="text-muted-foreground">not minutes.</span>
                 </h1>
                 <p className="max-w-md text-lg text-muted-foreground sm:text-xl lg:max-w-xl">
-                  Most apps need 5 screens to log one set. We need 2 taps.
+                  Strong logs fast. Fitbod plans for you. Boostcamp gives you programs.
                   <span className="mt-2 block text-base">
-                    Built for sweaty hands, bad gym WiFi, and the 45 seconds you have before your next set.
+                    OpenTrainer keeps the useful parts: fast logging, plain progression, equipment-aware routines, and exportable data. No social feed. No black-box readiness scores. No lock-in.
                   </span>
                 </p>
                 <div className="flex flex-col items-center gap-3 lg:items-start">
@@ -166,6 +166,35 @@ export default function Home() {
               </svg>
               Full data export
             </p>
+          </div>
+        </section>
+
+        {/* Competitive position */}
+        <section className="mx-auto w-full max-w-6xl px-4 py-20 sm:px-6 lg:px-8">
+          <div className="mb-12 text-center">
+            <h2 className="text-3xl font-bold tracking-tight">
+              Built from the useful parts of the category
+            </h2>
+            <p className="mt-2 text-muted-foreground">
+              The market already proved what matters. OpenTrainer removes the rest.
+            </p>
+          </div>
+          <div className="grid gap-4 md:grid-cols-3">
+            <ComparisonCard
+              app="Strong / Hevy"
+              keeps="Fast set logging, history, rest timer"
+              cuts="Social feeds, streak mechanics, interface clutter"
+            />
+            <ComparisonCard
+              app="Fitbod"
+              keeps="Equipment-aware planning and next-step guidance"
+              cuts="Opaque recovery scores and overbuilt planning"
+            />
+            <ComparisonCard
+              app="Boostcamp"
+              keeps="Program structure, auto-progression, simple goals"
+              cuts="Marketplace browsing when you just need today's session"
+            />
           </div>
         </section>
 
@@ -536,6 +565,34 @@ function FeatureCard({
 }
 
 
+
+function ComparisonCard({
+  app,
+  keeps,
+  cuts,
+}: {
+  app: string;
+  keeps: string;
+  cuts: string;
+}) {
+  return (
+    <div className="rounded-xl border bg-card p-5">
+      <p className="text-xs font-mono uppercase tracking-[0.18em] text-muted-foreground">
+        {app}
+      </p>
+      <div className="mt-4 space-y-3 text-sm">
+        <div>
+          <p className="font-semibold text-green-600 dark:text-green-400">Keep</p>
+          <p className="mt-1 text-muted-foreground">{keeps}</p>
+        </div>
+        <div>
+          <p className="font-semibold text-destructive">Cut</p>
+          <p className="mt-1 text-muted-foreground">{cuts}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
 
 function FAQItem({ question, answer }: { question: string; answer: string }) {
   const [isOpen, setIsOpen] = useState(false);

--- a/src/app/workout/active/page.tsx
+++ b/src/app/workout/active/page.tsx
@@ -17,6 +17,7 @@ import { SmartSwapSheet } from "@/components/workout/smart-swap-sheet";
 import { SwapFollowUpDialog } from "@/components/workout/swap-followup-dialog";
 import { EditSetSheet, EditableSet } from "@/components/workout/edit-set-sheet";
 import { WorkoutTimeEditorDialog } from "@/components/workout/workout-time-editor-dialog";
+import { SessionCommandCenter } from "@/components/workout/session-command-center";
 import {
 	Dialog,
 	DialogContent,
@@ -30,6 +31,7 @@ import { useHaptic } from "@/hooks/use-haptic";
 import { Skeleton } from "@/components/ui/skeleton";
 import { toast } from "sonner";
 import { calculateProgressionSuggestion } from "@/lib/progression";
+import { convertWeight, type WeightUnit } from "@/lib/units";
 import posthog from "posthog-js";
 
 type EntryData = {
@@ -645,6 +647,46 @@ export default function ActiveWorkoutPage() {
 		}
 	};
 
+	const sessionStats = (() => {
+		let loggedSets = 0;
+		let targetSets = 0;
+		let totalVolume = 0;
+		// Normalize all lifting volume to lb so mixed-unit workouts sum correctly.
+		const unit: WeightUnit = "lb";
+
+		for (const [, { entries: groupEntries, meta }] of exerciseGroups) {
+			if (meta.category === "cardio") {
+				targetSets += 1;
+				if (groupEntries.some((entry) => entry.kind === "cardio")) loggedSets += 1;
+				continue;
+			}
+
+			const liftingEntries = groupEntries.filter((entry) => entry.kind === "lifting" && entry.lifting);
+			loggedSets += liftingEntries.length;
+			targetSets += meta.targetSets ?? Math.max(liftingEntries.length, 1);
+
+			for (const entry of liftingEntries) {
+				if (!entry.lifting) continue;
+				const weight = entry.lifting.weight ?? 0;
+				const weightLb = convertWeight(weight, entry.lifting.unit ?? unit, unit);
+				totalVolume += weightLb * (entry.lifting.reps ?? 0);
+			}
+		}
+
+		return { loggedSets, targetSets, totalVolume, unit };
+	})();
+
+	const currentExerciseName = exerciseList[currentExerciseIndex]?.[0];
+	const nextExerciseName = exerciseList[currentExerciseIndex + 1]?.[0];
+
+	const jumpToCurrentExercise = () => {
+		if (!currentExerciseName) return;
+		const element = exerciseRefs.current.get(currentExerciseName);
+		if (element) {
+			element.scrollIntoView({ behavior: "smooth", block: "center" });
+		}
+	};
+
 	return (
 		<div className="flex min-h-screen flex-col">
 			<header className="sticky top-0 z-40 border-b bg-background/95 backdrop-blur">
@@ -682,6 +724,20 @@ export default function ActiveWorkoutPage() {
 					</div>
 				</div>
 			</header>
+
+			<div className="px-4 pt-4">
+				<SessionCommandCenter
+					duration={duration}
+					exerciseCount={exerciseList.length}
+					currentExerciseName={currentExerciseName}
+					nextExerciseName={nextExerciseName}
+					loggedSets={sessionStats.loggedSets}
+					targetSets={sessionStats.targetSets}
+					totalVolume={sessionStats.totalVolume}
+					unit={sessionStats.unit}
+					onJumpToCurrent={jumpToCurrentExercise}
+				/>
+			</div>
 
 			<main className="flex-1 space-y-4 p-4">
 				{Array.from(exerciseGroups.entries()).map(

--- a/src/components/dashboard/dashboard-brief-card.tsx
+++ b/src/components/dashboard/dashboard-brief-card.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { formatDuration } from "@/lib/utils";
+import { ArrowRight, CalendarClock, Dumbbell, Flame } from "lucide-react";
+
+type DashboardBriefCardProps = {
+	weeklyWorkoutCount: number;
+	weeklyGoal: number;
+	weeklyTotalSets: number;
+	weeklyTotalDuration?: number;
+	hasActiveWorkout: boolean;
+	hasHistory: boolean;
+	onStartWorkout: () => void;
+	onContinueWorkout: () => void;
+};
+
+export function DashboardBriefCard({
+	weeklyWorkoutCount,
+	weeklyGoal,
+	weeklyTotalSets,
+	weeklyTotalDuration,
+	hasActiveWorkout,
+	hasHistory,
+	onStartWorkout,
+	onContinueWorkout,
+}: DashboardBriefCardProps) {
+	const workoutsLeft = Math.max(weeklyGoal - weeklyWorkoutCount, 0);
+	const brief = hasActiveWorkout
+		? "Workout in progress. Pick up where you left off."
+		: workoutsLeft === 0
+			? "Weekly goal complete. Anything extra is a bonus."
+			: hasHistory
+				? `${workoutsLeft} session${workoutsLeft === 1 ? "" : "s"} left to hit this week's goal.`
+				: "Log your first workout to start building history.";
+	const cta = hasActiveWorkout ? "Continue workout" : "Start workout";
+	const onClick = hasActiveWorkout ? onContinueWorkout : onStartWorkout;
+
+	return (
+		<Card className="gap-4 overflow-hidden border-primary/30 bg-linear-to-br from-primary/10 via-card to-card p-4 shadow-none">
+			<div className="flex flex-col gap-3 sm:flex-row sm:items-start sm:justify-between sm:gap-4">
+				<div className="min-w-0">
+					<p className="text-xs font-mono uppercase tracking-[0.18em] text-muted-foreground">
+						Today&apos;s brief
+					</p>
+					<h2 className="mt-1 text-lg font-semibold leading-tight sm:text-xl">{brief}</h2>
+				</div>
+				<Button
+					type="button"
+					size="sm"
+					onClick={onClick}
+					className="w-full sm:w-auto sm:shrink-0"
+				>
+					{cta}
+					<ArrowRight className="ml-1.5 h-3.5 w-3.5" />
+				</Button>
+			</div>
+
+			<div className="grid grid-cols-3 gap-2">
+				<BriefMetric icon={Flame} label="Week" value={`${weeklyWorkoutCount}/${weeklyGoal}`} />
+				<BriefMetric icon={Dumbbell} label="Sets" value={String(weeklyTotalSets)} />
+				<BriefMetric icon={CalendarClock} label="Time" value={formatDuration(weeklyTotalDuration)} />
+			</div>
+		</Card>
+	);
+}
+
+function BriefMetric({
+	icon: Icon,
+	label,
+	value,
+}: {
+	icon: typeof Flame;
+	label: string;
+	value: string;
+}) {
+	return (
+		<div className="min-w-0 rounded-lg border bg-background/70 px-2.5 py-2 sm:px-3">
+			<Icon className="mb-1 h-3.5 w-3.5 text-muted-foreground" />
+			<p className="truncate font-mono text-sm font-semibold tabular-nums sm:text-base">
+				{value}
+			</p>
+			<p className="truncate text-[10px] uppercase tracking-wide text-muted-foreground">
+				{label}
+			</p>
+		</div>
+	);
+}

--- a/src/components/workout/session-command-center.tsx
+++ b/src/components/workout/session-command-center.tsx
@@ -1,0 +1,114 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { cn } from "@/lib/utils";
+import { ArrowDown, CheckCircle2, Dumbbell, Gauge, Target } from "lucide-react";
+
+type SessionCommandCenterProps = {
+	duration: string;
+	exerciseCount: number;
+	currentExerciseName?: string;
+	nextExerciseName?: string;
+	loggedSets: number;
+	targetSets: number;
+	totalVolume: number;
+	unit: "lb" | "kg";
+	onJumpToCurrent: () => void;
+};
+
+function formatVolume(volume: number, unit: "lb" | "kg") {
+	if (volume <= 0) return `0 ${unit}`;
+	if (volume >= 1000) return `${Math.round(volume / 100) / 10}k ${unit}`;
+	return `${Math.round(volume)} ${unit}`;
+}
+
+export function SessionCommandCenter({
+	duration,
+	exerciseCount,
+	currentExerciseName,
+	nextExerciseName,
+	loggedSets,
+	targetSets,
+	totalVolume,
+	unit,
+	onJumpToCurrent,
+}: SessionCommandCenterProps) {
+	const hasPlan = exerciseCount > 0;
+	const progress = targetSets > 0 ? Math.min(100, Math.round((loggedSets / targetSets) * 100)) : loggedSets > 0 ? 100 : 0;
+	const setsRemaining = Math.max(targetSets - loggedSets, 0);
+	const nextAction = !hasPlan
+		? "Add an exercise to get started."
+		: setsRemaining === 0
+			? "All planned sets logged. Finish up or add extra work."
+			: currentExerciseName
+				? `Log ${currentExerciseName}`
+				: "Choose your first exercise.";
+
+	return (
+		<Card className="gap-4 border-primary/30 bg-linear-to-br from-primary/10 via-card to-card p-4 shadow-none">
+			<div className="flex flex-wrap items-start justify-between gap-x-4 gap-y-2">
+				<div className="min-w-0 flex-1 basis-52">
+					<p className="text-xs font-mono uppercase tracking-[0.18em] text-muted-foreground">
+						Session overview
+					</p>
+					<h2 className="mt-1 truncate text-lg font-semibold sm:text-xl">{nextAction}</h2>
+					<p className="mt-1 truncate text-sm text-muted-foreground">
+						{nextExerciseName ? `Up next: ${nextExerciseName}.` : "Log sets as you go."}
+					</p>
+				</div>
+				<Button
+					type="button"
+					variant="outline"
+					size="sm"
+					className="w-full sm:w-auto sm:shrink-0"
+					onClick={onJumpToCurrent}
+					disabled={!hasPlan || !currentExerciseName}
+				>
+					<ArrowDown className="mr-1.5 h-3.5 w-3.5" />
+					Current exercise
+				</Button>
+			</div>
+
+			<div className="space-y-2">
+				<div className="flex items-center justify-between text-xs text-muted-foreground">
+					<span>{loggedSets}/{targetSets || loggedSets} planned sets</span>
+					<span>{progress}%</span>
+				</div>
+				<div className="h-2 overflow-hidden rounded-full bg-muted">
+					<div
+						className={cn("h-full rounded-full bg-primary transition-all", progress === 100 && "bg-green-500")}
+						style={{ width: `${progress}%` }}
+					/>
+				</div>
+			</div>
+
+			<div className="grid grid-cols-2 gap-2 text-center sm:grid-cols-4">
+				<Metric icon={Gauge} label="Time" value={duration || "0m"} />
+				<Metric icon={CheckCircle2} label="Left" value={targetSets > 0 ? String(setsRemaining) : "—"} />
+				<Metric icon={Dumbbell} label="Volume" value={formatVolume(totalVolume, unit)} />
+				<Metric icon={Target} label="Moves" value={String(exerciseCount)} />
+			</div>
+		</Card>
+	);
+}
+
+function Metric({
+	icon: Icon,
+	label,
+	value,
+}: {
+	icon: typeof Gauge;
+	label: string;
+	value: string;
+}) {
+	return (
+		<div className="min-w-0 rounded-lg border bg-background/70 px-2 py-2">
+			<Icon className="mx-auto mb-1 h-3.5 w-3.5 text-muted-foreground" />
+			<p className="truncate font-mono text-sm font-semibold tabular-nums">{value}</p>
+			<p className="truncate text-[10px] uppercase tracking-wide text-muted-foreground">
+				{label}
+			</p>
+		</div>
+	);
+}

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -4,3 +4,10 @@ import { twMerge } from "tailwind-merge"
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
+
+export function formatDuration(minutes?: number, fallback = "0m") {
+  if (minutes == null || Number.isNaN(minutes)) return fallback
+  const hours = Math.floor(minutes / 60)
+  const mins = minutes % 60
+  return hours > 0 ? `${hours}h ${mins}m` : `${mins}m`
+}


### PR DESCRIPTION
## Summary
- Adds a dashboard "Today's brief" card that collapses weekly goal progress, session volume, time, and the next obvious CTA into one integrated decision surface.
- Adds an active workout session overview showing current exercise, next exercise, planned-set progress, elapsed time, sets left, volume, and a jump-to-current action.
- Repositions the landing page against Strong/Hevy, Fitbod, and Boostcamp: keep fast logging, equipment-aware planning, and program structure; cut feeds, opaque readiness scoring, and marketplace sprawl.
- Updates README positioning for the new session brief and focused workout mode.

## Verification
- `bun run lint` passed with existing warnings only in generated/demo files.
- `bun x tsc --noEmit` passed.
- `bun run build` passed.
- Independent code review passed; non-blocking suggestions were addressed where useful.

## Review
@greptile-apps please review.

## Notes
- Local `next start` smoke returned 500 because this checkout lacks real Clerk/Convex environment variables. Production build and static generation passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard: new top “brief” card showing weekly progress, total sets/time, and quick CTA to start or resume sessions.
  * Active workout: session command center with progress bar, time/volume/sets/moves tiles, current/next exercise info, and “jump to current exercise”.
  * Landing page: added competitive-positioning section comparing core keeps/cuts versus alternatives.

* **Documentation**
  * README: updated to highlight the dashboard brief and focused workout mode.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->