### PR TITLE
fix(training-lab): align weekly metrics to Monday

### DIFF
--- a/convex/ai/aggregators.ts
+++ b/convex/ai/aggregators.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 import { internalQuery } from "../_generated/server";
 import type { Id, Doc } from "../_generated/dataModel";
+import { getMondayWeekKey, getMondayWeekStartUtc, WEEK_IN_MS } from "../lib/week";
 
 const MODALITY_METS: Record<string, number> = {
   run: 9.8,
@@ -164,11 +165,12 @@ export const aggregateWorkoutData = internalQuery({
   args: {
     userId: v.id("users"),
     days: v.number(),
+    periodStart: v.optional(v.number()),
     includeHistoricalContext: v.optional(v.boolean()),
   },
   handler: async (ctx, args): Promise<AggregatedWorkoutData> => {
     const now = Date.now();
-    const periodStart = now - args.days * 24 * 60 * 60 * 1000;
+    const periodStart = args.periodStart ?? now - args.days * 24 * 60 * 60 * 1000;
 
     const workouts = await ctx.db
       .query("workouts")
@@ -364,7 +366,7 @@ function computeConsistency(
 
   const weeklyWorkouts = new Map<string, number>();
   for (const workout of workouts) {
-    const weekKey = getWeekStart(workout.startedAt);
+    const weekKey = getMondayWeekKey(workout.startedAt);
     weeklyWorkouts.set(weekKey, (weeklyWorkouts.get(weekKey) ?? 0) + 1);
   }
 
@@ -377,16 +379,16 @@ function computeConsistency(
   let longestStreak = 0;
   let tempStreak = 0;
 
-  const now = new Date();
-  const currentWeek = getWeekStart(now.getTime());
-  const lastWeek = getWeekStart(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+  const now = Date.now();
+  const currentWeekStart = getMondayWeekStartUtc(now);
+  const currentWeek = getMondayWeekKey(now);
+  const lastWeek = getMondayWeekKey(currentWeekStart - WEEK_IN_MS);
 
   const allWeeks: string[] = [];
   if (weeks.length > 0) {
-    const startDate = new Date(weeks[0]);
-    const endDate = new Date(currentWeek);
-    for (let d = startDate; d <= endDate; d.setDate(d.getDate() + 7)) {
-      allWeeks.push(getWeekStart(d.getTime()));
+    const firstWeekStart = Date.parse(`${weeks[0]}T00:00:00.000Z`);
+    for (let weekStart = firstWeekStart; weekStart <= currentWeekStart; weekStart += WEEK_IN_MS) {
+      allWeeks.push(getMondayWeekKey(weekStart));
     }
   }
 
@@ -524,7 +526,7 @@ function aggregateVolumeByMuscleOverTime(
     const workoutDate = workoutDateMap.get(entry.workoutId);
     if (!workoutDate) continue;
 
-    const weekStart = getWeekStart(workoutDate);
+    const weekStart = getMondayWeekKey(workoutDate);
     const exercise = exerciseMap.get(entry.exerciseName);
     const muscleGroups = exercise?.muscleGroups ?? ["other"];
 
@@ -917,14 +919,6 @@ function calculateTrend(
   if (percentChange > 5) return "up";
   if (percentChange < -5) return "down";
   return "flat";
-}
-
-function getWeekStart(timestamp: number): string {
-  const date = new Date(timestamp);
-  const dayOfWeek = date.getDay();
-  date.setDate(date.getDate() - dayOfWeek);
-  date.setHours(0, 0, 0, 0);
-  return date.toISOString().split("T")[0];
 }
 
 export const getLastAssessmentSummary = internalQuery({

--- a/convex/ai/trainingLab.ts
+++ b/convex/ai/trainingLab.ts
@@ -9,6 +9,7 @@ import type { Doc } from "../_generated/dataModel";
 import type { AggregatedWorkoutData } from "./aggregators";
 import type { TrainingLabReport, TrainingSnapshot } from "./trainingLabTypes";
 import { createConvexLogger, truncateId } from "../lib/logger";
+import { getMondayWeekStartUtc } from "../lib/week";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -117,10 +118,16 @@ export const generateReport = action({
     reportType: v.union(v.literal("snapshot"), v.literal("full")),
   },
   handler: async (ctx, args): Promise<TrainingLabReport | TrainingSnapshot> => {
+    const periodDays = args.periodDays ?? 7;
+    const now = Date.now();
+    const periodStart =
+      periodDays === 7
+        ? getMondayWeekStartUtc(now)
+        : now - periodDays * 24 * 60 * 60 * 1000;
     const logger = createConvexLogger("ai.trainingLab.generateReport");
     logger.set({
       ai: { action: "trainingLabReport", model: "gemini" },
-      request: { reportType: args.reportType, periodDays: args.periodDays ?? 7 },
+      request: { reportType: args.reportType, periodDays },
     });
 
     const identity = await ctx.auth.getUserIdentity();
@@ -166,7 +173,8 @@ export const generateReport = action({
 
     const aggregated = (await ctx.runQuery(internal.ai.aggregators.aggregateWorkoutData, {
       userId: user._id,
-      days: args.periodDays ?? 7,
+      days: periodDays,
+      periodStart,
       includeHistoricalContext: true,
     })) as AggregatedWorkoutData;
 
@@ -176,7 +184,7 @@ export const generateReport = action({
       throw new Error("No workouts to analyze");
     }
 
-    logger.set({ data: { workoutCount, periodDays: args.periodDays ?? 7 } });
+    logger.set({ data: { workoutCount, periodDays } });
 
     const systemPrompt =
       args.reportType === "full" ? TRAINING_LAB_FULL_PROMPT : TRAINING_LAB_SNAPSHOT_PROMPT;

--- a/convex/ai/trainingLabMutations.ts
+++ b/convex/ai/trainingLabMutations.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 import { query, internalMutation } from "../_generated/server";
 import { getCurrentUser } from "../auth";
 import type { TrainingLabReport, TrainingSnapshot, TrainingLabCTAState, TrainingLabDashboardStats } from "./trainingLabTypes";
+import { getMondayWeekKey, getMondayWeekStartUtc, WEEK_IN_MS } from "../lib/week";
 
 export const storeAssessment = internalMutation({
   args: {
@@ -85,6 +86,8 @@ export const getCtaState = query({
     const totalWorkouts = allWorkouts.length;
     
     const now = Date.now();
+    const weekStart = getMondayWeekStartUtc(now);
+    const currentWeekWorkouts = allWorkouts.filter((w) => w.startedAt >= weekStart);
     const oldestWorkout = allWorkouts.length > 0 
       ? Math.min(...allWorkouts.map(w => w.startedAt))
       : now;
@@ -113,18 +116,20 @@ export const getCtaState = query({
     const hasReport = !!lastAssessment;
     const lastAssessmentDate = lastAssessment?.createdAt ?? 0;
 
-    const workoutsSince = allWorkouts.filter((w) => w.startedAt > lastAssessmentDate);
+    const workoutsSince = currentWeekWorkouts.filter((w) => w.startedAt > lastAssessmentDate);
     const count = workoutsSince.length;
 
-    const canGenerate = hasReport ? count > 0 : totalWorkouts > 0;
+    const canGenerate = hasReport ? count > 0 : currentWeekWorkouts.length > 0;
 
     let message: string;
     if (totalWorkouts === 0) {
       message = "Complete your first workout to unlock insights";
+    } else if (currentWeekWorkouts.length === 0) {
+      message = "Complete a workout this week to generate your analysis";
     } else if (!hasReport) {
-      message = totalWorkouts === 1
+      message = currentWeekWorkouts.length === 1
         ? "Your first analysis is ready"
-        : `${totalWorkouts} workouts logged. Generate your analysis`;
+        : `${currentWeekWorkouts.length} workouts this week. Generate your analysis`;
     } else if (count === 0) {
       message = "Log a workout to refresh your analysis";
     } else {
@@ -176,14 +181,6 @@ export const getLatestReport = query({
   },
 });
 
-function getWeekStart(timestamp: number): string {
-  const date = new Date(timestamp);
-  const dayOfWeek = date.getDay();
-  date.setDate(date.getDate() - dayOfWeek);
-  date.setHours(0, 0, 0, 0);
-  return date.toISOString().split("T")[0];
-}
-
 export const getDashboardStats = query({
   args: {},
   handler: async (ctx): Promise<TrainingLabDashboardStats | null> => {
@@ -191,9 +188,9 @@ export const getDashboardStats = query({
     if (!user) return null;
 
     const now = Date.now();
-    const weekStart = new Date(getWeekStart(now)).getTime();
-    const twoWeeksAgo = weekStart - 7 * 24 * 60 * 60 * 1000;
-    const fourWeeksAgo = weekStart - 28 * 24 * 60 * 60 * 1000;
+    const weekStart = getMondayWeekStartUtc(now);
+    const twoWeeksAgo = weekStart - WEEK_IN_MS;
+    const fourWeeksAgo = weekStart - 4 * WEEK_IN_MS;
 
     const recentWorkouts = await ctx.db
       .query("workouts")
@@ -269,15 +266,15 @@ export const getDashboardStats = query({
 
     const weeklyWorkouts = new Map<string, number>();
     for (const workout of allWorkouts) {
-      const weekKey = getWeekStart(workout.startedAt);
+      const weekKey = getMondayWeekKey(workout.startedAt);
       weeklyWorkouts.set(weekKey, (weeklyWorkouts.get(weekKey) ?? 0) + 1);
     }
 
     let currentStreak = 0;
     let longestStreak = 0;
     let tempStreak = 0;
-    const currentWeek = getWeekStart(now);
-    const lastWeek = getWeekStart(now - 7 * 24 * 60 * 60 * 1000);
+    const currentWeek = getMondayWeekKey(now);
+    const lastWeek = getMondayWeekKey(weekStart - WEEK_IN_MS);
 
     const weeks = Array.from(weeklyWorkouts.keys()).sort().reverse();
     for (const week of weeks) {

--- a/convex/lib/week.ts
+++ b/convex/lib/week.ts
@@ -1,0 +1,23 @@
+export const WEEK_IN_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Returns 00:00 UTC on the Monday that contains the supplied timestamp.
+ *
+ * OpenTrainer does not currently persist a user time zone, so server-side
+ * calendar periods use UTC consistently rather than depending on the runtime's
+ * local time zone.
+ */
+export function getMondayWeekStartUtc(timestamp: number): number {
+  const date = new Date(timestamp);
+  const daysSinceMonday = (date.getUTCDay() + 6) % 7;
+
+  return Date.UTC(
+    date.getUTCFullYear(),
+    date.getUTCMonth(),
+    date.getUTCDate() - daysSinceMonday
+  );
+}
+
+export function getMondayWeekKey(timestamp: number): string {
+  return new Date(getMondayWeekStartUtc(timestamp)).toISOString().split("T")[0];
+}

--- a/convex/workouts.ts
+++ b/convex/workouts.ts
@@ -4,6 +4,7 @@ import type { MutationCtx } from "./_generated/server";
 import { mutation, query } from "./_generated/server";
 import { getCurrentUser } from "./auth";
 import { createConvexLogger, truncateId } from "./lib/logger";
+import { getMondayWeekStartUtc, WEEK_IN_MS } from "./lib/week";
 
 type WorkoutSummary = NonNullable<Doc<"workouts">["summary"]>;
 
@@ -686,24 +687,17 @@ export const getDashboardStats = query({
     }
 
     // Calculate start of current week (Monday)
-    const now = new Date();
-    const dayOfWeek = now.getDay();
-    // getDay() returns 0 for Sunday, 1 for Monday, etc.
-    // We want Monday as day 0, so we adjust: (dayOfWeek + 6) % 7 gives us days since Monday
-    const daysSinceMonday = (dayOfWeek + 6) % 7;
-    const mondayOfThisWeek = new Date(now);
-    mondayOfThisWeek.setDate(now.getDate() - daysSinceMonday);
-    mondayOfThisWeek.setHours(0, 0, 0, 0);
+    const now = Date.now();
+    const mondayOfThisWeek = getMondayWeekStartUtc(now);
 
     // Get current week (Monday through Sunday) for activity dots
     const currentWeek: { date: string; dayName: string; hasWorkout: boolean }[] = [];
 
     for (let i = 0; i < 7; i++) {
-      const date = new Date(mondayOfThisWeek);
-      date.setDate(mondayOfThisWeek.getDate() + i);
+      const date = new Date(mondayOfThisWeek + i * 24 * 60 * 60 * 1000);
       currentWeek.push({
         date: date.toISOString().split("T")[0],
-        dayName: date.toLocaleDateString("en-US", { weekday: "short" }),
+        dayName: date.toLocaleDateString("en-US", { weekday: "short", timeZone: "UTC" }),
         hasWorkout: false,
       });
     }
@@ -715,7 +709,7 @@ export const getDashboardStats = query({
       .filter((q) =>
         q.and(
           q.eq(q.field("status"), "completed"),
-          q.gte(q.field("startedAt"), mondayOfThisWeek.getTime())
+          q.gte(q.field("startedAt"), mondayOfThisWeek)
         )
       )
       .collect();
@@ -731,7 +725,7 @@ export const getDashboardStats = query({
 
     // Calculate this week's stats
     const thisWeekWorkouts = recentWorkouts.filter(
-      (w) => w.startedAt >= mondayOfThisWeek.getTime()
+      (w) => w.startedAt >= mondayOfThisWeek
     );
 
     const weeklyWorkoutCount = thisWeekWorkouts.length;
@@ -746,9 +740,7 @@ export const getDashboardStats = query({
     }
 
     // Get weekly trend data (last 4 weeks)
-    const fourWeeksAgo = new Date(now);
-    fourWeeksAgo.setDate(now.getDate() - 28);
-    fourWeeksAgo.setHours(0, 0, 0, 0);
+    const fourWeeksAgo = mondayOfThisWeek - 3 * WEEK_IN_MS;
 
     const trendWorkouts = await ctx.db
       .query("workouts")
@@ -756,7 +748,7 @@ export const getDashboardStats = query({
       .filter((q) =>
         q.and(
           q.eq(q.field("status"), "completed"),
-          q.gte(q.field("startedAt"), fourWeeksAgo.getTime())
+          q.gte(q.field("startedAt"), fourWeeksAgo)
         )
       )
       .collect();
@@ -764,15 +756,11 @@ export const getDashboardStats = query({
     // Group by week for trend chart
     const weeklyTrend: { week: string; volume: number; workouts: number; duration: number }[] = [];
     for (let i = 3; i >= 0; i--) {
-      const weekStart = new Date(now);
-      weekStart.setDate(now.getDate() - (i * 7 + dayOfWeek));
-      weekStart.setHours(0, 0, 0, 0);
-
-      const weekEnd = new Date(weekStart);
-      weekEnd.setDate(weekStart.getDate() + 7);
+      const weekStart = mondayOfThisWeek - i * WEEK_IN_MS;
+      const weekEnd = weekStart + WEEK_IN_MS;
 
       const weekWorkouts = trendWorkouts.filter(
-        (w) => w.startedAt >= weekStart.getTime() && w.startedAt < weekEnd.getTime()
+        (w) => w.startedAt >= weekStart && w.startedAt < weekEnd
       );
 
       let volume = 0;
@@ -783,7 +771,11 @@ export const getDashboardStats = query({
       }
 
       weeklyTrend.push({
-        week: weekStart.toLocaleDateString("en-US", { month: "short", day: "numeric" }),
+        week: new Date(weekStart).toLocaleDateString("en-US", {
+          month: "short",
+          day: "numeric",
+          timeZone: "UTC",
+        }),
         volume,
         workouts: weekWorkouts.length,
         duration,

--- a/tests/week.test.mjs
+++ b/tests/week.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getMondayWeekKey, getMondayWeekStartUtc } from "../convex/lib/week.ts";
+
+test("keeps Monday and Sunday in the same Monday-starting week", () => {
+  const monday = Date.parse("2026-07-20T00:00:00.000Z");
+  const sunday = Date.parse("2026-07-26T23:59:59.999Z");
+
+  assert.equal(getMondayWeekStartUtc(monday), monday);
+  assert.equal(getMondayWeekStartUtc(sunday), monday);
+  assert.equal(getMondayWeekKey(sunday), "2026-07-20");
+});
+
+test("resets the week at Monday 00:00 UTC", () => {
+  const sunday = Date.parse("2026-07-19T23:59:59.999Z");
+  const monday = Date.parse("2026-07-20T00:00:00.000Z");
+
+  assert.equal(getMondayWeekKey(sunday), "2026-07-13");
+  assert.equal(getMondayWeekKey(monday), "2026-07-20");
+});
+
+test("handles a Monday-starting week across a year boundary", () => {
+  assert.equal(getMondayWeekKey(Date.parse("2027-01-03T12:00:00.000Z")), "2026-12-28");
+  assert.equal(getMondayWeekKey(Date.parse("2027-01-04T00:00:00.000Z")), "2027-01-04");
+});


### PR DESCRIPTION
## What does this PR do?

Aligns all Training Lab and dashboard week calculations to a shared Monday-starting boundary.

### Problem and evidence

Training Lab had duplicate helpers that grouped workouts on Sunday. Its default 7-day analysis also used a rolling window, so the Volume by Muscle UI could sum buckets from two different calendar weeks instead of resetting on Monday. The main dashboard used Monday for current-week totals but still grouped its four-week trend from Sunday.

### Implementation

- Adds one UTC Monday-boundary helper and week key shared by Training Lab aggregation, Training Lab dashboard stats, and dashboard trends.
- Makes the default 7-day Training Lab report aggregate week-to-date from Monday 00:00 UTC; explicit non-7-day windows retain their rolling-window behavior.
- Limits weekly report eligibility and workouts-since-report counts to the current Monday-starting week so the CTA cannot offer a report with no current-week data.
- Groups muscle-volume history, consistency weeks, streak keys, activity dots, and the four-week dashboard trend with the same Monday key.
- Adds focused Sunday-to-Monday and year-boundary coverage.

### Compatibility

No schema or production-record migration is required. Existing timestamps and stored reports are unchanged; newly generated weekly reports use the corrected boundary. Because OpenTrainer does not persist a user time zone today, server-side weeks are deliberately anchored to UTC for deterministic behavior.

## Related issue

N/A

## How to test

1. Run `bun test tests/week.test.mjs` and confirm 3 tests pass.
2. Run `bun run lint` and confirm 0 errors. The 7 reported warnings are pre-existing generated/demo-file warnings.
3. Run `bunx tsc --noEmit` and confirm it exits successfully.
4. Run `git diff --check` and confirm it exits successfully.
5. Manual boundary case: a workout at Sunday 23:59:59 UTC groups under the preceding Monday; a workout at Monday 00:00 UTC starts a new week.
6. Manual aggregation case: generate a default Training Lab report after Monday and confirm its muscle-set totals include only workouts from that Monday onward.
7. Manual trend case: confirm all four dashboard buckets are labeled by Monday and each interval ends at the following Monday.

## Checklist

- [x] I have tested this locally
- [x] `bun run lint` passes
- [x] I have updated docs if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/house-of-giants/codesmith/opentrainer/pr/42"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787253716&installation_model_id=19704&pr_number=42&repository=house-of-giants%2Fopentrainer&return_to=https%3A%2F%2Fgithub.com%2Fhouse-of-giants%2Fopentrainer%2Fpull%2F42&signature=5a058c13dcf677d7f0ac6e694469c7c3c83bb9f6329551798fb5208992582a81"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->