### PR TITLE
feat(workouts): support timed strength sets

### DIFF
--- a/convex/ai/aggregators.ts
+++ b/convex/ai/aggregators.ts
@@ -962,7 +962,7 @@ export const getExerciseContext = internalQuery({
       .take(9);
 
     const recentSessions = recentEntries
-      .filter((e) => e.kind === "lifting" && e.lifting)
+      .filter((e) => e.kind === "lifting" && e.lifting && e.lifting.durationSeconds === undefined)
       .slice(0, 3)
       .map((e) => ({
         wt: e.lifting!.weight ?? 0,

--- a/convex/ai/prompts.ts
+++ b/convex/ai/prompts.ts
@@ -211,7 +211,9 @@ SCHEMA:
       "reasoning": "string (1-2 sentences explaining biomechanical similarity)",
       "equipmentNeeded": ["string"],
       "muscleEmphasis": "string (how stimulus compares to original)",
-      "difficultyAdjustment": "easier|similar|harder"
+      "difficultyAdjustment": "easier|similar|harder",
+      "measurementType": "reps|duration",
+      "targetHoldSeconds": "number|null (required for timed holds)"
     }
   ],
   "note": "string|null (optional insight about the swap pattern)"
@@ -230,6 +232,7 @@ GUIDELINES:
 5. Consider the user's recent training volume to identify potential imbalances.
 6. Order alternatives from most to least recommended.
 7. Keep reasoning concise but informative.
+8. Use measurementType "duration" and targetHoldSeconds for timed isometric holds.
 
 MOVEMENT PATTERN MATCHING:
 - Horizontal push → horizontal push (bench → push-up, dumbbell press)
@@ -250,7 +253,9 @@ SCHEMA:
       "exercise": "string (standard exercise name)",
       "reasoning": "string (1-2 sentences explaining why this is a good substitute)",
       "equipmentNeeded": ["string"],
-      "difficultyAdjustment": "easier|similar|harder"
+      "difficultyAdjustment": "easier|similar|harder",
+      "measurementType": "reps|duration",
+      "targetHoldSeconds": "number|null (required for timed holds)"
     }
   ]
 }
@@ -267,6 +272,7 @@ GUIDELINES:
 4. Consider the routine context (other exercises in the same day) to avoid redundancy.
 5. Order alternatives from most to least recommended.
 6. Keep reasoning concise.
+7. Use measurementType "duration" and targetHoldSeconds for timed isometric holds.
 
 COMMON EXERCISE NAMES (use these exact names):
 - Chest: Bench Press, Incline Bench Press, Dumbbell Bench Press, Push Up, Cable Fly, Dumbbell Fly, Machine Chest Press
@@ -330,6 +336,8 @@ SCHEMA:
           "kind": "lifting|cardio|mobility",
           "targetSets": number (typically 3-5 for lifting),
           "targetReps": "string (e.g., '8-12', '5x5', '3x8-10')",
+          "measurementType": "reps|duration (use duration for timed strength holds such as Plank)",
+          "targetHoldSeconds": "number|null (required when measurementType is duration)",
           "notes": "string|null (brief coaching cue or note)"
         }
       ]
@@ -372,6 +380,7 @@ PROGRAM DESIGN GUIDELINES:
    - Include both push and pull movements each session
    - For beginners: stick to basics, fewer exercises per session
    - For advanced: add variation and isolation work
+   - Use measurementType "duration" and targetHoldSeconds for timed isometric holds; do not prescribe reps for them
 
 4. GOAL-SPECIFIC ADJUSTMENTS:
    - Strength: Lower rep ranges (3-6), longer rest, compound focus

--- a/convex/ai/routineGenerator.ts
+++ b/convex/ai/routineGenerator.ts
@@ -13,6 +13,8 @@ export interface RoutineSwapAlternative {
   reasoning: string;
   equipmentNeeded: string[];
   difficultyAdjustment: "easier" | "similar" | "harder";
+  measurementType?: "reps" | "duration";
+  targetHoldSeconds?: number;
 }
 
 export interface RoutineSwapResponse {
@@ -29,6 +31,8 @@ export interface GeneratedRoutineDay {
     kind: "lifting" | "cardio" | "mobility";
     targetSets: number;
     targetReps: string;
+    measurementType?: "reps" | "duration";
+    targetHoldSeconds?: number;
     notes?: string;
   }>;
 }
@@ -199,6 +203,14 @@ export const generateRoutine = action({
         if (typeof exercise.targetReps !== "string") {
           exercise.targetReps = "8-12";
         }
+        if (exercise.measurementType === "duration") {
+          exercise.targetHoldSeconds =
+            typeof exercise.targetHoldSeconds === "number" && exercise.targetHoldSeconds > 0
+              ? Math.min(exercise.targetHoldSeconds, 3600)
+              : 30;
+        } else {
+          exercise.measurementType = "reps";
+        }
       }
     }
 
@@ -309,6 +321,15 @@ export const getRoutineSwapAlternatives = action({
       ) {
         logger.fail(new Error("Invalid alternative exercise name"));
         throw new Error("Invalid alternative exercise name");
+      }
+      if (alt.measurementType === "duration") {
+        alt.targetHoldSeconds =
+          typeof alt.targetHoldSeconds === "number" && alt.targetHoldSeconds > 0
+            ? Math.min(alt.targetHoldSeconds, 3600)
+            : 30;
+      } else {
+        alt.measurementType = "reps";
+        alt.targetHoldSeconds = undefined;
       }
     }
 

--- a/convex/ai/smartSwap.ts
+++ b/convex/ai/smartSwap.ts
@@ -16,6 +16,8 @@ export interface SmartSwapResponse {
     equipmentNeeded: string[];
     muscleEmphasis: string;
     difficultyAdjustment?: "easier" | "similar" | "harder";
+    measurementType?: "reps" | "duration";
+    targetHoldSeconds?: number;
   }>;
   note?: string;
   swapId?: Id<"exerciseSwaps">;
@@ -119,6 +121,18 @@ export const getAlternatives = action({
     });
 
     const result = JSON.parse(response.text) as SmartSwapResponse;
