### PR TITLE
fix(workouts): honor preferred weight units

### DIFF
--- a/src/app/workout/[id]/page.tsx
+++ b/src/app/workout/[id]/page.tsx
@@ -33,6 +33,11 @@ import { ExportWorkoutDialog } from "@/components/workout/export-workout-dialog"
 import { WorkoutTimeEditorDialog } from "@/components/workout/workout-time-editor-dialog";
 import { toast } from "sonner";
 import posthog from "posthog-js";
+import {
+  calculateVolumeInUnit,
+  displayWeight,
+  type WeightUnit,
+} from "@/lib/units";
 
 type LiftingEntry = {
   _id: string;
@@ -58,6 +63,8 @@ type CardioEntry = {
     mode: "steady" | "intervals";
     durationSeconds: number;
     intensity?: number;
+    vestWeight?: number;
+    vestWeightUnit?: "kg" | "lb";
   };
   createdAt: number;
 };
@@ -84,6 +91,7 @@ export default function WorkoutDetailsPage() {
   const updateWorkoutTimes = useMutation(api.workouts.updateWorkoutTimes);
   const deleteWorkout = useMutation(api.workouts.deleteWorkout);
   const isPro = user?.tier === "pro";
+  const preferredUnit: WeightUnit = user?.preferredUnits ?? "lb";
 
   const formatDate = (timestamp: number) => {
     return new Date(timestamp).toLocaleDateString("en-US", {
@@ -148,7 +156,7 @@ export default function WorkoutDetailsPage() {
     }));
   };
 
-  if (workout === undefined) {
+  if (workout === undefined || user === undefined) {
     return (
       <div className="flex min-h-screen flex-col">
         <header className="sticky top-0 z-40 border-b bg-background/95 backdrop-blur">
@@ -185,6 +193,14 @@ export default function WorkoutDetailsPage() {
   }
 
   const groupedExercises = groupEntriesByExercise(workout.entries as Entry[]);
+  const displayedVolume = calculateVolumeInUnit(
+    (workout.entries as Entry[]).flatMap((entry) =>
+      entry.kind === "lifting" && entry.lifting.durationSeconds === undefined
+        ? [entry.lifting]
+        : []
+    ),
+    preferredUnit
+  );
   const editableCompletedAt =
     workout.completedAt ??
     workout.startedAt + Math.max(workout.summary?.totalDurationMinutes ?? 60, 1) * 60000;
@@ -306,13 +322,13 @@ export default function WorkoutDetailsPage() {
               </div>
             )}
             {(() => {
-              const volume = workout.summary?.totalVolume;
+              const volume = displayedVolume;
               return volume && volume > 0 ? (
                 <div>
                   <p className="text-muted-foreground">Volume</p>
                   <p className="font-medium font-mono tabular-nums flex items-center gap-1">
                     <Weight className="h-4 w-4" />
-                    {volume.toLocaleString()} lb
+                    {Math.round(volume).toLocaleString()} {preferredUnit}
                   </p>
                 </div>
               ) : null;
@@ -388,7 +404,11 @@ export default function WorkoutDetailsPage() {
                               ) : (
                                 <>
                                   <span className="font-medium font-mono tabular-nums">
-                                    {entry.lifting.weight ?? 0} {entry.lifting.unit}
+                                    {displayWeight(
+                                      entry.lifting.weight ?? 0,
+                                      entry.lifting.unit,
+                                      preferredUnit
+                                    )} {preferredUnit}
                                   </span>
                                   <span className="text-muted-foreground">x</span>
                                   <span className="font-medium font-mono tabular-nums">
@@ -423,6 +443,15 @@ export default function WorkoutDetailsPage() {
                                 <Badge variant="secondary" className="text-xs">
                                   Level {entry.cardio.intensity}
                                 </Badge>
+                              )}
+                              {entry.cardio.vestWeight !== undefined && (
+                                <span className="font-medium font-mono tabular-nums">
+                                  Vest {displayWeight(
+                                    entry.cardio.vestWeight,
+                                    entry.cardio.vestWeightUnit ?? "lb",
+                                    preferredUnit
+                                  )} {preferredUnit}
+                                </span>
                               )}
                             </div>
                           </div>

--- a/src/app/workout/active/page.tsx
+++ b/src/app/workout/active/page.tsx
@@ -35,7 +35,12 @@ import { useHaptic } from "@/hooks/use-haptic";
 import { Skeleton } from "@/components/ui/skeleton";
 import { toast } from "sonner";
 import { calculateProgressionSuggestion } from "@/lib/progression";
-import { convertWeight, type WeightUnit } from "@/lib/units";
+import {
+	calculateVolumeInUnit,
+	displayWeight,
+	editedWeightForStorage,
+	type WeightUnit,
+} from "@/lib/units";
 import posthog from "posthog-js";
 
 type EntryData = {
@@ -75,13 +80,8 @@ function ExerciseAccordionWithHistory({
 
 	const ghostData = useMemo(() => {
 		if (!history || history.length === 0) return null;
-		return calculateProgressionSuggestion(history, targetReps);
-	}, [history, targetReps]);
-
-	const resolvedUnit =
-		sets.length > 0
-			? sets[sets.length - 1].unit
-			: ghostData?.lastSession.unit ?? unit;
+		return calculateProgressionSuggestion(history, targetReps, unit);
+	}, [history, targetReps, unit]);
 
 	return (
 		<ExerciseAccordion
@@ -90,7 +90,7 @@ function ExerciseAccordionWithHistory({
 			sets={sets}
 			lastSession={ghostData?.lastSession}
 			progressionSuggestion={ghostData?.suggestion}
-			unit={resolvedUnit}
+			unit={unit}
 			{...rest}
 		/>
 	);
@@ -171,6 +171,8 @@ export default function ActiveWorkoutPage() {
 	const exerciseRefs = useRef<Map<string, HTMLDivElement>>(new Map());
 
 	const workout = useQuery(api.workouts.getActiveWorkout);
+	const user = useQuery(api.users.getCurrentUser);
+	const preferredUnit: WeightUnit = user?.preferredUnits ?? "lb";
 	const entries = useQuery(
 		api.entries.getEntriesByWorkout,
 		workout ? { workoutId: workout._id } : "skip"
@@ -360,7 +362,7 @@ export default function ActiveWorkoutPage() {
 		}
 	}, [currentExerciseIndex, exerciseList]);
 
-	if (workout === undefined || workout === null) {
+	if (workout === undefined || workout === null || user === undefined) {
 		return (
 			<div className="flex min-h-screen flex-col p-4">
 				<Skeleton className="mb-4 h-8 w-48" />
@@ -393,7 +395,7 @@ export default function ActiveWorkoutPage() {
 					setNumber,
 					reps: set.reps,
 					weight: set.weight,
-					unit: set.unit,
+					unit: preferredUnit,
 					isBodyweight: set.isBodyweight,
 					rpe: set.rpe ?? undefined,
 				},
@@ -403,7 +405,7 @@ export default function ActiveWorkoutPage() {
 				set_number: setNumber,
 				reps: set.reps,
 				weight: set.weight,
-				unit: set.unit,
+				unit: preferredUnit,
 				is_bodyweight: set.isBodyweight ?? false,
 				rpe: set.rpe ?? null,
 			});
@@ -690,6 +692,9 @@ export default function ActiveWorkoutPage() {
 		}
 	) => {
 		if (!set.entryId) return;
+		const storedSet = exerciseGroups
+			.get(exerciseName)
+			?.entries.find((entry) => entry._id === set.entryId)?.lifting;
 		setEditingSet({
 			entryId: set.entryId,
 			exerciseName,
@@ -697,6 +702,8 @@ export default function ActiveWorkoutPage() {
 			reps: set.reps,
 			weight: set.weight,
 			unit: set.unit,
+			storedWeight: storedSet?.weight,
+			storedUnit: storedSet?.unit,
 			isBodyweight: set.isBodyweight,
 			rpe: set.rpe,
 		});
@@ -736,8 +743,18 @@ export default function ActiveWorkoutPage() {
 						: {
 								setNumber: editingSet.setNumber,
 								reps: data.reps,
-								weight: data.weight,
-								unit: editingSet.unit,
+								weight:
+									data.weight === undefined
+										? undefined
+										: editedWeightForStorage({
+												displayedWeight: data.weight,
+												displayUnit: editingSet.unit,
+												storedUnit:
+													editingSet.storedUnit ?? editingSet.unit,
+												originalDisplayedWeight: editingSet.weight,
+												originalStoredWeight: editingSet.storedWeight,
+											}),
+								unit: editingSet.storedUnit ?? editingSet.unit,
 								isBodyweight: editingSet.isBodyweight,
 								rpe: data.rpe ?? undefined,
 							},
@@ -768,8 +785,6 @@ export default function ActiveWorkoutPage() {
 		let loggedSets = 0;
 		let targetSets = 0;
 		let totalVolume = 0;
-		// Normalize all lifting volume to lb so mixed-unit workouts sum correctly.
-		const unit: WeightUnit = "lb";
 
 		for (const [, { entries: groupEntries, meta }] of exerciseGroups) {
 			if (meta.category === "cardio") {
@@ -782,15 +797,15 @@ export default function ActiveWorkoutPage() {
 			loggedSets += liftingEntries.length;
 			targetSets += meta.targetSets ?? Math.max(liftingEntries.length, 1);
 
-			for (const entry of liftingEntries) {
-				if (!entry.lifting) continue;
-				const weight = entry.lifting.weight ?? 0;
-				const weightLb = convertWeight(weight, entry.lifting.unit ?? unit, unit);
-				totalVolume += weightLb * (entry.lifting.reps ?? 0);
-			}
+			totalVolume += calculateVolumeInUnit(
+				liftingEntries.flatMap((entry) =>
+					entry.lifting ? [entry.lifting] : []
+				),
+				preferredUnit
+			);
 		}
 
-		return { loggedSets, targetSets, totalVolume, unit };
+		return { loggedSets, targetSets, totalVolume, unit: preferredUnit };
 	})();
 
 	const currentExerciseName = exerciseList[currentExerciseIndex]?.[0];
@@ -882,6 +897,7 @@ export default function ActiveWorkoutPage() {
 									<CardioExerciseCard
 										exerciseName={name}
 										primaryMetric={meta.primaryMetric ?? "duration"}
+										unit={preferredUnit}
 										status={status}
 										defaultMinutes={meta.targetDurationMinutes}
 										note={getExerciseNote(name)}
@@ -945,15 +961,22 @@ export default function ActiveWorkoutPage() {
 
 						const sets = groupEntries
 							.filter((e) => e.kind === "lifting" && e.lifting)
-							.map((e) => ({
-								entryId: e._id,
-								setNumber: e.lifting!.setNumber,
-								reps: e.lifting!.reps ?? 0,
-								weight: e.lifting!.weight ?? 0,
-								unit: (e.lifting!.unit ?? "lb") as "lb" | "kg",
-								isBodyweight: e.lifting!.isBodyweight,
-								rpe: e.lifting!.rpe ?? null,
-							}));
+							.map((e) => {
+								const sourceUnit = e.lifting!.unit ?? "lb";
+								return {
+									entryId: e._id,
+									setNumber: e.lifting!.setNumber,
+									reps: e.lifting!.reps ?? 0,
+									weight: displayWeight(
+										e.lifting!.weight ?? 0,
+										sourceUnit,
+										preferredUnit
+									),
+									unit: preferredUnit,
+									isBodyweight: e.lifting!.isBodyweight,
+									rpe: e.lifting!.rpe ?? null,
+								};
+							});
 
 						const parseTargetReps = (
 							targetReps?: string
@@ -976,6 +999,7 @@ export default function ActiveWorkoutPage() {
 									exerciseName={name}
 									sets={sets}
 									status={status}
+									unit={preferredUnit}
 									equipment={meta.equipment}
 									defaultReps={parseTargetReps(meta.targetReps)}
 									targetSets={meta.targetSets}

--- a/src/components/workout/cardio-exercise-card.tsx
+++ b/src/components/workout/cardio-exercise-card.tsx
@@ -189,7 +189,7 @@ export function CardioExerciseCard({
   const [rpe, setRpe] = useState(5);
   const [showEquipment, setShowEquipment] = useState(false);
   const [useVest, setUseVest] = useState(false);
-  const [vestWeight, setVestWeight] = useState(20);
+  const [vestWeight, setVestWeight] = useState(unit === "kg" ? 10 : 20);
   const [isLogged, setIsLogged] = useState(false);
   const [showNoteSheet, setShowNoteSheet] = useState(false);
 

--- a/src/components/workout/edit-set-sheet.tsx
+++ b/src/components/workout/edit-set-sheet.tsx
@@ -22,6 +22,8 @@ export interface EditableSet {
   weight: number;
   durationSeconds?: number;
   unit: "lb" | "kg";
+  storedWeight?: number;
+  storedUnit?: "lb" | "kg";
   isBodyweight?: boolean;
   rpe?: number | null;
 }
@@ -105,7 +107,7 @@ function EditSetContent({
               label={set.isBodyweight ? "Added Weight" : "Weight"}
               value={weight}
               onChange={setWeight}
-              step={5}
+              step={set.unit === "kg" ? 2.5 : 5}
               min={0}
               unit={set.unit}
             />

--- a/src/components/workout/exercise-accordion.tsx
+++ b/src/components/workout/exercise-accordion.tsx
@@ -348,7 +348,7 @@ export function ExerciseAccordion({
 	sets,
 	status,
 	equipment,
-	defaultWeight = 45,
+	defaultWeight,
 	defaultReps = 8,
 	unit = "lb",
 	targetSets,
@@ -366,11 +366,15 @@ export function ExerciseAccordion({
 	const resolvedUnit =
 		sets.length > 0 ? sets[sets.length - 1].unit : lastSession?.unit ?? unit;
 	const resolvedWeightStep = resolvedUnit === "kg" ? 2.5 : 5;
+	const resolvedDefaultWeight =
+		defaultWeight ?? (resolvedUnit === "kg" ? 20 : 45);
 
 	const initialWeight =
 		sets.length > 0
 			? sets[sets.length - 1].weight
-			: progressionSuggestion?.targetWeight ?? lastSession?.weight ?? defaultWeight;
+			: progressionSuggestion?.targetWeight ??
+				lastSession?.weight ??
+				resolvedDefaultWeight;
 	const initialReps =
 		sets.length > 0
 			? sets[sets.length - 1].reps

--- a/src/lib/progression.test.ts
+++ b/src/lib/progression.test.ts
@@ -18,9 +18,20 @@ describe("progression unit normalization", () => {
           workoutId: "previous",
           date: "2026-07-07T00:00:00.000Z",
           sets: [
-            { setNumber: 1, weight: 220.5, reps: 8, rpe: null, unit: "lb" },
+            {
+              setNumber: 1,
+              weight: 100 / 0.453592,
+              reps: 8,
+              rpe: null,
+              unit: "lb",
+            },
           ],
-          bestSet: { weight: 220.5, reps: 8, rpe: null, unit: "lb" },
+          bestSet: {
+            weight: 100 / 0.453592,
+            reps: 8,
+            rpe: null,
+            unit: "lb",
+          },
         },
       ],
       "8",
@@ -65,6 +76,39 @@ describe("progression unit normalization", () => {
       rpe: 8,
       date: "2026-07-14T00:00:00.000Z",
       unit: "kg",
+    });
+  });
+
+  test("does not collapse distinct canonical weights that display the same", () => {
+    const result = calculateProgressionSuggestion(
+      [
+        {
+          workoutId: "latest",
+          date: "2026-07-14T00:00:00.000Z",
+          sets: [
+            { setNumber: 1, weight: 100, reps: 8, rpe: null, unit: "kg" },
+          ],
+          bestSet: { weight: 100, reps: 8, rpe: null, unit: "kg" },
+        },
+        {
+          workoutId: "previous",
+          date: "2026-07-07T00:00:00.000Z",
+          sets: [
+            { setNumber: 1, weight: 220.4, reps: 8, rpe: null, unit: "lb" },
+          ],
+          bestSet: { weight: 220.4, reps: 8, rpe: null, unit: "lb" },
+        },
+      ],
+      "8",
+      "kg"
+    );
+
+    assert.equal(result?.lastSession.weight, 100);
+    assert.deepEqual(result?.suggestion, {
+      type: "hold",
+      targetWeight: 100,
+      targetReps: 8,
+      reasoning: "Build consistency at this weight.",
     });
   });
 });

--- a/src/lib/progression.test.ts
+++ b/src/lib/progression.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { calculateProgressionSuggestion } from "./progression";
+
+describe("progression unit normalization", () => {
+  test("normalizes mixed history before comparing sessions and suggesting weight", () => {
+    const result = calculateProgressionSuggestion(
+      [
+        {
+          workoutId: "latest",
+          date: "2026-07-14T00:00:00.000Z",
+          sets: [
+            { setNumber: 1, weight: 100, reps: 8, rpe: null, unit: "kg" },
+          ],
+          bestSet: { weight: 100, reps: 8, rpe: null, unit: "kg" },
+        },
+        {
+          workoutId: "previous",
+          date: "2026-07-07T00:00:00.000Z",
+          sets: [
+            { setNumber: 1, weight: 220.5, reps: 8, rpe: null, unit: "lb" },
+          ],
+          bestSet: { weight: 220.5, reps: 8, rpe: null, unit: "lb" },
+        },
+      ],
+      "8",
+      "kg"
+    );
+
+    assert.deepEqual(result?.lastSession, {
+      weight: 100,
+      reps: 8,
+      rpe: null,
+      date: "2026-07-14T00:00:00.000Z",
+      unit: "kg",
+    });
+    assert.deepEqual(result?.suggestion, {
+      type: "increase_weight",
+      targetWeight: 102.5,
+      targetReps: 8,
+      reasoning: "Hit 8 reps for 2 sessions. Ready to add weight.",
+    });
+  });
+
+  test("reselects the heaviest set after converting a mixed-unit session", () => {
+    const result = calculateProgressionSuggestion(
+      [
+        {
+          workoutId: "mixed",
+          date: "2026-07-14T00:00:00.000Z",
+          sets: [
+            { setNumber: 1, weight: 100, reps: 8, rpe: 8, unit: "lb" },
+            { setNumber: 2, weight: 60, reps: 6, rpe: 8, unit: "kg" },
+          ],
+          bestSet: { weight: 100, reps: 8, rpe: 8, unit: "lb" },
+        },
+      ],
+      undefined,
+      "kg"
+    );
+
+    assert.deepEqual(result?.lastSession, {
+      weight: 60,
+      reps: 6,
+      rpe: 8,
+      date: "2026-07-14T00:00:00.000Z",
+      unit: "kg",
+    });
+  });
+});

--- a/src/lib/progression.ts
+++ b/src/lib/progression.ts
@@ -1,3 +1,5 @@
+import { displayWeight, type WeightUnit } from "./units";
+
 type ExerciseSession = {
   workoutId: string;
   date: string;
@@ -15,6 +17,32 @@ type ExerciseSession = {
     unit: "kg" | "lb";
   };
 };
+
+function convertSessionToUnit(
+  session: ExerciseSession,
+  unit: WeightUnit
+): ExerciseSession {
+  const sets = session.sets.map((set) => ({
+    ...set,
+    weight: displayWeight(set.weight, set.unit, unit),
+    unit,
+  }));
+  const workingSets = sets.filter((set) => set.reps > 0);
+  const bestSet = (workingSets.length > 0 ? workingSets : sets).reduce(
+    (best, current) => (current.weight > best.weight ? current : best),
+    {
+      ...session.bestSet,
+      weight: displayWeight(
+        session.bestSet.weight,
+        session.bestSet.unit,
+        unit
+      ),
+      unit,
+    }
+  );
+
+  return { ...session, sets, bestSet };
+}
 
 export type ProgressionSuggestion = {
   type: "increase_weight" | "increase_reps" | "hold" | "deload";
@@ -99,15 +127,20 @@ function getAvgRpe(sessions: ExerciseSession[]): number | null {
 
 export function calculateProgressionSuggestion(
   sessions: ExerciseSession[],
-  targetRepRange?: string
+  targetRepRange?: string,
+  preferredUnit?: WeightUnit
 ): { lastSession: GhostSetData; suggestion: ProgressionSuggestion } | null {
   if (sessions.length === 0) return null;
 
-  const lastSession = sessions[0];
+  const normalizedSessions = preferredUnit
+    ? sessions.map((session) => convertSessionToUnit(session, preferredUnit))
+    : sessions;
+
+  const lastSession = normalizedSessions[0];
   const { bestSet } = lastSession;
   const repRange = parseRepRange(targetRepRange);
 
-  const sessionsAtWeight = sessionsAtSameWeight(sessions);
+  const sessionsAtWeight = sessionsAtSameWeight(normalizedSessions);
   const consecutiveSessionsAtWeight = sessionsAtWeight.length;
 
   const sessionsHittingTarget = repRange
@@ -115,14 +148,14 @@ export function calculateProgressionSuggestion(
     : [];
   const consecutiveTargetHits = sessionsHittingTarget.length;
 
-  const sessionsAtWeightAndReps = sessionsAtSameWeightAndReps(sessions);
+  const sessionsAtWeightAndReps = sessionsAtSameWeightAndReps(normalizedSessions);
   const consecutiveAtWeightAndReps = sessionsAtWeightAndReps.length;
 
   const avgRpe = getAvgRpe(sessionsAtWeight.slice(0, 3));
   const lastRpe = bestSet.rpe;
   const hasAnyRpeData = avgRpe !== null || lastRpe !== null;
 
-  const recentRpes = sessions
+  const recentRpes = normalizedSessions
     .slice(0, 3)
     .map((s) => s.bestSet.rpe)
     .filter((rpe): rpe is number => rpe !== null);

--- a/src/lib/progression.ts
+++ b/src/lib/progression.ts
@@ -1,4 +1,4 @@
-import { displayWeight, type WeightUnit } from "./units";
+import { convertWeight, displayWeight, type WeightUnit } from "./units";
 
 type ExerciseSession = {
   workoutId: string;
@@ -24,7 +24,7 @@ function convertSessionToUnit(
 ): ExerciseSession {
   const sets = session.sets.map((set) => ({
     ...set,
-    weight: displayWeight(set.weight, set.unit, unit),
+    weight: convertWeight(set.weight, set.unit, unit),
     unit,
   }));
   const workingSets = sets.filter((set) => set.reps > 0);
@@ -32,7 +32,7 @@ function convertSessionToUnit(
     (best, current) => (current.weight > best.weight ? current : best),
     {
       ...session.bestSet,
-      weight: displayWeight(
+      weight: convertWeight(
         session.bestSet.weight,
         session.bestSet.unit,
         unit
@@ -217,7 +217,7 @@ export function calculateProgressionSuggestion(
 
   return {
     lastSession: {
-      weight: bestSet.weight,
+      weight: displayWeight(bestSet.weight, bestSet.unit, bestSet.unit),
       reps: bestSet.reps,
       rpe: bestSet.rpe,
       date: lastSession.date,
@@ -225,7 +225,10 @@ export function calculateProgressionSuggestion(
     },
     suggestion: {
       type: suggestionType,
-      targetWeight,
+      targetWeight:
+        targetWeight === null
+          ? null
+          : displayWeight(targetWeight, bestSet.unit, bestSet.unit),
       targetReps,
       reasoning,
     },

--- a/src/lib/units.test.ts
+++ b/src/lib/units.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import {
+  calculateVolumeInUnit,
+  convertWeight,
+  displayWeight,
+  editedWeightForStorage,
+} from "./units";
+
+describe("weight units", () => {
+  test("converts pounds and kilograms for display", () => {
+    assert.equal(displayWeight(225, "lb", "kg"), 102.1);
+    assert.equal(displayWeight(100, "kg", "lb"), 220.5);
+  });
+
+  test("leaves same-unit source values unchanged before display rounding", () => {
+    assert.equal(convertWeight(42.25, "lb", "lb"), 42.25);
+    assert.equal(convertWeight(42.25, "kg", "kg"), 42.25);
+  });
+
+  test("sums mixed-unit volume in the requested unit without per-set rounding", () => {
+    const sets = [
+      { weight: 100, reps: 10, unit: "lb" as const },
+      { weight: 100, reps: 10, unit: "kg" as const },
+      { reps: 8, unit: "lb" as const },
+    ];
+
+    assert.ok(Math.abs(calculateVolumeInUnit(sets, "kg") - 1453.592) < 1e-6);
+    assert.ok(Math.abs(calculateVolumeInUnit(sets, "lb") - 3204.62) < 1e-6);
+  });
+
+  test("preserves a legacy source value unless its displayed weight changes", () => {
+    assert.equal(
+      editedWeightForStorage({
+        displayedWeight: 102.1,
+        displayUnit: "kg",
+        storedUnit: "lb",
+        originalDisplayedWeight: 102.1,
+        originalStoredWeight: 225,
+      }),
+      225
+    );
+    assert.equal(
+      editedWeightForStorage({
+        displayedWeight: 102.6,
+        displayUnit: "kg",
+        storedUnit: "lb",
+        originalDisplayedWeight: 102.1,
+        originalStoredWeight: 225,
+      }),
+      226
+    );
+  });
+});

--- a/src/lib/units.ts
+++ b/src/lib/units.ts
@@ -1,5 +1,11 @@
 export type WeightUnit = "lb" | "kg";
 
+export type WeightedReps = {
+  weight?: number;
+  reps?: number;
+  unit?: WeightUnit;
+};
+
 const LB_TO_KG = 0.453592;
 const KG_TO_LB = 2.20462;
 
@@ -27,4 +33,35 @@ export function displayWeight(
 ): number {
   const converted = convertWeight(weight, fromUnit, toUnit);
   return roundWeight(converted, toUnit);
+}
+
+export function calculateVolumeInUnit(
+  sets: WeightedReps[],
+  toUnit: WeightUnit
+): number {
+  return sets.reduce((total, set) => {
+    const weight = set.weight ?? 0;
+    const reps = set.reps ?? 0;
+    const sourceUnit = set.unit ?? toUnit;
+    return total + convertWeight(weight, sourceUnit, toUnit) * reps;
+  }, 0);
+}
+
+export function editedWeightForStorage({
+  displayedWeight,
+  displayUnit,
+  storedUnit,
+  originalDisplayedWeight,
+  originalStoredWeight,
+}: {
+  displayedWeight: number;
+  displayUnit: WeightUnit;
+  storedUnit: WeightUnit;
+  originalDisplayedWeight: number;
+  originalStoredWeight?: number;
+}): number | undefined {
+  if (displayedWeight === originalDisplayedWeight) {
+    return originalStoredWeight;
+  }
+  return displayWeight(displayedWeight, displayUnit, storedUnit);
 }


### PR DESCRIPTION
> **Stacked dependency:** This PR is based on and must merge after #44 (`feat/time-based-strength`). Its active-workout changes build directly on the timed-strength flow.

## What does this PR do?

Fixes the production symptom where an account configured for kilograms still defaulted new active-workout sets to pounds and could have its preference overridden by the most recent historical entry.

- Reads `preferredUnits` from the authenticated user before rendering the active workout, with a deterministic `lb` fallback for legacy/no-user records.
- Stores all newly logged weighted lifting sets and cardio vest weights in the preferred unit.
- Converts every persisted set from its own source unit exactly once for active-workout display, progression suggestions, session volume, and workout detail history.
- Normalizes mixed-unit history before comparing sessions or selecting the best set.
- Preserves the original stored value and unit when editing legacy sets; only an edited weight is converted back to that records source unit.
- Keeps duration-based strength sets weightless and unchanged.
- Uses unit-appropriate default loads and increments.

Compatibility: no schema changes, data migrations, or production writes. Existing mixed-unit entries remain untouched and continue to retain their stored source unit.

## Related issue

N/A

## How to test

1. Set profile units to kg, open an active workout, and confirm lifting and weighted-vest controls use kg.
2. With lb and kg history for the same exercise, confirm last-session values and progression targets render in the selected unit.
3. Edit reps/RPE on a legacy lb set while viewing kg and confirm its stored weight/unit remain unchanged; edit the weight and confirm it is converted back to lb once.
4. Confirm active-session and completed-workout volume use the selected unit, including mixed-unit records.
5. Confirm timed-strength sets still use duration only.

Automated verification:
- `bun test src/lib/units.test.ts src/lib/progression.test.ts` — 6 passed, 0 failed
- `bunx tsc --noEmit` — passed
- `bun run lint` — passed with 7 pre-existing generated/demo warnings and 0 errors
- `bun run build` — passed
- `git diff --check` — passed

## Checklist

- [x] I have tested this locally
- [x] `bun run lint` passes
- [x] I have updated docs if needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/house-of-giants/codesmith/opentrainer/pr/45"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787254890&installation_model_id=19704&pr_number=45&repository=house-of-giants%2Fopentrainer&return_to=https%3A%2F%2Fgithub.com%2Fhouse-of-giants%2Fopentrainer%2Fpull%2F45&signature=67622e087245afcf4180910e051cdf810af4faa26a696109894a960676c874d6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->