+
+    for (const alternative of result.alternatives) {
+      if (alternative.measurementType === "duration") {
+        alternative.targetHoldSeconds =
+          typeof alternative.targetHoldSeconds === "number" && alternative.targetHoldSeconds > 0
+            ? Math.min(alternative.targetHoldSeconds, 3600)
+            : 30;
+      } else {
+        alternative.measurementType = "reps";
+        alternative.targetHoldSeconds = undefined;
+      }
+    }
 
     const swapId = await ctx.runMutation((internal.ai as any).swapMutations.recordSwap, {
       userId: user._id,

--- a/convex/entries.ts
+++ b/convex/entries.ts
@@ -8,6 +8,7 @@ const liftingDataValidator = v.object({
   setNumber: v.number(),
   reps: v.optional(v.number()),
   weight: v.optional(v.number()),
+  durationSeconds: v.optional(v.number()),
   unit: v.union(v.literal("kg"), v.literal("lb")),
   rpe: v.optional(v.number()),
   rir: v.optional(v.number()),
@@ -99,6 +100,17 @@ export const addLiftingEntry = mutation({
     if (workout.status !== "in_progress") {
       logger.fail(new Error("Cannot add entries to a completed workout"));
       throw new Error("Cannot add entries to a completed workout");
+    }
+
+    const { durationSeconds, reps } = args.lifting;
+    if (durationSeconds !== undefined && (!Number.isFinite(durationSeconds) || durationSeconds <= 0)) {
+      throw new Error("Duration must be greater than zero");
+    }
+    if (durationSeconds !== undefined && reps !== undefined) {
+      throw new Error("A lifting set cannot use both duration and reps");
+    }
+    if (durationSeconds === undefined && (reps === undefined || !Number.isFinite(reps) || reps <= 0)) {
+      throw new Error("Reps must be greater than zero");
     }
 
     const existingEntry = await ctx.db
@@ -223,6 +235,19 @@ export const updateLiftingEntry = mutation({
 
     if (entry.kind !== "lifting") {
       throw new Error("Entry is not a lifting entry");
+    }
+
+    if (args.lifting) {
+      const { durationSeconds, reps } = args.lifting;
+      if (durationSeconds !== undefined && (!Number.isFinite(durationSeconds) || durationSeconds <= 0)) {
+        throw new Error("Duration must be greater than zero");
+      }
+      if (durationSeconds !== undefined && reps !== undefined) {
+        throw new Error("A lifting set cannot use both duration and reps");
+      }
+      if (durationSeconds === undefined && (reps === undefined || !Number.isFinite(reps) || reps <= 0)) {
+        throw new Error("Reps must be greater than zero");
+      }
     }
 
     await ctx.db.patch(args.entryId, {
@@ -463,7 +488,7 @@ export const getExerciseHistory = query({
       );
 
       const sets = sessionEntries
-        .filter((e) => e.lifting)
+        .filter((e) => e.lifting && e.lifting.durationSeconds === undefined)
         .map((e) => ({
           setNumber: e.lifting!.setNumber,
           weight: e.lifting!.weight ?? 0,
@@ -485,6 +510,64 @@ export const getExerciseHistory = query({
         date: new Date(workout.completedAt ?? workout.startedAt).toISOString(),
         sets,
         bestSet,
+      });
+    }
+
+    return sessions;
+  },
+});
+
+export const getTimedExerciseHistory = query({
+  args: {
+    exerciseName: v.string(),
+    sessionCount: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const user = await getCurrentUser(ctx, { requireAuth: false, requireUser: false });
+    if (!user) return [];
+
+    const limit = args.sessionCount ?? 3;
+    const entries = await ctx.db
+      .query("entries")
+      .withIndex("by_user_created", (q) => q.eq("userId", user._id))
+      .order("desc")
+      .filter((q) =>
+        q.and(
+          q.eq(q.field("exerciseName"), args.exerciseName),
+          q.eq(q.field("kind"), "lifting")
+        )
+      )
+      .collect();
+
+    const sessionMap = new Map<Id<"workouts">, (typeof entries)[number][]>();
+    for (const entry of entries) {
+      if (!entry.lifting?.durationSeconds) continue;
+      const existing = sessionMap.get(entry.workoutId) ?? [];
+      existing.push(entry);
+      sessionMap.set(entry.workoutId, existing);
+    }
+
+    const sessions = [];
+    for (const [workoutId, sessionEntries] of sessionMap) {
+      if (sessions.length >= limit) break;
+      const workout = await ctx.db.get(workoutId);
+      if (!workout || workout.status !== "completed") continue;
+
+      const sets = sessionEntries
+        .filter((entry) => entry.lifting?.durationSeconds)
+        .sort((a, b) => (a.lifting?.setNumber ?? 0) - (b.lifting?.setNumber ?? 0))
+        .map((entry) => ({
+          setNumber: entry.lifting!.setNumber,
+          durationSeconds: entry.lifting!.durationSeconds!,
+          rpe: entry.lifting!.rpe ?? null,
+        }));
+
+      if (sets.length === 0) continue;
+      sessions.push({
+        workoutId,
+        date: new Date(workout.completedAt ?? workout.startedAt).toISOString(),
+        sets,
+        longestHoldSeconds: Math.max(...sets.map((set) => set.durationSeconds)),
       });
     }
 
@@ -564,7 +647,7 @@ export const getExerciseHistoryInternal = internalQuery({
       );
 
       const sets = sessionEntries
-        .filter((e) => e.lifting)
+        .filter((e) => e.lifting && e.lifting.durationSeconds === undefined)
         .map((e) => ({
           setNumber: e.lifting!.setNumber,
           weight: e.lifting!.weight ?? 0,
@@ -592,5 +675,3 @@ export const getExerciseHistoryInternal = internalQuery({
     return sessions;
   },
 });
-
-

--- a/convex/exercises.ts
+++ b/convex/exercises.ts
@@ -99,7 +99,7 @@ const SYSTEM_EXERCISES = [
   // --------------------------------------------------------------------------
   // Core
   // --------------------------------------------------------------------------
-  { name: "Plank", aliases: ["Front Plank"], category: "lifting", muscleGroups: ["core"], equipment: ["bodyweight"] },
+  { name: "Plank", aliases: ["Front Plank"], category: "lifting", muscleGroups: ["core"], equipment: ["bodyweight"], measurementType: "duration" },
   { name: "Crunch", aliases: ["Ab Crunch"], category: "lifting", muscleGroups: ["core"], equipment: ["bodyweight"] },
   { name: "Leg Raise", aliases: ["Hanging Leg Raise", "Lying Leg Raise"], category: "lifting", muscleGroups: ["core"], equipment: ["bodyweight"] },
   { name: "Russian Twist", aliases: ["Seated Russian Twist"], category: "lifting", muscleGroups: ["core"], equipment: ["bodyweight", "dumbbell"] },
@@ -242,6 +242,7 @@ export const seedSystemExercises = mutation({
         equipment: exercise.equipment?.length ? [...exercise.equipment] : undefined,
         modality: "modality" in exercise ? exercise.modality : undefined,
         primaryMetric: "primaryMetric" in exercise ? (exercise.primaryMetric as "duration" | "distance") : undefined,
+        measurementType: "measurementType" in exercise ? (exercise.measurementType as "duration") : undefined,
         isSystemExercise: true,
         createdAt: now,
       });
@@ -279,7 +280,8 @@ export const updateSystemExercises = mutation({
         JSON.stringify(existingExercise.aliases ?? []) !== JSON.stringify(exercise.aliases ?? []) ||
         JSON.stringify(existingExercise.equipment ?? []) !== JSON.stringify(exercise.equipment ?? []) ||
         JSON.stringify(existingExercise.muscleGroups ?? []) !== JSON.stringify(exercise.muscleGroups ?? []) ||
-        existingExercise.category !== exercise.category;
+        existingExercise.category !== exercise.category ||
+        existingExercise.measurementType !== ("measurementType" in exercise ? exercise.measurementType : undefined);
 
       if (needsUpdate) {
         await ctx.db.patch(existingExercise._id, {
@@ -287,6 +289,7 @@ export const updateSystemExercises = mutation({
           equipment: exercise.equipment?.length ? [...exercise.equipment] : undefined,
           muscleGroups: exercise.muscleGroups?.length ? [...exercise.muscleGroups] : undefined,
           category: exercise.category as "lifting" | "cardio" | "mobility" | "other",
+          measurementType: "measurementType" in exercise ? (exercise.measurementType as "duration") : undefined,
         });
         updated++;
       }
@@ -313,6 +316,7 @@ export const createExercise = mutation({
     equipment: v.optional(v.array(v.string())),
     modality: v.optional(v.string()),
     primaryMetric: v.optional(v.union(v.literal("duration"), v.literal("distance"))),
+    measurementType: v.optional(v.union(v.literal("reps"), v.literal("duration"))),
   },
   handler: async (ctx, args) => {
     const user = await getCurrentUser(ctx);
@@ -327,6 +331,7 @@ export const createExercise = mutation({
       equipment: args.equipment,
       modality: args.modality,
       primaryMetric: args.primaryMetric,
+      measurementType: args.measurementType,
       isSystemExercise: false,
       createdAt: Date.now(),
     });
@@ -344,6 +349,7 @@ export const updateExercise = mutation({
     id: v.id("exercises"),
     muscleGroups: v.optional(v.array(v.string())),
     name: v.optional(v.string()),
+    measurementType: v.optional(v.union(v.literal("reps"), v.literal("duration"))),
   },
   handler: async (ctx, args) => {
     const user = await getCurrentUser(ctx);
@@ -364,6 +370,7 @@ export const updateExercise = mutation({
     const updates: Partial<{
       muscleGroups?: string[];
       name?: string;
+      measurementType?: "reps" | "duration";
     }> = {};
 
     if (args.muscleGroups !== undefined) {
@@ -372,6 +379,10 @@ export const updateExercise = mutation({
 
     if (args.name !== undefined) {
       updates.name = args.name;
+    }
+
+    if (args.measurementType !== undefined) {
+      updates.measurementType = args.measurementType;
     }
 
     await ctx.db.patch(args.id, updates);

--- a/convex/lib/routineMeasurements.test.ts
+++ b/convex/lib/routineMeasurements.test.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import {
+  convertWorkoutEntriesToRoutineFormat,
+  convertWorkoutExercisesToRoutineFormat,
+} from "./routineMeasurements";
+
+describe("convertWorkoutExercisesToRoutineFormat", () => {
+  test("keeps rep and timed prescriptions when an exported exercise mixes modes", () => {
+    const result = convertWorkoutExercisesToRoutineFormat([{
+      name: "Plank",
+      kind: "lifting",
+      sets: [
+        { reps: 12, weight: 20, rpe: 7 },
+        { durationSeconds: 30, rpe: 8 },
+        { durationSeconds: 60, rpe: 9 },
+      ],
+    }]);
+
+    assert.deepEqual(result, [
+      {
+        name: "Plank",
+        kind: "lifting",
+        targetSets: 1,
+        targetReps: "12",
+        targetRpe: 7,
+      },
+      {
+        name: "Plank",
+        kind: "lifting",
+        targetSets: 2,
+        targetRpe: 9,
+        measurementType: "duration",
+        targetHoldSeconds: 45,
+      },
+    ]);
+  });
+
+  test("preserves the first source mode when splitting a mixed export", () => {
+    const result = convertWorkoutExercisesToRoutineFormat([{
+      name: "Plank",
+      kind: "lifting",
+      sets: [
+        { durationSeconds: 30 },
+        { reps: 10 },
+      ],
+    }]);
+
+    assert.deepEqual(
+      result.map((exercise) => exercise.measurementType ?? "reps"),
+      ["duration", "reps"]
+    );
+  });
+
+  test("does not count warmups in either working prescription", () => {
+    const result = convertWorkoutExercisesToRoutineFormat([{
+      name: "Plank",
+      kind: "lifting",
+      sets: [
+        { reps: 5, isWarmup: true },
+        { durationSeconds: 40 },
+      ],
+    }]);
+
+    assert.deepEqual(result, [{
+      name: "Plank",
+      kind: "lifting",
+      targetSets: 1,
+      measurementType: "duration",
+      targetHoldSeconds: 40,
+    }]);
+  });
+});
+
+describe("convertWorkoutEntriesToRoutineFormat", () => {
+  test("creates separate routine rows for rep and timed entries with the same name", () => {
+    const result = convertWorkoutEntriesToRoutineFormat([
+      {
+        exerciseId: "exercise-1",
+        exerciseName: "Plank",
+        kind: "lifting",
+        lifting: {},
+      },
+      {
+        exerciseId: "exercise-1",
+        exerciseName: "Plank",
+        kind: "lifting",
+        lifting: { durationSeconds: 30 },
+      },
+      {
+        exerciseId: "exercise-1",
+        exerciseName: "Plank",
+        kind: "lifting",
+        lifting: { durationSeconds: 60 },
+      },
+    ]);
+
+    assert.deepEqual(result, [
+      {
+        exerciseId: "exercise-1",
+        exerciseName: "Plank",
+        kind: "lifting",
+        targetSets: 1,
+        targetReps: "8-12",
+        measurementType: undefined,
+        targetDuration: undefined,
+        targetHoldSeconds: undefined,
+      },
+      {
+        exerciseId: "exercise-1",
+        exerciseName: "Plank",
+        kind: "lifting",
+        targetSets: 2,
+        targetReps: undefined,
+        measurementType: "duration",
+        targetDuration: undefined,
+        targetHoldSeconds: 45,
+      },
+    ]);
+  });
+});

--- a/convex/lib/routineMeasurements.ts
+++ b/convex/lib/routineMeasurements.ts
@@ -1,0 +1,196 @@
+export type WorkoutExerciseForRoutine = {
+  name?: string;
+  kind?: string;
+  sets?: Array<{
+    weight?: number;
+    reps?: number;
+    durationSeconds?: number;
+    rpe?: number;
+    isWarmup?: boolean;
+  }>;
+  cardio?: unknown;
+};
+
+export type ConvertedRoutineExercise = {
+  name: string;
+  kind: string;
+  targetSets?: number;
+  targetReps?: string;
+  targetRpe?: number;
+  targetDuration?: number;
+  measurementType?: "reps" | "duration";
+  targetHoldSeconds?: number;
+};
+
+export type WorkoutEntryForRoutine<TExerciseId = string> = {
+  exerciseId?: TExerciseId;
+  exerciseName: string;
+  kind: "lifting" | "cardio" | "mobility";
+  lifting?: {
+    durationSeconds?: number;
+  };
+};
+
+export type StoredRoutineExercise<TExerciseId = string> = {
+  exerciseId?: TExerciseId;
+  exerciseName: string;
+  kind: "lifting" | "cardio" | "mobility";
+  targetSets?: number;
+  targetReps?: string;
+  measurementType?: "duration";
+  targetDuration?: number;
+  targetHoldSeconds?: number;
+};
+
+type WorkoutSet = NonNullable<WorkoutExerciseForRoutine["sets"]>[number];
+
+function average(values: number[]): number | undefined {
+  if (values.length === 0) return undefined;
+  return Math.round(values.reduce((sum, value) => sum + value, 0) / values.length);
+}
+
+function averageRpe(sets: WorkoutSet[]): number | undefined {
+  return average(
+    sets.flatMap((set) => (set.rpe === undefined ? [] : [set.rpe]))
+  );
+}
+
+function convertLiftingSets(name: string, sets: WorkoutSet[]): ConvertedRoutineExercise[] {
+  const workingSets = sets.filter((set) => !set.isWarmup);
+
+  if (workingSets.length === 0) {
+    return [{
+      name,
+      kind: "lifting",
+      targetSets: sets.length,
+      targetReps: "8-12",
+    }];
+  }
+
+  const timedSets = workingSets.filter((set) => (set.durationSeconds ?? 0) > 0);
+  const repSets = workingSets.filter((set) => (set.durationSeconds ?? 0) <= 0);
+  const converted: ConvertedRoutineExercise[] = [];
+
+  // Keep the source ordering when a workout contains both measurement modes.
+  // Each routine row still has exactly one logger, preserving the existing model.
+  const firstTimedIndex = workingSets.findIndex((set) => (set.durationSeconds ?? 0) > 0);
+  const firstRepIndex = workingSets.findIndex((set) => (set.durationSeconds ?? 0) <= 0);
+  const modes = [
+    { mode: "reps" as const, index: firstRepIndex },
+    { mode: "duration" as const, index: firstTimedIndex },
+  ].filter(({ index }) => index >= 0).sort((a, b) => a.index - b.index);
+
+  for (const { mode } of modes) {
+    if (mode === "duration") {
+      const targetRpe = averageRpe(timedSets);
+      converted.push({
+        name,
+        kind: "lifting",
+        targetSets: timedSets.length,
+        ...(targetRpe === undefined ? {} : { targetRpe }),
+        measurementType: "duration",
+        targetHoldSeconds: average(
+          timedSets.map((set) => set.durationSeconds ?? 0)
+        ),
+      });
+      continue;
+    }
+
+    const averageReps = average(repSets.map((set) => set.reps ?? 0)) ?? 0;
+    const targetRpe = averageRpe(repSets);
+    converted.push({
+      name,
+      kind: "lifting",
+      targetSets: repSets.length,
+      targetReps: averageReps > 0 ? `${averageReps}` : "8-12",
+      ...(targetRpe === undefined ? {} : { targetRpe }),
+    });
+  }
+
+  return converted;
+}
+
+export function convertWorkoutExercisesToRoutineFormat(
+  exercises: WorkoutExerciseForRoutine[]
+): ConvertedRoutineExercise[] {
+  return exercises.flatMap((exercise) => {
+    if (!exercise.name || typeof exercise.name !== "string") {
+      throw new Error(
+        "Workout export contains an exercise without a name. This might be corrupted. Try exporting the workout again."
+      );
+    }
+
+    const kind = exercise.kind === "cardio"
+      ? "cardio"
+      : exercise.kind === "mobility"
+        ? "mobility"
+        : "lifting";
+
+    if (kind === "lifting" && Array.isArray(exercise.sets)) {
+      return convertLiftingSets(exercise.name, exercise.sets);
+    }
+
+    return [{
+      name: exercise.name,
+      kind,
+      targetDuration: kind === "cardio" ? 15 : undefined,
+    }];
+  });
+}
+
+export function convertWorkoutEntriesToRoutineFormat<TExerciseId>(
+  entries: WorkoutEntryForRoutine<TExerciseId>[]
+): StoredRoutineExercise<TExerciseId>[] {
+  const exerciseMap = new Map<string, {
+    exerciseId?: TExerciseId;
+    exerciseName: string;
+    kind: "lifting" | "cardio" | "mobility";
+    sets: number;
+    durations: number[];
+  }>();
+
+  for (const entry of entries) {
+    const measurementType = entry.kind === "lifting" && entry.lifting?.durationSeconds !== undefined
+      ? "duration"
+      : "reps";
+    const key = JSON.stringify([entry.exerciseName, entry.kind, measurementType]);
+    const existing = exerciseMap.get(key);
+
+    if (!existing) {
+      exerciseMap.set(key, {
+        exerciseId: entry.exerciseId,
+        exerciseName: entry.exerciseName,
+        kind: entry.kind,
+        sets: 1,
+        durations: entry.lifting?.durationSeconds !== undefined
+          ? [entry.lifting.durationSeconds]
+          : [],
+      });
+      continue;
+    }
+
+    exerciseMap.set(key, {
+      ...existing,
+      sets: existing.sets + 1,
+      durations: entry.lifting?.durationSeconds !== undefined
+        ? [...existing.durations, entry.lifting.durationSeconds]
+        : existing.durations,
+    });
+  }
+
+  return Array.from(exerciseMap.values()).map((data) => {
+    const isTimedStrength = data.kind === "lifting" && data.durations.length > 0;
+    return {
+      exerciseId: data.exerciseId,
+      exerciseName: data.exerciseName,
+      kind: data.kind,
+      targetSets: data.kind === "lifting" || data.kind === "mobility" ? data.sets : undefined,
+      targetReps: data.kind === "lifting" && !isTimedStrength ? "8-12" : undefined,
+      measurementType: isTimedStrength ? "duration" as const : undefined,
+      targetDuration: data.kind === "cardio" ? 15 : undefined,
+      targetHoldSeconds: isTimedStrength
+        ? average(data.durations)
+        : data.kind === "mobility" ? 30 : undefined,
+    };
+  });
+}

--- a/convex/routines.ts
+++ b/convex/routines.ts
@@ -1,6 +1,11 @@
 import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
 import { getCurrentUser } from "./auth";
+import {
+  convertWorkoutEntriesToRoutineFormat,
+  convertWorkoutExercisesToRoutineFormat,
+  type WorkoutExerciseForRoutine,
+} from "./lib/routineMeasurements";
 
 const routineExerciseValidator = v.object({
   exerciseId: v.optional(v.id("exercises")),
@@ -21,79 +26,6 @@ const routineDayValidator = v.object({
   name: v.string(),
   exercises: v.array(routineExerciseValidator),
 });
-
-type WorkoutExercise = {
-  name?: string;
-  kind?: string;
-  sets?: Array<{
-    weight?: number;
-    reps?: number;
-    durationSeconds?: number;
-    rpe?: number;
-    isWarmup?: boolean;
-  }>;
-  cardio?: unknown;
-};
-
-type RoutineExercise = {
-  name: string;
-  kind: string;
-  targetSets?: number;
-  targetReps?: string;
-  targetRpe?: number;
-  targetDuration?: number;
-  measurementType?: "reps" | "duration";
-  targetHoldSeconds?: number;
-};
-
-function convertWorkoutExercisesToRoutineFormat(exercises: WorkoutExercise[]): RoutineExercise[] {
-  return exercises.map((ex) => {
-    if (!ex.name || typeof ex.name !== "string") {
-      throw new Error(
-        "Workout export contains an exercise without a name. This might be corrupted. Try exporting the workout again."
-      );
-    }
-
-    const kind = ex.kind === "cardio" ? "cardio" : (ex.kind === "mobility" ? "mobility" : "lifting");
-
-    const exercise: RoutineExercise = {
-      name: ex.name,
-      kind,
-    };
-
-    if (kind === "lifting" && ex.sets && Array.isArray(ex.sets)) {
-      const workingSets = ex.sets.filter((s) => !s.isWarmup);
-      if (workingSets.length > 0) {
-        exercise.targetSets = workingSets.length;
-        const durationSets = workingSets.filter((s) => (s.durationSeconds ?? 0) > 0);
-        if (durationSets.length > 0) {
-          exercise.measurementType = "duration";
-          exercise.targetHoldSeconds = Math.round(
-            durationSets.reduce((sum, s) => sum + (s.durationSeconds ?? 0), 0) / durationSets.length
-          );
-        } else {
-          const avgReps = Math.round(
-            workingSets.reduce((sum, s) => sum + (s.reps ?? 0), 0) / workingSets.length
-          );
-          exercise.targetReps = avgReps > 0 ? `${avgReps}` : "8-12";
-        }
-        const rpes = workingSets.map((s) => s.rpe).filter((r) => r !== undefined);
-        if (rpes.length > 0) {
-          exercise.targetRpe = Math.round(
-            rpes.reduce((sum, r) => sum + (r ?? 0), 0) / rpes.length
-          );
-        }
-      } else {
-        exercise.targetSets = ex.sets.length;
-        exercise.targetReps = "8-12";
-      }
-    } else if (kind === "cardio") {
-      exercise.targetDuration = 15;
-    }
-
-    return exercise;
-  });
-}
 
 export const createRoutine = mutation({
   args: {
@@ -145,45 +77,7 @@ export const createRoutineFromWorkout = mutation({
       .withIndex("by_workout", (q) => q.eq("workoutId", args.workoutId))
       .collect();
 
-    const exerciseMap = new Map<string, {
-      kind: "lifting" | "cardio" | "mobility";
-      sets: number;
-      durations: number[];
-    }>();
-    
-    for (const entry of entries) {
-      const existing = exerciseMap.get(entry.exerciseName);
-      if (!existing) {
-        exerciseMap.set(entry.exerciseName, {
-          kind: entry.kind,
-          sets: 1,
-          durations: entry.lifting?.durationSeconds ? [entry.lifting.durationSeconds] : [],
-        });
-      } else {
-        exerciseMap.set(entry.exerciseName, {
-          ...existing,
-          sets: existing.sets + 1,
-          durations: entry.lifting?.durationSeconds
-            ? [...existing.durations, entry.lifting.durationSeconds]
-            : existing.durations,
-        });
-      }
-    }
-
-    const exercises = Array.from(exerciseMap.entries()).map(([name, data]) => {
-      const isTimedStrength = data.kind === "lifting" && data.durations.length > 0;
-      return {
-        exerciseName: name,
-        kind: data.kind,
-        targetSets: data.kind === "lifting" || data.kind === "mobility" ? data.sets : undefined,
-        targetReps: data.kind === "lifting" && !isTimedStrength ? "8-12" : undefined,
-        measurementType: isTimedStrength ? ("duration" as const) : undefined,
-        targetDuration: data.kind === "cardio" ? 15 : undefined,
-        targetHoldSeconds: isTimedStrength
-          ? Math.round(data.durations.reduce((sum, duration) => sum + duration, 0) / data.durations.length)
-          : data.kind === "mobility" ? 30 : undefined,
-      };
-    });
+    const exercises = convertWorkoutEntriesToRoutineFormat(entries);
 
     const now = Date.now();
 
@@ -307,18 +201,7 @@ export const importRoutineFromJson = mutation({
       description?: string;
       workout?: {
         title?: string;
-        exercises?: Array<{
-          name?: string;
-          kind?: string;
-          sets?: Array<{
-            weight?: number;
-            reps?: number;
-            durationSeconds?: number;
-            rpe?: number;
-            isWarmup?: boolean;
-          }>;
-          cardio?: unknown;
-        }>;
+        exercises?: WorkoutExerciseForRoutine[];
       };
       days?: Array<{
         name?: string;
@@ -480,18 +363,7 @@ export const importDayToRoutine = mutation({
       name?: string;
       workout?: {
         title?: string;
-        exercises?: Array<{
-          name?: string;
-          kind?: string;
-          sets?: Array<{
-            weight?: number;
-            reps?: number;
-            durationSeconds?: number;
-            rpe?: number;
-            isWarmup?: boolean;
-          }>;
-          cardio?: unknown;
-        }>;
+        exercises?: WorkoutExerciseForRoutine[];
       };
       exercises?: Array<{
         name?: string;

--- a/convex/routines.ts
+++ b/convex/routines.ts
@@ -9,6 +9,7 @@ const routineExerciseValidator = v.object({
   targetSets: v.optional(v.number()),
   targetReps: v.optional(v.string()),
   targetRpe: v.optional(v.number()),
+  measurementType: v.optional(v.union(v.literal("reps"), v.literal("duration"))),
   targetDuration: v.optional(v.number()),
   targetIntensity: v.optional(v.number()),
   targetHoldSeconds: v.optional(v.number()),
@@ -27,6 +28,7 @@ type WorkoutExercise = {
   sets?: Array<{
     weight?: number;
     reps?: number;
+    durationSeconds?: number;
     rpe?: number;
     isWarmup?: boolean;
   }>;
@@ -40,6 +42,8 @@ type RoutineExercise = {
   targetReps?: string;
   targetRpe?: number;
   targetDuration?: number;
+  measurementType?: "reps" | "duration";
+  targetHoldSeconds?: number;
 };
 
 function convertWorkoutExercisesToRoutineFormat(exercises: WorkoutExercise[]): RoutineExercise[] {
@@ -61,10 +65,18 @@ function convertWorkoutExercisesToRoutineFormat(exercises: WorkoutExercise[]): R
       const workingSets = ex.sets.filter((s) => !s.isWarmup);
       if (workingSets.length > 0) {
         exercise.targetSets = workingSets.length;
-        const avgReps = Math.round(
-          workingSets.reduce((sum, s) => sum + (s.reps ?? 0), 0) / workingSets.length
-        );
-        exercise.targetReps = avgReps > 0 ? `${avgReps}` : "8-12";
+        const durationSets = workingSets.filter((s) => (s.durationSeconds ?? 0) > 0);
+        if (durationSets.length > 0) {
+          exercise.measurementType = "duration";
+          exercise.targetHoldSeconds = Math.round(
+            durationSets.reduce((sum, s) => sum + (s.durationSeconds ?? 0), 0) / durationSets.length
+          );
+        } else {
+          const avgReps = Math.round(
+            workingSets.reduce((sum, s) => sum + (s.reps ?? 0), 0) / workingSets.length
+          );
+          exercise.targetReps = avgReps > 0 ? `${avgReps}` : "8-12";
+        }
         const rpes = workingSets.map((s) => s.rpe).filter((r) => r !== undefined);
         if (rpes.length > 0) {
           exercise.targetRpe = Math.round(
@@ -133,25 +145,45 @@ export const createRoutineFromWorkout = mutation({
       .withIndex("by_workout", (q) => q.eq("workoutId", args.workoutId))
       .collect();
 
-    const exerciseMap = new Map<string, { kind: "lifting" | "cardio" | "mobility"; sets: number }>();
+    const exerciseMap = new Map<string, {
+      kind: "lifting" | "cardio" | "mobility";
+      sets: number;
+      durations: number[];
+    }>();
     
     for (const entry of entries) {
       const existing = exerciseMap.get(entry.exerciseName);
       if (!existing) {
-        exerciseMap.set(entry.exerciseName, { kind: entry.kind, sets: 1 });
+        exerciseMap.set(entry.exerciseName, {
+          kind: entry.kind,
+          sets: 1,
+          durations: entry.lifting?.durationSeconds ? [entry.lifting.durationSeconds] : [],
+        });
       } else {
-        exerciseMap.set(entry.exerciseName, { ...existing, sets: existing.sets + 1 });
+        exerciseMap.set(entry.exerciseName, {
+          ...existing,
+          sets: existing.sets + 1,
+          durations: entry.lifting?.durationSeconds
+            ? [...existing.durations, entry.lifting.durationSeconds]
+            : existing.durations,
+        });
       }
     }
 
-    const exercises = Array.from(exerciseMap.entries()).map(([name, data]) => ({
-      exerciseName: name,
-      kind: data.kind,
-      targetSets: data.kind === "lifting" ? data.sets : (data.kind === "mobility" ? data.sets : undefined),
-      targetReps: data.kind === "lifting" ? "8-12" : undefined,
-      targetDuration: data.kind === "cardio" ? 15 : undefined,
-      targetHoldSeconds: data.kind === "mobility" ? 30 : undefined,
-    }));
+    const exercises = Array.from(exerciseMap.entries()).map(([name, data]) => {
+      const isTimedStrength = data.kind === "lifting" && data.durations.length > 0;
+      return {
+        exerciseName: name,
+        kind: data.kind,
+        targetSets: data.kind === "lifting" || data.kind === "mobility" ? data.sets : undefined,
+        targetReps: data.kind === "lifting" && !isTimedStrength ? "8-12" : undefined,
+        measurementType: isTimedStrength ? ("duration" as const) : undefined,
+        targetDuration: data.kind === "cardio" ? 15 : undefined,
+        targetHoldSeconds: isTimedStrength
+          ? Math.round(data.durations.reduce((sum, duration) => sum + duration, 0) / data.durations.length)
+          : data.kind === "mobility" ? 30 : undefined,
+      };
+    });
 
     const now = Date.now();
 
@@ -281,6 +313,7 @@ export const importRoutineFromJson = mutation({
           sets?: Array<{
             weight?: number;
             reps?: number;
+            durationSeconds?: number;
             rpe?: number;
             isWarmup?: boolean;
           }>;
@@ -295,6 +328,7 @@ export const importRoutineFromJson = mutation({
           targetSets?: number;
           targetReps?: string;
           targetRpe?: number;
+          measurementType?: string;
           targetDuration?: number;
           targetIntensity?: number;
           targetHoldSeconds?: number;
@@ -364,6 +398,7 @@ export const importRoutineFromJson = mutation({
           targetSets: typeof ex.targetSets === "number" ? ex.targetSets : undefined,
           targetReps: typeof ex.targetReps === "string" ? ex.targetReps : undefined,
           targetRpe: typeof ex.targetRpe === "number" ? ex.targetRpe : undefined,
+          measurementType: ex.measurementType === "duration" ? "duration" as const : undefined,
           targetDuration: typeof ex.targetDuration === "number" ? ex.targetDuration : undefined,
           targetIntensity: typeof ex.targetIntensity === "number" ? ex.targetIntensity : undefined,
           targetHoldSeconds: typeof ex.targetHoldSeconds === "number" ? ex.targetHoldSeconds : undefined,
@@ -451,6 +486,7 @@ export const importDayToRoutine = mutation({
           sets?: Array<{
             weight?: number;
             reps?: number;
+            durationSeconds?: number;
             rpe?: number;
             isWarmup?: boolean;
           }>;
@@ -463,6 +499,7 @@ export const importDayToRoutine = mutation({
         targetSets?: number;
         targetReps?: string;
         targetRpe?: number;
+        measurementType?: string;
         targetDuration?: number;
         targetIntensity?: number;
         targetHoldSeconds?: number;
@@ -509,6 +546,7 @@ export const importDayToRoutine = mutation({
         targetSets: typeof ex.targetSets === "number" ? ex.targetSets : undefined,
         targetReps: typeof ex.targetReps === "string" ? ex.targetReps : undefined,
         targetRpe: typeof ex.targetRpe === "number" ? ex.targetRpe : undefined,
+        measurementType: ex.measurementType === "duration" ? "duration" as const : undefined,
         targetDuration: typeof ex.targetDuration === "number" ? ex.targetDuration : undefined,
         targetIntensity: typeof ex.targetIntensity === "number" ? ex.targetIntensity : undefined,
         targetHoldSeconds: typeof ex.targetHoldSeconds === "number" ? ex.targetHoldSeconds : undefined,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -88,6 +88,8 @@ export default defineSchema({
     // For lifting exercises
     muscleGroups: v.optional(v.array(v.string())),
     equipment: v.optional(v.array(v.string())),
+    // Defaults to reps for backward compatibility. Duration is for timed holds.
+    measurementType: v.optional(v.union(v.literal("reps"), v.literal("duration"))),
     
     // For cardio exercises
     modality: v.optional(v.string()), // run, bike, row, stairstepper, etc.
@@ -170,6 +172,7 @@ export default defineSchema({
       setNumber: v.number(),
       reps: v.optional(v.number()),
       weight: v.optional(v.number()),
+      durationSeconds: v.optional(v.number()),
       unit: v.union(v.literal("kg"), v.literal("lb")),
       rpe: v.optional(v.number()), // 1-10 scale
       rir: v.optional(v.number()), // Reps in reserve
@@ -274,10 +277,11 @@ export default defineSchema({
         targetSets: v.optional(v.number()),
         targetReps: v.optional(v.string()), // e.g., "8-12"
         targetRpe: v.optional(v.number()),
+        measurementType: v.optional(v.union(v.literal("reps"), v.literal("duration"))),
         // Target for cardio
         targetDuration: v.optional(v.number()), // minutes
         targetIntensity: v.optional(v.number()),
-        // Target for mobility
+        // Target for mobility or duration-based lifting holds
         targetHoldSeconds: v.optional(v.number()),
         perSide: v.optional(v.boolean()),
         notes: v.optional(v.string()),

--- a/convex/workouts.ts
+++ b/convex/workouts.ts
@@ -591,17 +591,33 @@ export const getRoutineExercisesForWorkout = query({
 
     const exercisesWithEquipment = await Promise.all(
       exercises.map(async (ex) => {
-        const exerciseData = ex.exerciseId
-          ? await ctx.db.get(ex.exerciseId)
-          : await ctx.db
-              .query("exercises")
-              .withIndex("by_name", (query) => query.eq("name", ex.exerciseName))
-              .first();
+        let exerciseData = ex.exerciseId ? await ctx.db.get(ex.exerciseId) : null;
+
+        if (exerciseData?.userId && exerciseData.userId !== user._id) {
+          exerciseData = null;
+        }
+
+        if (!ex.exerciseId) {
+          const accessibleMatches = (await ctx.db
+            .query("exercises")
+            .withIndex("by_name", (query) => query.eq("name", ex.exerciseName))
+            .collect())
+            .filter((candidate) => !candidate.userId || candidate.userId === user._id);
+
+          // A legacy or imported routine may not have an exerciseId. Only enrich
+          // it when the name identifies one accessible catalog row; otherwise its
+          // explicit routine metadata (or the legacy reps default) is authoritative.
+          exerciseData = accessibleMatches.length === 1 ? accessibleMatches[0] : null;
+        }
+
         if (exerciseData) {
           return {
             ...ex,
-            equipment: exerciseData?.equipment,
-            measurementType: ex.measurementType ?? exerciseData?.measurementType,
+            equipment: exerciseData.equipment,
+            // A catalog mode is authoritative only when the routine stores that
+            // catalog row's id. Name-only legacy rows retain the reps default.
+            measurementType: ex.measurementType
+              ?? (ex.exerciseId ? exerciseData.measurementType : undefined),
           };
         }
         return ex;

--- a/convex/workouts.ts
+++ b/convex/workouts.ts
@@ -591,11 +591,17 @@ export const getRoutineExercisesForWorkout = query({
 
     const exercisesWithEquipment = await Promise.all(
       exercises.map(async (ex) => {
-        if (ex.exerciseId) {
-          const exerciseData = await ctx.db.get(ex.exerciseId);
+        const exerciseData = ex.exerciseId
+          ? await ctx.db.get(ex.exerciseId)
+          : await ctx.db
+              .query("exercises")
+              .withIndex("by_name", (query) => query.eq("name", ex.exerciseName))
+              .first();
+        if (exerciseData) {
           return {
             ...ex,
             equipment: exerciseData?.equipment,
+            measurementType: ex.measurementType ?? exerciseData?.measurementType,
           };
         }
         return ex;
@@ -872,6 +878,7 @@ export const exportWorkoutAsJson = query({
               setNumber: number;
               weight?: number;
               reps?: number;
+              durationSeconds?: number;
               unit: "kg" | "lb";
               rpe?: number;
               isWarmup?: boolean;
@@ -882,6 +889,7 @@ export const exportWorkoutAsJson = query({
             };
             if (e.lifting.weight !== undefined) set.weight = e.lifting.weight;
             if (e.lifting.reps !== undefined) set.reps = e.lifting.reps;
+            if (e.lifting.durationSeconds !== undefined) set.durationSeconds = e.lifting.durationSeconds;
             if (e.lifting.rpe !== undefined) set.rpe = e.lifting.rpe;
             if (e.lifting.isWarmup) set.isWarmup = true;
             if (e.lifting.isBodyweight) set.isBodyweight = true;

--- a/src/app/routines/[id]/edit/page.tsx
+++ b/src/app/routines/[id]/edit/page.tsx
@@ -113,6 +113,9 @@ function SortableExerciseItem({
 				: `${exercise.targetSets}×${exercise.targetReps}`;
 			return exercise.perSide ? `${base} /side` : base;
 		}
+		if (exercise.measurementType === "duration") {
+			return `${exercise.targetSets}×${exercise.targetHoldSeconds ?? 30}s`;
+		}
 		return `${exercise.targetSets}×${exercise.targetReps}`;
 	};
 	const summary = getSummary();
@@ -183,13 +186,17 @@ export default function EditRoutinePage() {
 	const [showImportDayDialog, setShowImportDayDialog] = useState(false);
 
 	useEffect(() => {
-		if (routine && !isInitialized) {
+		if (routine && exercises && !isInitialized) {
 			setRoutineName(routine.name);
 			setDescription(routine.description || "");
 			const parsedDays = routine.days.map((day) => ({
 				id: crypto.randomUUID(),
 				name: day.name,
 				exercises: day.exercises.map((ex) => {
+					const catalogExercise = exercises.find(
+						(catalogEntry) =>
+							catalogEntry._id === ex.exerciseId || catalogEntry.name === ex.exerciseName
+					);
 					let targetDuration = ex.targetDuration;
 					if (ex.kind === "cardio" && !targetDuration && ex.targetReps) {
 						const match = ex.targetReps.match(/(\d+)/);
@@ -204,6 +211,7 @@ export default function EditRoutinePage() {
 						kind: ex.kind,
 						targetSets: ex.targetSets || 3,
 						targetReps: ex.targetReps || "8-12",
+						measurementType: ex.measurementType ?? catalogExercise?.measurementType,
 						targetDuration: targetDuration || 20,
 						targetHoldSeconds: ex.targetHoldSeconds || 30,
 						perSide: ex.perSide || false,
@@ -217,7 +225,7 @@ export default function EditRoutinePage() {
 			}
 			setIsInitialized(true);
 		}
-	}, [routine, isInitialized]);
+	}, [routine, exercises, isInitialized]);
 
 	const sensors = useSensors(
 		useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
@@ -311,7 +319,8 @@ export default function EditRoutinePage() {
 	const addExerciseToDay = (
 		exerciseName: string,
 		exerciseId?: Id<"exercises">,
-		kind: "lifting" | "cardio" | "mobility" = "lifting"
+		kind: "lifting" | "cardio" | "mobility" = "lifting",
+		measurementType?: "reps" | "duration"
 	) => {
 		if (!activeDayId) return;
 		vibrate("medium");
@@ -321,6 +330,8 @@ export default function EditRoutinePage() {
 			exerciseName,
 			...DEFAULT_EXERCISE,
 			kind,
+			measurementType,
+			targetHoldSeconds: measurementType === "duration" ? 30 : DEFAULT_EXERCISE.targetHoldSeconds,
 		};
 		setDays(
 			days.map((d) =>
@@ -389,12 +400,15 @@ export default function EditRoutinePage() {
 						targetSets:
 							e.kind === "lifting" || e.kind === "mobility" ? e.targetSets : 1,
 						targetReps:
-							e.kind === "lifting" || e.kind === "mobility"
+							(e.kind === "lifting" && e.measurementType !== "duration") || e.kind === "mobility"
 								? e.targetReps
 								: undefined,
+						measurementType: e.kind === "lifting" ? e.measurementType : undefined,
 						targetDuration: e.kind === "cardio" ? e.targetDuration : undefined,
 						targetHoldSeconds:
-							e.kind === "mobility" ? e.targetHoldSeconds : undefined,
+							e.kind === "mobility" || e.measurementType === "duration"
+								? e.targetHoldSeconds
+								: undefined,
 						perSide: e.kind === "mobility" ? e.perSide : undefined,
 					})),
 				})),
@@ -771,7 +785,8 @@ export default function EditRoutinePage() {
 												? "cardio"
 												: exercise.category === "mobility"
 													? "mobility"
-													: "lifting"
+													: "lifting",
+											exercise.measurementType
 										)
 									}
 								>

--- a/src/app/routines/new/ai/page.tsx
+++ b/src/app/routines/new/ai/page.tsx
@@ -190,7 +190,9 @@ export default function AIRoutineGeneratorPage() {
             exerciseName: ex.exerciseName,
             kind: ex.kind,
             targetSets: ex.targetSets,
-            targetReps: ex.targetReps,
+            targetReps: ex.measurementType === "duration" ? undefined : ex.targetReps,
+            measurementType: ex.measurementType,
+            targetHoldSeconds: ex.targetHoldSeconds,
           })),
         })),
       });
@@ -265,7 +267,7 @@ export default function AIRoutineGeneratorPage() {
     }
   };
   
-  const handleSelectAlternative = (newExerciseName: string) => {
+  const handleSelectAlternative = (alternative: RoutineSwapAlternative) => {
     if (!generatedRoutine) return;
     
     vibrate("medium");
@@ -278,14 +280,25 @@ export default function AIRoutineGeneratorPage() {
           ...day,
           exercises: day.exercises.map((ex, ei) => {
             if (ei !== swapSheet.exerciseIndex) return ex;
-            return { ...ex, exerciseName: newExerciseName };
+            return {
+              ...ex,
+              exerciseName: alternative.exercise,
+              measurementType: alternative.measurementType,
+              targetHoldSeconds: alternative.targetHoldSeconds,
+              targetReps:
+                alternative.measurementType === "duration"
+                  ? ""
+                  : ex.measurementType === "duration"
+                    ? "8-12"
+                    : ex.targetReps,
+            };
           }),
         };
       }),
     };
     
     setGeneratedRoutine(updatedRoutine);
-    toast.success(`Swapped to ${newExerciseName}`);
+    toast.success(`Swapped to ${alternative.exercise}`);
     setSwapSheet((prev) => ({ ...prev, open: false }));
   };
   
@@ -612,7 +625,9 @@ export default function AIRoutineGeneratorPage() {
                             </div>
                             <div className="flex items-center gap-2 shrink-0">
                               <Badge variant="outline" className="text-xs font-mono">
-                                {exercise.targetSets} × {exercise.targetReps}
+                                {exercise.targetSets} × {exercise.measurementType === "duration"
+                                  ? `${exercise.targetHoldSeconds ?? 30}s`
+                                  : exercise.targetReps}
                               </Badge>
                               <RefreshCw className="h-3.5 w-3.5 text-muted-foreground" />
                             </div>
@@ -762,7 +777,7 @@ export default function AIRoutineGeneratorPage() {
                           )}
                         </div>
                       </div>
-                      <Button size="sm" onClick={() => handleSelectAlternative(alt.exercise)}>
+                      <Button size="sm" onClick={() => handleSelectAlternative(alt)}>
                         <Check className="h-4 w-4 mr-1.5" />
                         Use
                       </Button>

--- a/src/app/routines/new/page.tsx
+++ b/src/app/routines/new/page.tsx
@@ -65,6 +65,8 @@ type RoutineExercise = {
   kind: "lifting" | "cardio";
   targetSets: number;
   targetReps: string;
+  measurementType?: "reps" | "duration";
+  targetHoldSeconds?: number;
   restSeconds: number;
 };
 
@@ -157,17 +159,36 @@ function SortableExerciseItem({
           />
         </div>
         <div className="flex-1">
-          <Label className="text-xs text-muted-foreground">Reps</Label>
-          <Input
-            value={exercise.targetReps}
-            onChange={(e) =>
-              onUpdate(dayId, exercise.id, {
-                targetReps: e.target.value,
-              })
-            }
-            placeholder="8-12"
-            className="h-8 text-center"
-          />
+          <Label className="text-xs text-muted-foreground">
+            {exercise.measurementType === "duration" ? "Seconds" : "Reps"}
+          </Label>
+          {exercise.measurementType === "duration" ? (
+            <Input
+              type="number"
+              inputMode="numeric"
+              value={exercise.targetHoldSeconds ?? 30}
+              onChange={(e) => {
+                const parsed = Number.parseInt(e.target.value, 10);
+                onUpdate(dayId, exercise.id, {
+                  targetHoldSeconds: Number.isNaN(parsed) ? 1 : Math.max(1, parsed),
+                });
+              }}
+              className="h-8 text-center"
+              min={1}
+              max={3600}
+            />
+          ) : (
+            <Input
+              value={exercise.targetReps}
+              onChange={(e) =>
+                onUpdate(dayId, exercise.id, {
+                  targetReps: e.target.value,
+                })
+              }
+              placeholder="8-12"
+              className="h-8 text-center"
+            />
+          )}
         </div>
         <div className="flex-1">
           <Label className="text-xs text-muted-foreground">Rest (s)</Label>
@@ -331,7 +352,8 @@ export default function NewRoutinePage() {
   const addExerciseToDay = (
     exerciseName: string,
     exerciseId?: Id<"exercises">,
-    kind: "lifting" | "cardio" = "lifting"
+    kind: "lifting" | "cardio" = "lifting",
+    measurementType?: "reps" | "duration"
   ) => {
     if (!activeDayId) return;
 
@@ -342,6 +364,8 @@ export default function NewRoutinePage() {
       exerciseName,
       ...DEFAULT_EXERCISE,
       kind,
+      measurementType,
+      targetHoldSeconds: measurementType === "duration" ? 30 : undefined,
     };
 
     setDays(
@@ -414,7 +438,9 @@ export default function NewRoutinePage() {
             exerciseName: e.exerciseName,
             kind: e.kind,
             targetSets: e.targetSets || 1,
-            targetReps: e.targetReps,
+            targetReps: e.measurementType === "duration" ? undefined : e.targetReps,
+            measurementType: e.measurementType,
+            targetHoldSeconds: e.measurementType === "duration" ? e.targetHoldSeconds : undefined,
           })),
         })),
       });
@@ -692,7 +718,8 @@ export default function NewRoutinePage() {
                     addExerciseToDay(
                       exercise.name,
                       exercise._id,
-                      exercise.category === "cardio" ? "cardio" : "lifting"
+                      exercise.category === "cardio" ? "cardio" : "lifting",
+                      exercise.measurementType
                     )
                   }
                 >

--- a/src/app/workout/[id]/page.tsx
+++ b/src/app/workout/[id]/page.tsx
@@ -42,6 +42,7 @@ type LiftingEntry = {
     setNumber: number;
     reps?: number;
     weight?: number;
+    durationSeconds?: number;
     unit: "kg" | "lb";
     rpe?: number;
     isWarmup?: boolean;
@@ -380,13 +381,21 @@ export default function WorkoutDetailsPage() {
                               )}
                             </span>
                             <div className="flex items-center gap-3">
-                              <span className="font-medium font-mono tabular-nums">
-                                {entry.lifting.weight ?? 0} {entry.lifting.unit}
-                              </span>
-                              <span className="text-muted-foreground">x</span>
-                              <span className="font-medium font-mono tabular-nums">
-                                {entry.lifting.reps ?? 0} reps
-                              </span>
+                              {entry.lifting.durationSeconds !== undefined ? (
+                                <span className="font-medium font-mono tabular-nums">
+                                  {formatCardioDuration(entry.lifting.durationSeconds)} hold
+                                </span>
+                              ) : (
+                                <>
+                                  <span className="font-medium font-mono tabular-nums">
+                                    {entry.lifting.weight ?? 0} {entry.lifting.unit}
+                                  </span>
+                                  <span className="text-muted-foreground">x</span>
+                                  <span className="font-medium font-mono tabular-nums">
+                                    {entry.lifting.reps ?? 0} reps
+                                  </span>
+                                </>
+                              )}
                               {entry.lifting.rpe && (
                                 <Badge variant="secondary" className="text-xs">
                                   RPE {entry.lifting.rpe}

--- a/src/app/workout/active/page.tsx
+++ b/src/app/workout/active/page.tsx
@@ -6,6 +6,10 @@ import { useQuery, useMutation } from "convex/react";
 import { api } from "../../../../convex/_generated/api";
 import { Button } from "@/components/ui/button";
 import { ExerciseAccordion } from "@/components/workout/exercise-accordion";
+import {
+	TimedExerciseAccordion,
+	type TimedSetData,
+} from "@/components/workout/timed-exercise-accordion";
 import { CardioExerciseCard } from "@/components/workout/cardio-exercise-card";
 import { RestTimerOverlay } from "@/components/workout/rest-timer-overlay";
 import {
@@ -42,6 +46,7 @@ type EntryData = {
 		setNumber: number;
 		reps?: number;
 		weight?: number;
+		durationSeconds?: number;
 		unit: "kg" | "lb";
 		isBodyweight?: boolean;
 		rpe?: number;
@@ -91,6 +96,21 @@ function ExerciseAccordionWithHistory({
 	);
 }
 
+function TimedExerciseAccordionWithHistory({
+	exerciseName,
+	...props
+}: Omit<React.ComponentProps<typeof TimedExerciseAccordion>, "lastSession">) {
+	const history = useQuery(api.entries.getTimedExerciseHistory, { exerciseName });
+
+	return (
+		<TimedExerciseAccordion
+			exerciseName={exerciseName}
+			lastSession={history?.[0]}
+			{...props}
+		/>
+	);
+}
+
 type PendingExercise = {
 	name: string;
 	category: "lifting" | "cardio" | "mobility" | "other";
@@ -98,6 +118,8 @@ type PendingExercise = {
 	targetSets?: number;
 	targetReps?: string;
 	targetDurationMinutes?: number;
+	measurementType?: "reps" | "duration";
+	targetHoldSeconds?: number;
 	equipment?: string[];
 	muscleGroups?: string[];
 };
@@ -220,6 +242,7 @@ export default function ActiveWorkoutPage() {
 							name: entry.exerciseName,
 							category: entry.kind === "cardio" ? "cardio" : "lifting",
 							primaryMetric: entry.kind === "cardio" ? "duration" : undefined,
+							measurementType: entry.lifting?.durationSeconds ? "duration" : undefined,
 						},
 					});
 				}
@@ -254,6 +277,8 @@ export default function ActiveWorkoutPage() {
 					targetSets: ex.targetSets,
 					targetReps: ex.targetReps,
 					targetDurationMinutes: ex.targetDuration,
+					measurementType: ex.measurementType,
+					targetHoldSeconds: ex.targetHoldSeconds,
 					equipment: exerciseWithEquipment.equipment,
 				};
 			});
@@ -301,7 +326,13 @@ export default function ActiveWorkoutPage() {
 			return;
 		}
 
-		const liftingEntries = groupEntries.filter((e) => e.kind === "lifting");
+		const liftingEntries = groupEntries.filter(
+			(e) =>
+				e.kind === "lifting" &&
+				(meta.measurementType === "duration"
+					? e.lifting?.durationSeconds !== undefined
+					: e.lifting?.durationSeconds === undefined)
+		);
 		const isComplete =
 			meta.targetSets !== undefined && liftingEntries.length >= meta.targetSets;
 
@@ -383,6 +414,42 @@ export default function ActiveWorkoutPage() {
 		}
 	};
 
+	const handleAddTimedSet = async (
+		exerciseName: string,
+		set: { durationSeconds: number; rpe?: number | null }
+	) => {
+		const group = exerciseGroups.get(exerciseName);
+		const existingSets = group?.entries.filter(
+			(entry) => entry.kind === "lifting" && entry.lifting?.durationSeconds !== undefined
+		) ?? [];
+		const setNumber = existingSets.length + 1;
+
+		try {
+			await addLiftingEntry({
+				workoutId: workout._id,
+				clientId: generateClientId(),
+				exerciseName,
+				lifting: {
+					setNumber,
+					durationSeconds: set.durationSeconds,
+					unit: "lb",
+					rpe: set.rpe ?? undefined,
+				},
+			});
+			posthog.capture("set_logged", {
+				exercise_name: exerciseName,
+				set_number: setNumber,
+				measurement_type: "duration",
+				duration_seconds: set.durationSeconds,
+				rpe: set.rpe ?? null,
+			});
+			setShowRestTimer(true);
+		} catch (error) {
+			posthog.captureException(error);
+			throw error;
+		}
+	};
+
 	const handleLogCardio = async (
 		exerciseName: string,
 		data: {
@@ -440,6 +507,7 @@ export default function ActiveWorkoutPage() {
 						category: exercise.category,
 						muscleGroups: exercise.muscleGroups,
 						primaryMetric: exercise.primaryMetric,
+						measurementType: exercise.measurementType,
 					});
 				} catch (error) {
 					console.error("Failed to create exercise:", error);
@@ -450,7 +518,15 @@ export default function ActiveWorkoutPage() {
 		setShowAddExercise(false);
 	};
 
-	const handleSwapComplete = (oldExercise: string, newExercise: string) => {
+	const handleSwapComplete = (
+		oldExercise: string,
+		selection: {
+			name: string;
+			measurementType: "reps" | "duration";
+			targetHoldSeconds?: number;
+		}
+	) => {
+		const newExercise = selection.name;
 		const isPendingExercise = pendingExercises.some(
 			(p) => p.name === oldExercise
 		);
@@ -458,13 +534,32 @@ export default function ActiveWorkoutPage() {
 		if (isPendingExercise) {
 			setPendingExercises((prev) =>
 				prev.map((p) =>
-					p.name === oldExercise ? { ...p, name: newExercise } : p
+					p.name === oldExercise
+						? {
+								...p,
+								name: newExercise,
+								measurementType: selection.measurementType,
+								targetHoldSeconds:
+									selection.measurementType === "duration"
+										? selection.targetHoldSeconds ?? 30
+										: undefined,
+								targetReps:
+									selection.measurementType === "duration"
+										? undefined
+										: p.targetReps ?? "8-12",
+							}
+						: p
 				)
 			);
 		} else if (!exerciseGroups.has(newExercise)) {
 			setPendingExercises((prev) => [
 				...prev,
-				{ name: newExercise, category: "lifting" as const },
+				{
+					name: newExercise,
+					category: "lifting" as const,
+					measurementType: selection.measurementType,
+					targetHoldSeconds: selection.targetHoldSeconds,
+				},
 			]);
 		}
 		posthog.capture("exercise_swapped", {
@@ -607,23 +702,45 @@ export default function ActiveWorkoutPage() {
 		});
 	};
 
+	const handleEditTimedSet = (exerciseName: string, set: TimedSetData) => {
+		if (!set.entryId) return;
+		setEditingSet({
+			entryId: set.entryId,
+			exerciseName,
+			setNumber: set.setNumber,
+			reps: 0,
+			weight: 0,
+			unit: "lb",
+			durationSeconds: set.durationSeconds,
+			rpe: set.rpe,
+		});
+	};
+
 	const handleUpdateSet = async (
 		entryId: string,
-		data: { reps: number; weight: number; rpe?: number | null }
+		data: { reps?: number; weight?: number; durationSeconds?: number; rpe?: number | null }
 	) => {
 		if (!editingSet) return;
 		try {
 			await updateLiftingEntry({
 				entryId:
 					entryId as unknown as import("../../../../convex/_generated/dataModel").Id<"entries">,
-				lifting: {
-					setNumber: editingSet.setNumber,
-					reps: data.reps,
-					weight: data.weight,
-					unit: editingSet.unit,
-					isBodyweight: editingSet.isBodyweight,
-					rpe: data.rpe ?? undefined,
-				},
+				lifting:
+					data.durationSeconds !== undefined
+						? {
+								setNumber: editingSet.setNumber,
+								durationSeconds: data.durationSeconds,
+								unit: editingSet.unit,
+								rpe: data.rpe ?? undefined,
+							}
+						: {
+								setNumber: editingSet.setNumber,
+								reps: data.reps,
+								weight: data.weight,
+								unit: editingSet.unit,
+								isBodyweight: editingSet.isBodyweight,
+								rpe: data.rpe ?? undefined,
+							},
 			});
 			vibrate("success");
 			toast.success("Set updated");
@@ -785,6 +902,47 @@ export default function ActiveWorkoutPage() {
 							);
 						}
 
+						if (meta.measurementType === "duration") {
+							const timedSets = groupEntries
+								.filter(
+									(entry) =>
+										entry.kind === "lifting" &&
+										entry.lifting?.durationSeconds !== undefined
+								)
+								.map((entry) => ({
+									entryId: entry._id,
+									setNumber: entry.lifting!.setNumber,
+									durationSeconds: entry.lifting!.durationSeconds!,
+									rpe: entry.lifting!.rpe ?? null,
+								}));
+
+							return (
+								<div
+									key={name}
+									ref={(element) => {
+										if (element) exerciseRefs.current.set(name, element);
+									}}
+								>
+									<TimedExerciseAccordionWithHistory
+										exerciseName={name}
+										sets={timedSets}
+										status={getExerciseStatus()}
+										targetSets={meta.targetSets}
+										targetDurationSeconds={meta.targetHoldSeconds}
+										note={getExerciseNote(name)}
+										onAddSet={(set) => handleAddTimedSet(name, set)}
+										onEditSet={(set) => handleEditTimedSet(name, set)}
+										onSwap={() => setSwapExercise(name)}
+										onNoteChange={(note) => handleNoteChange(name, note)}
+										onSelect={() => {
+											setManualNavigation(true);
+											setCurrentExerciseIndex(index);
+										}}
+									/>
+								</div>
+							);
+						}
+
 						const sets = groupEntries
 							.filter((e) => e.kind === "lifting" && e.lifting)
 							.map((e) => ({
@@ -881,8 +1039,8 @@ export default function ActiveWorkoutPage() {
 					onOpenChange={(open) => !open && setSwapExercise(null)}
 					workoutId={workout._id}
 					exerciseName={swapExercise}
-					onSwapComplete={(newExercise) =>
-						handleSwapComplete(swapExercise, newExercise)
+					onSwapComplete={(selection) =>
+						handleSwapComplete(swapExercise, selection)
 					}
 				/>
 			)}

--- a/src/app/workout/active/page.tsx
+++ b/src/app/workout/active/page.tsx
@@ -36,6 +36,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { toast } from "sonner";
 import { calculateProgressionSuggestion } from "@/lib/progression";
 import { convertWeight, type WeightUnit } from "@/lib/units";
+import { getExerciseGroupKey } from "@/lib/workout-exercise-group";
 import posthog from "posthog-js";
 
 type EntryData = {
@@ -124,6 +125,17 @@ type PendingExercise = {
 	muscleGroups?: string[];
 };
 
+function getEntryGroupKey(entry: EntryData) {
+	return getExerciseGroupKey({
+		name: entry.exerciseName,
+		category: entry.kind === "cardio" ? "cardio" : "lifting",
+		measurementType:
+			entry.kind === "lifting" && entry.lifting?.durationSeconds !== undefined
+				? "duration"
+				: "reps",
+	});
+}
+
 function useDuration(startedAt: number | undefined) {
 	const [duration, setDuration] = useState("");
 
@@ -155,7 +167,10 @@ export default function ActiveWorkoutPage() {
 	const [pendingExercises, setPendingExercises] = useState<PendingExercise[]>(
 		[]
 	);
-	const [swapExercise, setSwapExercise] = useState<string | null>(null);
+	const [swapExercise, setSwapExercise] = useState<{
+		groupKey: string;
+		name: string;
+	} | null>(null);
 	const [showSwapFollowUp, setShowSwapFollowUp] = useState(false);
 	const [editingSet, setEditingSet] = useState<EditableSet | null>(null);
 	const [currentExerciseIndex, setCurrentExerciseIndex] = useState(0);
@@ -224,25 +239,29 @@ export default function ActiveWorkoutPage() {
 
 		// First, add all pending exercises to establish stable order and meta (targetSets, targetReps, etc.)
 		for (const pending of pendingExercises) {
-			groups.set(pending.name, { entries: [], meta: pending });
+			groups.set(getExerciseGroupKey(pending), { entries: [], meta: pending });
 		}
 
 		// Then, add entries to their groups (entries may exist for exercises in pendingExercises)
 		if (entries) {
 			for (const entry of entries) {
-				const existing = groups.get(entry.exerciseName);
+				const groupKey = getEntryGroupKey(entry as EntryData);
+				const existing = groups.get(groupKey);
 				if (existing) {
 					existing.entries.push(entry as EntryData);
 				} else {
 					// Entry for an exercise not in pendingExercises (edge case: old data or manual add)
 					// Add at the end to preserve stable ordering of pending exercises
-					groups.set(entry.exerciseName, {
+					groups.set(groupKey, {
 						entries: [entry as EntryData],
 						meta: {
 							name: entry.exerciseName,
 							category: entry.kind === "cardio" ? "cardio" : "lifting",
 							primaryMetric: entry.kind === "cardio" ? "duration" : undefined,
-							measurementType: entry.lifting?.durationSeconds ? "duration" : undefined,
+							measurementType:
+								entry.lifting?.durationSeconds !== undefined
+									? "duration"
+									: undefined,
 						},
 					});
 				}
@@ -350,8 +369,8 @@ export default function ActiveWorkoutPage() {
 		const currentExercise = exerciseList[currentExerciseIndex];
 		if (!currentExercise) return;
 
-		const [name] = currentExercise;
-		const element = exerciseRefs.current.get(name);
+		const [groupKey] = currentExercise;
+		const element = exerciseRefs.current.get(groupKey);
 
 		if (element) {
 			setTimeout(() => {
@@ -380,7 +399,11 @@ export default function ActiveWorkoutPage() {
 			rpe?: number | null;
 		}
 	) => {
-		const group = exerciseGroups.get(exerciseName);
+		const group = exerciseGroups.get(getExerciseGroupKey({
+			name: exerciseName,
+			category: "lifting",
+			measurementType: "reps",
+		}));
 		const existingSets = group?.entries ?? [];
 		const setNumber = existingSets.length + 1;
 
@@ -418,7 +441,11 @@ export default function ActiveWorkoutPage() {
 		exerciseName: string,
 		set: { durationSeconds: number; rpe?: number | null }
 	) => {
-		const group = exerciseGroups.get(exerciseName);
+		const group = exerciseGroups.get(getExerciseGroupKey({
+			name: exerciseName,
+			category: "lifting",
+			measurementType: "duration",
+		}));
 		const existingSets = group?.entries.filter(
 			(entry) => entry.kind === "lifting" && entry.lifting?.durationSeconds !== undefined
 		) ?? [];
@@ -499,7 +526,8 @@ export default function ActiveWorkoutPage() {
 	};
 
 	const handleAddExercise = async (exercise: ExerciseSelection) => {
-		if (!exerciseGroups.has(exercise.name)) {
+		const groupKey = getExerciseGroupKey(exercise);
+		if (!exerciseGroups.has(groupKey)) {
 			if (exercise.muscleGroups && exercise.muscleGroups.length > 0) {
 				try {
 					await createExercise({
@@ -519,7 +547,7 @@ export default function ActiveWorkoutPage() {
 	};
 
 	const handleSwapComplete = (
-		oldExercise: string,
+		oldExercise: { groupKey: string; name: string },
 		selection: {
 			name: string;
 			measurementType: "reps" | "duration";
@@ -528,13 +556,13 @@ export default function ActiveWorkoutPage() {
 	) => {
 		const newExercise = selection.name;
 		const isPendingExercise = pendingExercises.some(
-			(p) => p.name === oldExercise
+			(p) => getExerciseGroupKey(p) === oldExercise.groupKey
 		);
 
 		if (isPendingExercise) {
 			setPendingExercises((prev) =>
 				prev.map((p) =>
-					p.name === oldExercise
+					getExerciseGroupKey(p) === oldExercise.groupKey
 						? {
 								...p,
 								name: newExercise,
@@ -551,7 +579,11 @@ export default function ActiveWorkoutPage() {
 						: p
 				)
 			);
-		} else if (!exerciseGroups.has(newExercise)) {
+		} else if (!exerciseGroups.has(getExerciseGroupKey({
+			name: newExercise,
+			category: "lifting",
+			measurementType: selection.measurementType,
+		}))) {
 			setPendingExercises((prev) => [
 				...prev,
 				{
@@ -563,7 +595,7 @@ export default function ActiveWorkoutPage() {
 			]);
 		}
 		posthog.capture("exercise_swapped", {
-			old_exercise: oldExercise,
+			old_exercise: oldExercise.name,
 			new_exercise: newExercise,
 			workout_id: workout._id,
 		});
@@ -793,12 +825,13 @@ export default function ActiveWorkoutPage() {
 		return { loggedSets, targetSets, totalVolume, unit };
 	})();
 
-	const currentExerciseName = exerciseList[currentExerciseIndex]?.[0];
-	const nextExerciseName = exerciseList[currentExerciseIndex + 1]?.[0];
+	const currentExerciseName = exerciseList[currentExerciseIndex]?.[1].meta.name;
+	const nextExerciseName = exerciseList[currentExerciseIndex + 1]?.[1].meta.name;
 
 	const jumpToCurrentExercise = () => {
-		if (!currentExerciseName) return;
-		const element = exerciseRefs.current.get(currentExerciseName);
+		const currentExerciseKey = exerciseList[currentExerciseIndex]?.[0];
+		if (!currentExerciseKey) return;
+		const element = exerciseRefs.current.get(currentExerciseKey);
 		if (element) {
 			element.scrollIntoView({ behavior: "smooth", block: "center" });
 		}
@@ -858,7 +891,8 @@ export default function ActiveWorkoutPage() {
 
 			<main className="flex-1 space-y-4 p-4">
 				{Array.from(exerciseGroups.entries()).map(
-					([name, { entries: groupEntries, meta }], index) => {
+					([groupKey, { entries: groupEntries, meta }], index) => {
+						const name = meta.name;
 						const getExerciseStatus = ():
 							| "completed"
 							| "current"
@@ -874,9 +908,9 @@ export default function ActiveWorkoutPage() {
 
 							return (
 								<div
-									key={name}
+									key={groupKey}
 									ref={(el) => {
-										if (el) exerciseRefs.current.set(name, el);
+										if (el) exerciseRefs.current.set(groupKey, el);
 									}}
 								>
 									<CardioExerciseCard
@@ -918,9 +952,9 @@ export default function ActiveWorkoutPage() {
 
 							return (
 								<div
-									key={name}
+									key={groupKey}
 									ref={(element) => {
-										if (element) exerciseRefs.current.set(name, element);
+										if (element) exerciseRefs.current.set(groupKey, element);
 									}}
 								>
 									<TimedExerciseAccordionWithHistory
@@ -932,7 +966,7 @@ export default function ActiveWorkoutPage() {
 										note={getExerciseNote(name)}
 										onAddSet={(set) => handleAddTimedSet(name, set)}
 										onEditSet={(set) => handleEditTimedSet(name, set)}
-										onSwap={() => setSwapExercise(name)}
+										onSwap={() => setSwapExercise({ groupKey, name })}
 										onNoteChange={(note) => handleNoteChange(name, note)}
 										onSelect={() => {
 											setManualNavigation(true);
@@ -967,9 +1001,9 @@ export default function ActiveWorkoutPage() {
 
 						return (
 							<div
-								key={name}
+								key={groupKey}
 								ref={(el) => {
-									if (el) exerciseRefs.current.set(name, el);
+									if (el) exerciseRefs.current.set(groupKey, el);
 								}}
 							>
 								<ExerciseAccordionWithHistory
@@ -997,7 +1031,7 @@ export default function ActiveWorkoutPage() {
 										isBodyweight?: boolean;
 										rpe?: number | null;
 									}) => handleEditSet(name, set)}
-									onSwap={() => setSwapExercise(name)}
+									onSwap={() => setSwapExercise({ groupKey, name })}
 									onNoteChange={(note: string) => handleNoteChange(name, note)}
 									onSelect={() => {
 										setManualNavigation(true);
@@ -1038,7 +1072,7 @@ export default function ActiveWorkoutPage() {
 					open={!!swapExercise}
 					onOpenChange={(open) => !open && setSwapExercise(null)}
 					workoutId={workout._id}
-					exerciseName={swapExercise}
+					exerciseName={swapExercise.name}
 					onSwapComplete={(selection) =>
 						handleSwapComplete(swapExercise, selection)
 					}

--- a/src/components/workout/add-exercise-sheet.tsx
+++ b/src/components/workout/add-exercise-sheet.tsx
@@ -21,6 +21,7 @@ export interface ExerciseSelection {
   name: string;
   category: "lifting" | "cardio" | "mobility" | "other";
   primaryMetric?: "duration" | "distance";
+  measurementType?: "reps" | "duration";
   equipment?: string[];
   muscleGroups?: string[];
 }
@@ -41,6 +42,7 @@ export function AddExerciseSheet({
   const [activeTab, setActiveTab] = useState<"lifting" | "cardio">("lifting");
   const [selectedMuscleGroups, setSelectedMuscleGroups] = useState<string[]>([]);
   const [showMuscleGroupPicker, setShowMuscleGroupPicker] = useState(false);
+  const [customMeasurementType, setCustomMeasurementType] = useState<"reps" | "duration">("reps");
   const { vibrate } = useHaptic();
 
   const exercises = useQuery(api.exercises.getExercises, {
@@ -57,6 +59,7 @@ export function AddExerciseSheet({
     setSearchQuery("");
     setSelectedMuscleGroups([]);
     setShowMuscleGroupPicker(false);
+    setCustomMeasurementType("reps");
   };
 
   const toggleMuscleGroup = (muscle: string) => {
@@ -80,6 +83,7 @@ export function AddExerciseSheet({
         name: customExercise.trim(),
         category: activeTab,
         primaryMetric: activeTab === "cardio" ? "duration" : undefined,
+        measurementType: activeTab === "lifting" ? customMeasurementType : undefined,
         muscleGroups: selectedMuscleGroups.length > 0 ? selectedMuscleGroups : undefined,
       });
     }
@@ -142,6 +146,18 @@ export function AddExerciseSheet({
 
             {customExercise.trim() && activeTab === "lifting" && (
               <div className="flex flex-col gap-2">
+				<div className="space-y-2">
+				  <span className="text-sm font-medium">Measure By</span>
+				  <Tabs
+					value={customMeasurementType}
+					onValueChange={(value) => setCustomMeasurementType(value as "reps" | "duration")}
+				  >
+					<TabsList className="grid w-full grid-cols-2">
+					  <TabsTrigger value="reps">Reps</TabsTrigger>
+					  <TabsTrigger value="duration">Time</TabsTrigger>
+					</TabsList>
+				  </Tabs>
+				</div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm font-medium">
                     Muscle Groups {showMuscleGroupPicker && <span className="text-destructive">*</span>}
@@ -197,6 +213,7 @@ export function AddExerciseSheet({
                       name: exercise.name,
                       category: exercise.category,
                       primaryMetric: exercise.primaryMetric,
+                      measurementType: exercise.measurementType,
                       equipment: exercise.equipment,
                       muscleGroups: exercise.muscleGroups,
                     })
@@ -207,6 +224,9 @@ export function AddExerciseSheet({
                     <span className="text-xs text-muted-foreground ml-2 shrink-0">
                       {exercise.primaryMetric === "distance" ? "Distance" : "Time"}
                     </span>
+                  )}
+                  {exercise.category === "lifting" && exercise.measurementType === "duration" && (
+                    <span className="text-xs text-muted-foreground ml-2 shrink-0">Time</span>
                   )}
                 </button>
               ))}

--- a/src/components/workout/edit-exercise-sheet.tsx
+++ b/src/components/workout/edit-exercise-sheet.tsx
@@ -28,6 +28,7 @@ export type RoutineExercise = {
 	kind: "lifting" | "cardio" | "mobility";
 	targetSets: number;
 	targetReps: string;
+	measurementType?: "reps" | "duration";
 	targetDuration?: number;
 	targetHoldSeconds?: number;
 	perSide?: boolean;
@@ -81,6 +82,9 @@ function EditExerciseForm({
 	);
 	const [sets, setSets] = useState(exercise.targetSets);
 	const [reps, setReps] = useState(exercise.targetReps);
+	const [measurementType, setMeasurementType] = useState<"reps" | "duration">(
+		exercise.measurementType ?? "reps"
+	);
 	const [duration, setDuration] = useState(exercise.targetDuration ?? 20);
 	const [holdSeconds, setHoldSeconds] = useState(
 		exercise.targetHoldSeconds ?? 30
@@ -130,6 +134,7 @@ function EditExerciseForm({
 						id: exerciseId,
 						muscleGroups,
 						name,
+						measurementType,
 					});
 				} catch (error) {
 					toast.error("Failed to update exercise");
@@ -142,6 +147,7 @@ function EditExerciseForm({
 						name,
 						category: kind,
 						muscleGroups,
+						measurementType,
 					});
 				} catch (error) {
 					toast.error("Failed to create exercise");
@@ -158,6 +164,7 @@ function EditExerciseForm({
 			kind,
 			targetSets: sets,
 			targetReps: reps,
+			measurementType: kind === "lifting" ? measurementType : undefined,
 			targetDuration: duration,
 			targetHoldSeconds: holdSeconds,
 			perSide,
@@ -185,7 +192,7 @@ function EditExerciseForm({
 			<DrawerHeader>
 				<DrawerTitle>Edit Exercise</DrawerTitle>
 				<DrawerDescription>
-					Configure sets, reps, and rest time
+					Configure how this exercise is measured and logged
 				</DrawerDescription>
 			</DrawerHeader>
 
@@ -228,6 +235,18 @@ function EditExerciseForm({
 
 				{kind === "lifting" ? (
 					<>
+						<div className="space-y-3">
+							<Label>Measure By</Label>
+							<Tabs
+								value={measurementType}
+								onValueChange={(value) => setMeasurementType(value as "reps" | "duration")}
+							>
+								<TabsList className="grid h-12 w-full grid-cols-2">
+									<TabsTrigger value="reps" className="h-10">Reps</TabsTrigger>
+									<TabsTrigger value="duration" className="h-10">Time</TabsTrigger>
+								</TabsList>
+							</Tabs>
+						</div>
 						<div className="space-y-3">
 							<Label>
 								Muscle Groups
@@ -305,6 +324,7 @@ function EditExerciseForm({
 							</div>
 						</div>
 
+						{measurementType === "reps" ? (
 						<div className="space-y-3">
 							<Label>Reps</Label>
 							<div className="grid grid-cols-4 gap-2">
@@ -338,6 +358,35 @@ function EditExerciseForm({
 								className="h-12 text-center font-mono"
 							/>
 						</div>
+						) : (
+							<div className="space-y-4">
+								<div className="flex items-center justify-between">
+									<Label>Hold Duration</Label>
+									<span className="text-2xl font-mono font-bold tabular-nums">
+										{holdSeconds}s
+									</span>
+								</div>
+								<div className="grid grid-cols-4 gap-2">
+									{[15, 30, 45, 60].map((preset) => (
+										<Button
+											key={preset}
+											variant={holdSeconds === preset ? "default" : "outline"}
+											className="h-12 font-mono"
+											onClick={() => setHoldSeconds(preset)}
+										>
+											{preset}s
+										</Button>
+									))}
+								</div>
+								<Slider
+									value={[holdSeconds]}
+									onValueChange={([value]) => setHoldSeconds(value)}
+									min={5}
+									max={300}
+									step={5}
+								/>
+							</div>
+						)}
 
 						<div className="space-y-4">
 							<div className="flex items-center justify-between">

--- a/src/components/workout/edit-set-sheet.tsx
+++ b/src/components/workout/edit-set-sheet.tsx
@@ -20,6 +20,7 @@ export interface EditableSet {
   setNumber: number;
   reps: number;
   weight: number;
+  durationSeconds?: number;
   unit: "lb" | "kg";
   isBodyweight?: boolean;
   rpe?: number | null;
@@ -28,7 +29,7 @@ export interface EditableSet {
 interface EditSetSheetProps {
   set: EditableSet | null;
   onOpenChange: (open: boolean) => void;
-  onSave: (entryId: string, data: { reps: number; weight: number; rpe?: number | null }) => void;
+  onSave: (entryId: string, data: { reps?: number; weight?: number; durationSeconds?: number; rpe?: number | null }) => void;
   onDelete: (entryId: string) => void;
 }
 
@@ -40,15 +41,21 @@ function EditSetContent({
 }: {
   set: EditableSet;
   onOpenChange: (open: boolean) => void;
-  onSave: (entryId: string, data: { reps: number; weight: number; rpe?: number | null }) => void;
+  onSave: (entryId: string, data: { reps?: number; weight?: number; durationSeconds?: number; rpe?: number | null }) => void;
   onDelete: (entryId: string) => void;
 }) {
   const [weight, setWeight] = useState(set.weight);
   const [reps, setReps] = useState(set.reps);
+  const [durationSeconds, setDurationSeconds] = useState(set.durationSeconds ?? 30);
   const [rpe, setRpe] = useState<number | null>(set.rpe ?? null);
 
   const handleSave = () => {
-    onSave(set.entryId, { reps, weight, rpe });
+    onSave(
+      set.entryId,
+      set.durationSeconds !== undefined
+        ? { durationSeconds, rpe }
+        : { reps, weight, rpe }
+    );
     onOpenChange(false);
   };
 
@@ -58,6 +65,9 @@ function EditSetContent({
   };
 
   const formatSetDisplay = () => {
+    if (set.durationSeconds !== undefined) {
+      return `${durationSeconds} seconds`;
+    }
     if (set.isBodyweight && weight === 0) {
       return `BW × ${reps}`;
     }
@@ -78,6 +88,18 @@ function EditSetContent({
 
       <div className="flex-1 px-4 py-6">
         <div className="flex flex-wrap items-end justify-center gap-6">
+          {set.durationSeconds !== undefined ? (
+            <SetStepper
+              label="Duration"
+              value={durationSeconds}
+              onChange={setDurationSeconds}
+              step={5}
+              min={1}
+              max={3600}
+              unit="seconds"
+            />
+          ) : (
+            <>
           {(!set.isBodyweight || weight > 0) && (
             <SetStepper
               label={set.isBodyweight ? "Added Weight" : "Weight"}
@@ -96,6 +118,8 @@ function EditSetContent({
             min={1}
             max={100}
           />
+            </>
+          )}
         </div>
 
         <div className="mt-6">

--- a/src/components/workout/routine-detail-sheet.tsx
+++ b/src/components/workout/routine-detail-sheet.tsx
@@ -37,6 +37,8 @@ export type RoutineForDetail = {
       exerciseName: string;
       targetSets?: number;
       targetReps?: string;
+      measurementType?: "reps" | "duration";
+      targetHoldSeconds?: number;
     }>;
   }>;
 };
@@ -151,7 +153,9 @@ export function RoutineDetailSheet({ routine, onOpenChange }: RoutineDetailSheet
                           </span>
                           {ex.targetSets && (
                             <span className="text-xs text-muted-foreground font-mono tabular-nums ml-2">
-                              {ex.targetSets}×{ex.targetReps || "?"}
+                              {ex.targetSets}×{ex.measurementType === "duration"
+                                ? `${ex.targetHoldSeconds ?? 30}s`
+                                : ex.targetReps || "?"}
                             </span>
                           )}
                         </div>

--- a/src/components/workout/smart-swap-sheet.tsx
+++ b/src/components/workout/smart-swap-sheet.tsx
@@ -38,7 +38,11 @@ interface SmartSwapSheetProps {
 	onOpenChange: (open: boolean) => void;
 	workoutId: Id<"workouts">;
 	exerciseName: string;
-	onSwapComplete: (newExerciseName: string) => void;
+	onSwapComplete: (selection: {
+		name: string;
+		measurementType: "reps" | "duration";
+		targetHoldSeconds?: number;
+	}) => void;
 }
 
 const SWAP_REASONS: Array<{
@@ -93,6 +97,8 @@ export function SmartSwapSheet({
 			equipmentNeeded: string[];
 			muscleEmphasis: string;
 			difficultyAdjustment?: "easier" | "similar" | "harder";
+			measurementType?: "reps" | "duration";
+			targetHoldSeconds?: number;
 		}>
 	>([]);
 	const [swapId, setSwapId] = useState<Id<"exerciseSwaps"> | null>(null);
@@ -123,17 +129,21 @@ export function SmartSwapSheet({
 		}
 	};
 
-	const handleSelectAlternative = async (alternativeExercise: string) => {
+	const handleSelectAlternative = async (alternative: (typeof alternatives)[number]) => {
 		if (swapId) {
 			try {
-				await confirmSwap({ swapId, selectedExercise: alternativeExercise });
+				await confirmSwap({ swapId, selectedExercise: alternative.exercise });
 			} catch (error) {
 				console.error("Failed to confirm swap:", error);
 			}
 		}
 
-		toast.success(`Swapped to ${alternativeExercise}`);
-		onSwapComplete(alternativeExercise);
+		toast.success(`Swapped to ${alternative.exercise}`);
+		onSwapComplete({
+			name: alternative.exercise,
+			measurementType: alternative.measurementType ?? "reps",
+			targetHoldSeconds: alternative.targetHoldSeconds,
+		});
 		handleClose();
 	};
 
@@ -275,7 +285,7 @@ export function SmartSwapSheet({
 										</div>
 										<Button
 											size="sm"
-											onClick={() => handleSelectAlternative(alt.exercise)}
+											onClick={() => handleSelectAlternative(alt)}
 										>
 											<Check className="h-4 w-4 mr-1.5" />
 											Use

--- a/src/components/workout/timed-exercise-accordion.tsx
+++ b/src/components/workout/timed-exercise-accordion.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useState } from "react";
+import { Check, MessageSquare, Shuffle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { NoteSheet } from "./note-sheet";
+import { RpeSelector } from "./rpe-selector";
+import { useHaptic } from "@/hooks/use-haptic";
+import { cn } from "@/lib/utils";
+
+type ExerciseStatus = "completed" | "current" | "upcoming";
+
+export interface TimedSetData {
+	entryId?: string;
+	setNumber: number;
+	durationSeconds: number;
+	rpe?: number | null;
+}
+
+interface TimedExerciseAccordionProps {
+	exerciseName: string;
+	sets: TimedSetData[];
+	status: ExerciseStatus;
+	targetSets?: number;
+	targetDurationSeconds?: number;
+	lastSession?: {
+		date: string;
+		sets: Array<{ durationSeconds: number }>;
+	};
+	note?: string;
+	onAddSet: (set: { durationSeconds: number; rpe?: number | null }) => Promise<void>;
+	onEditSet?: (set: TimedSetData) => void;
+	onSwap?: () => void;
+	onNoteChange?: (note: string) => void;
+	onSelect?: () => void;
+}
+
+function formatDuration(seconds: number): string {
+	if (seconds < 60) return `${seconds}s`;
+	const minutes = Math.floor(seconds / 60);
+	const remainingSeconds = seconds % 60;
+	return remainingSeconds > 0 ? `${minutes}m ${remainingSeconds}s` : `${minutes}m`;
+}
+
+function formatHistoryDate(dateString: string): string {
+	return new Date(dateString).toLocaleDateString(undefined, {
+		month: "short",
+		day: "numeric",
+	});
+}
+
+export function TimedExerciseAccordion({
+	exerciseName,
+	sets,
+	status,
+	targetSets,
+	targetDurationSeconds = 30,
+	lastSession,
+	note,
+	onAddSet,
+	onEditSet,
+	onSwap,
+	onNoteChange,
+	onSelect,
+}: TimedExerciseAccordionProps) {
+	const { vibrate } = useHaptic();
+	const [durationSeconds, setDurationSeconds] = useState(
+		sets.at(-1)?.durationSeconds ?? targetDurationSeconds
+	);
+	const [rpe, setRpe] = useState<number | null>(null);
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [showNoteSheet, setShowNoteSheet] = useState(false);
+
+	const loggedCount = sets.length;
+	const isComplete = targetSets !== undefined && loggedCount >= targetSets;
+	const isExpanded = status === "current";
+
+	const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		if (!Number.isFinite(durationSeconds) || durationSeconds < 1) {
+			setError("Enter a duration of at least 1 second.");
+			return;
+		}
+
+		setError(null);
+		setIsSubmitting(true);
+		try {
+			await onAddSet({ durationSeconds, rpe });
+			setRpe(null);
+			vibrate("success");
+		} catch {
+			setError("This set could not be saved. Try again.");
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
+
+	return (
+		<div
+			className={cn(
+				"rounded-lg border transition-all duration-300 ease-out",
+				status === "current" && "border-primary/30 bg-card shadow-lg ring-1 ring-primary/10",
+				status === "completed" && "border-transparent bg-muted/20",
+				status === "upcoming" && "border-muted/50 bg-card/50 opacity-70"
+			)}
+		>
+			<div className="flex items-center gap-3 p-4">
+				<button
+					type="button"
+					onClick={status === "current" ? undefined : onSelect}
+					disabled={status === "current" || !onSelect}
+					className="flex min-h-12 min-w-0 flex-1 items-center gap-3 rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+				>
+					<span
+						className={cn(
+							"flex h-6 w-6 shrink-0 items-center justify-center rounded font-mono text-xs font-bold",
+							status === "current" && "bg-primary text-primary-foreground",
+							status === "completed" && "bg-primary/20 text-primary",
+							status === "upcoming" && "bg-muted text-muted-foreground"
+						)}
+					>
+						{status === "completed" ? <Check className="h-3.5 w-3.5" /> : loggedCount}
+					</span>
+					<span className="min-w-0 flex-1">
+						<span className="block truncate font-semibold">{exerciseName}</span>
+						<span className="block text-xs text-muted-foreground">
+							Timed hold · {formatDuration(targetDurationSeconds)} target
+						</span>
+					</span>
+					<span className="shrink-0 font-mono text-sm tabular-nums text-muted-foreground">
+						{targetSets === undefined ? loggedCount : `${loggedCount}/${targetSets}`}
+					</span>
+				</button>
+
+				{isExpanded && onSwap && (
+					<Button variant="ghost" size="icon" className="h-10 w-10" onClick={onSwap}>
+						<Shuffle className="h-4 w-4" />
+						<span className="sr-only">Swap exercise</span>
+					</Button>
+				)}
+				{isExpanded && onNoteChange && (
+					<Button variant="ghost" size="icon" className="h-10 w-10" onClick={() => setShowNoteSheet(true)}>
+						<MessageSquare className={cn("h-4 w-4", note && "fill-primary text-primary")} />
+						<span className="sr-only">Add note</span>
+					</Button>
+				)}
+			</div>
+
+			{isExpanded && (
+				<form onSubmit={handleSubmit} className="space-y-4 px-4 pb-4">
+					{lastSession && (
+						<p className="rounded border border-dashed border-muted-foreground/30 bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
+							Last {formatHistoryDate(lastSession.date)}: {lastSession.sets.map((set) => formatDuration(set.durationSeconds)).join(", ")}
+						</p>
+					)}
+
+					{sets.length > 0 && (
+						<div className="space-y-1" aria-label="Logged timed sets">
+							{sets.map((set) => (
+								<button
+									key={set.setNumber}
+									type="button"
+									onClick={() => onEditSet?.(set)}
+									disabled={!onEditSet || !set.entryId}
+									className="flex min-h-11 w-full items-center justify-between rounded border border-transparent bg-muted/40 px-3 text-sm enabled:hover:border-border enabled:hover:bg-muted"
+								>
+									<span className="text-muted-foreground">Set {set.setNumber}</span>
+									<span className="font-mono font-medium tabular-nums">{formatDuration(set.durationSeconds)}</span>
+									<Check className="h-4 w-4 text-primary" />
+								</button>
+							))}
+						</div>
+					)}
+
+					<div className="space-y-2">
+						<Label htmlFor={`duration-${exerciseName}`}>Duration (seconds)</Label>
+						<Input
+							id={`duration-${exerciseName}`}
+							name="durationSeconds"
+							type="number"
+							inputMode="numeric"
+							enterKeyHint="done"
+							min={1}
+							max={3600}
+							required
+							value={durationSeconds}
+							onChange={(event) => {
+								setError(null);
+								setDurationSeconds(Number(event.target.value));
+							}}
+							aria-describedby={error ? `duration-error-${exerciseName}` : undefined}
+							className="h-12 text-center font-mono text-lg"
+						/>
+					</div>
+
+					<RpeSelector value={rpe} onChange={setRpe} />
+
+					{error && (
+						<p id={`duration-error-${exerciseName}`} role="alert" className="text-sm text-destructive">
+							{error}
+						</p>
+					)}
+
+					<Button type="submit" size="lg" className="h-12 w-full" disabled={isComplete || isSubmitting}>
+						{isComplete
+							? "COMPLETE"
+							: isSubmitting
+								? "SAVING…"
+								: targetSets === undefined
+									? `LOG SET ${loggedCount + 1}`
+									: `LOG SET ${loggedCount + 1}/${targetSets}`}
+					</Button>
+				</form>
+			)}
+
+			{onNoteChange && (
+				<NoteSheet
+					open={showNoteSheet}
+					onOpenChange={setShowNoteSheet}
+					exerciseName={exerciseName}
+					note={note ?? ""}
+					onSave={onNoteChange}
+				/>
+			)}
+		</div>
+	);
+}

--- a/src/lib/workout-exercise-group.test.ts
+++ b/src/lib/workout-exercise-group.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { getExerciseGroupKey } from "./workout-exercise-group";
+
+describe("getExerciseGroupKey", () => {
+	test("separates rep and timed lifting rows with the same name", () => {
+		const repKey = getExerciseGroupKey({
+			name: "Plank",
+			category: "lifting",
+			measurementType: "reps",
+		});
+		const durationKey = getExerciseGroupKey({
+			name: "Plank",
+			category: "lifting",
+			measurementType: "duration",
+		});
+
+		assert.notEqual(repKey, durationKey);
+	});
+
+	test("keeps the missing measurement type backward compatible with reps", () => {
+		assert.equal(
+			getExerciseGroupKey({ name: "Squat", category: "lifting" }),
+			getExerciseGroupKey({
+				name: "Squat",
+				category: "lifting",
+				measurementType: "reps",
+			})
+		);
+	});
+});

--- a/src/lib/workout-exercise-group.ts
+++ b/src/lib/workout-exercise-group.ts
@@ -1,0 +1,14 @@
+export type ExerciseGroupDescriptor = {
+	name: string;
+	category: "lifting" | "cardio" | "mobility" | "other";
+	measurementType?: "reps" | "duration";
+};
+
+export function getExerciseGroupKey(exercise: ExerciseGroupDescriptor) {
+	const category = exercise.category === "cardio" ? "cardio" : "lifting";
+	const measurementType =
+		category === "lifting" && exercise.measurementType === "duration"
+			? "duration"
+			: "reps";
+	return JSON.stringify([exercise.name, category, measurementType]);
+}


### PR DESCRIPTION
## What does this PR do?

Fixes production feedback that timed strength exercises such as Plank can only be logged as meaningless reps and weight.

### Implementation

- Adds an optional `measurementType` (`reps` or `duration`) to exercise catalog and routine exercise records.
- Adds optional `durationSeconds` to lifting entries and validates that a set uses either positive reps or a positive duration, never both.
- Marks the built-in Plank as duration-based and carries measurement metadata through manual routines, routine editing, AI generation/swaps, Smart Swap, JSON import/export, and save-workout-as-routine flows.
- Adds an accessible timed-set logger with a visible seconds label, native numeric constraints, pending state, error announcement, RPE, notes, set editing/deletion, and previous-session duration history.
- Displays timed holds meaningfully in completed workout history and routine summaries.
- Excludes timed entries from rep/weight progression history and Smart Swap's rep-based recent-session context. Timed holds still count as strength sets and can contribute RPE to set-based training load, but omit reps/weight and therefore add no weight volume or PR data.

### Compatibility and deployment notes

- All new schema fields are optional. Existing exercise, routine, and lifting-entry documents continue to validate and default to rep-based behavior when `measurementType` is absent.
- Existing rep/weight records continue to parse, display, export, and feed progression unchanged.
- Duration entries remain `kind: "lifting"` so existing set-count and muscle-group analytics retain their meaning; `durationSeconds` is stored as a positive integer-like number while reps and weight are omitted.
- The existing required lifting `unit` field is retained for wire/schema compatibility but is not displayed or used for duration calculations.
- After deploying the schema/code, run the existing `exercises:updateSystemExercises` Convex mutation in the intended environment to backfill `measurementType: "duration"` onto the existing system Plank record. This PR does not mutate production data.
- This intentionally does not introduce Temporal or time-zone logic. Exercise holds are elapsed durations stored in seconds; calendar/week-boundary work belongs to the separate weekly analytics fix.

## Related issue

N/A

## How to test

Automated/static verification completed:

1. `bunx tsc --noEmit` — passes.
2. `bun run lint` — passes with 0 errors and 7 pre-existing warnings in generated/demo files.
3. `bun run build` — passes; all 23 static pages generated.
4. `git diff --check` — passes.

Manual verification after deploying to a development Convex environment:

1. Run `bunx convex run exercises:updateSystemExercises` and confirm Plank has `measurementType: "duration"`.
2. Add Plank to a routine. Confirm the routine editor defaults to **Time**, accepts a seconds target, and the routine summary shows sets × seconds.
3. Start that routine. Confirm Plank shows a labeled **Duration (seconds)** input instead of weight/reps, logs a timed set, prevents double submission while saving, and allows editing/deleting the logged duration.
4. Complete the workout and confirm history shows a timed hold (for example `0:30 hold`) rather than `0 lb × 0 reps`.
5. Start a legacy Bench Press routine and confirm its rep/weight logger, previous-session suggestion, volume, and completed history remain unchanged.
6. Export a workout with timed holds and re-import/save it as a routine; confirm duration measurement and target seconds are preserved.
7. Swap between a timed hold and a rep-based exercise and confirm the logger changes measurement mode with the selected alternative.

## Checklist

- [x] I've tested this locally
- [x] `bun run lint` passes
- [x] I've updated docs if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/house-of-giants/codesmith/opentrainer/pr/44"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787254200&installation_model_id=19704&pr_number=44&repository=house-of-giants%2Fopentrainer&return_to=https%3A%2F%2Fgithub.com%2Fhouse-of-giants%2Fopentrainer%2Fpull%2F44&signature=99de56139144823de83c06fb76a3a020cb02f6aa42a621060fcb85ecc6904b63"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->