### PR TITLE
fix(workouts): await cardio persistence before finish

### DIFF
--- a/src/app/workout/active/page.tsx
+++ b/src/app/workout/active/page.tsx
@@ -41,6 +41,10 @@ import {
 	editedWeightForStorage,
 	type WeightUnit,
 } from "@/lib/units";
+import {
+	CardioSaveBlockedError,
+	createCardioPersistenceGate,
+} from "@/lib/cardio-persistence";
 import posthog from "posthog-js";
 
 type EntryData = {
@@ -168,6 +172,11 @@ export default function ActiveWorkoutPage() {
 	);
 	const [isCompletingWithEditedTime, setIsCompletingWithEditedTime] =
 		useState(false);
+	const [isCompleting, setIsCompleting] = useState(false);
+	const [pendingCardioSaveCount, setPendingCardioSaveCount] = useState(0);
+	const [cardioPersistenceGate] = useState(() =>
+		createCardioPersistenceGate(setPendingCardioSaveCount)
+	);
 	const exerciseRefs = useRef<Map<string, HTMLDivElement>>(new Map());
 
 	const workout = useQuery(api.workouts.getActiveWorkout);
@@ -465,38 +474,50 @@ export default function ActiveWorkoutPage() {
 		}
 	) => {
 		try {
-			await addCardioEntry({
-				workoutId: workout._id,
-				clientId: generateClientId(),
-				exerciseName,
-				cardio: {
-					mode: "steady",
-					durationSeconds: data.durationSeconds,
+			await cardioPersistenceGate.runSave(async () => {
+				await addCardioEntry({
+					workoutId: workout._id,
+					clientId: generateClientId(),
+					exerciseName,
+					cardio: {
+						mode: "steady",
+						durationSeconds: data.durationSeconds,
+						distance: data.distance,
+						distanceUnit:
+							data.distanceUnit === "km"
+								? "km"
+								: data.distanceUnit === "mi"
+									? "mi"
+									: undefined,
+						rpe: data.rpe,
+						vestWeight: data.vestWeight,
+						vestWeightUnit: data.vestWeightUnit,
+						intensity: data.intensity,
+					},
+				});
+				posthog.capture("cardio_logged", {
+					exercise_name: exerciseName,
+					duration_seconds: data.durationSeconds,
 					distance: data.distance,
-					distanceUnit:
-						data.distanceUnit === "km"
-							? "km"
-							: data.distanceUnit === "mi"
-								? "mi"
-								: undefined,
+					distance_unit: data.distanceUnit,
 					rpe: data.rpe,
-					vestWeight: data.vestWeight,
-					vestWeightUnit: data.vestWeightUnit,
-					intensity: data.intensity,
-				},
-			});
-			posthog.capture("cardio_logged", {
-				exercise_name: exerciseName,
-				duration_seconds: data.durationSeconds,
-				distance: data.distance,
-				distance_unit: data.distanceUnit,
-				rpe: data.rpe,
+				});
 			});
 			// Don't remove from pendingExercises - we need to preserve order and metadata
 			toast.success("Cardio logged!");
 		} catch (error) {
-			toast.error("Failed to log cardio");
+			const reason =
+				error instanceof CardioSaveBlockedError
+					? "workout_completing"
+					: "mutation_failed";
+			posthog.capture("cardio_log_failed", { reason });
+			toast.error(
+				reason === "workout_completing"
+					? "Workout is already finishing"
+					: "Failed to log cardio"
+			);
 			console.error(error);
+			throw error;
 		}
 	};
 
@@ -596,6 +617,15 @@ export default function ActiveWorkoutPage() {
 	};
 
 	const handleComplete = async () => {
+		const completionStart = cardioPersistenceGate.tryStartCompletion();
+		if (completionStart !== "started") {
+			if (completionStart === "cardio_save_pending") {
+				toast.info("Wait for cardio to finish saving");
+			}
+			return;
+		}
+
+		setIsCompleting(true);
 		vibrate("success");
 		try {
 			await completeWorkout({ workoutId: workout._id });
@@ -604,10 +634,17 @@ export default function ActiveWorkoutPage() {
 			toast.error("Failed to complete workout");
 			posthog.captureException(error);
 			console.error(error);
+		} finally {
+			setIsCompleting(false);
+			cardioPersistenceGate.finishCompletion();
 		}
 	};
 
 	const handleOpenTimeEditor = () => {
+		if (cardioPersistenceGate.pendingCount > 0) {
+			toast.info("Wait for cardio to finish saving");
+			return;
+		}
 		setTimeEditorInitialEnd(Date.now());
 		setShowTimeEditor(true);
 	};
@@ -616,6 +653,15 @@ export default function ActiveWorkoutPage() {
 		startedAt: number,
 		completedAt: number
 	) => {
+		const completionStart = cardioPersistenceGate.tryStartCompletion();
+		if (completionStart !== "started") {
+			throw new Error(
+				completionStart === "cardio_save_pending"
+					? "Wait for cardio to finish saving"
+					: "Workout completion is already in progress"
+			);
+		}
+
 		setIsCompletingWithEditedTime(true);
 		vibrate("success");
 		try {
@@ -631,6 +677,7 @@ export default function ActiveWorkoutPage() {
 			throw error;
 		} finally {
 			setIsCompletingWithEditedTime(false);
+			cardioPersistenceGate.finishCompletion();
 		}
 	};
 
@@ -810,6 +857,8 @@ export default function ActiveWorkoutPage() {
 
 	const currentExerciseName = exerciseList[currentExerciseIndex]?.[0];
 	const nextExerciseName = exerciseList[currentExerciseIndex + 1]?.[0];
+	const hasPendingCardioSaves = pendingCardioSaveCount > 0;
+	const isWorkoutCompleting = isCompleting || isCompletingWithEditedTime;
 
 	const jumpToCurrentExercise = () => {
 		if (!currentExerciseName) return;
@@ -836,6 +885,7 @@ export default function ActiveWorkoutPage() {
 								size="sm"
 								className="h-auto px-1.5 py-0 text-xs text-muted-foreground"
 								onClick={handleOpenTimeEditor}
+								disabled={hasPendingCardioSaves || isWorkoutCompleting}
 							>
 								Edit time
 							</Button>
@@ -850,9 +900,32 @@ export default function ActiveWorkoutPage() {
 						>
 							Cancel
 						</Button>
-						<Button size="sm" onClick={handleComplete}>
-							Finish
+						<Button
+							size="sm"
+							onClick={handleComplete}
+							disabled={hasPendingCardioSaves || isWorkoutCompleting}
+							aria-describedby={
+								hasPendingCardioSaves ? "cardio-save-status" : undefined
+							}
+						>
+							{hasPendingCardioSaves
+								? "Saving..."
+								: isWorkoutCompleting
+									? "Finishing..."
+									: "Finish"}
 						</Button>
+						<span
+							id="cardio-save-status"
+							className="sr-only"
+							role="status"
+							aria-live="polite"
+						>
+							{hasPendingCardioSaves
+								? `${pendingCardioSaveCount} cardio ${
+										pendingCardioSaveCount === 1 ? "entry is" : "entries are"
+									} still saving.`
+								: ""}
+						</span>
 					</div>
 				</div>
 			</header>
@@ -884,7 +957,9 @@ export default function ActiveWorkoutPage() {
 						};
 
 						if (meta.category === "cardio") {
-							const hasLogged = groupEntries.some((e) => e.kind === "cardio");
+							const loggedCardioEntry = groupEntries.find(
+								(entry) => entry.kind === "cardio"
+							);
 							const status = getExerciseStatus();
 
 							return (
@@ -901,11 +976,8 @@ export default function ActiveWorkoutPage() {
 										status={status}
 										defaultMinutes={meta.targetDurationMinutes}
 										note={getExerciseNote(name)}
-										onLog={
-											hasLogged
-												? () => {}
-												: (data) => handleLogCardio(name, data)
-										}
+										loggedData={loggedCardioEntry?.cardio}
+										onLog={(data) => handleLogCardio(name, data)}
 										onNoteChange={(note: string) =>
 											handleNoteChange(name, note)
 										}

--- a/src/app/workout/active/page.tsx
+++ b/src/app/workout/active/page.tsx
@@ -64,7 +64,7 @@ type EntryData = {
 	cardio?: {
 		durationSeconds: number;
 		distance?: number;
-		distanceUnit?: "km" | "mi";
+		distanceUnit?: "m" | "km" | "mi";
 		rpe?: number;
 		vestWeight?: number;
 		vestWeightUnit?: "kg" | "lb";

--- a/src/components/workout/cardio-exercise-card.tsx
+++ b/src/components/workout/cardio-exercise-card.tsx
@@ -9,6 +9,10 @@ import { SetStepper } from "./set-stepper";
 import { useHaptic } from "@/hooks/use-haptic";
 import { Check, ChevronDown, ChevronUp, Dumbbell, MessageSquare } from "lucide-react";
 import { CardioSaveBlockedError } from "@/lib/cardio-persistence";
+import {
+  getCardioDisplaySummary,
+  type PersistedCardioSummary,
+} from "@/lib/cardio-display";
 import { cn } from "@/lib/utils";
 
 type ExerciseStatus = "completed" | "current" | "upcoming";
@@ -23,6 +27,12 @@ export type CardioLogData = {
   intensity?: number;
 };
 
+export type PersistedCardioLogData = Omit<
+  CardioLogData,
+  "distanceUnit"
+> &
+  PersistedCardioSummary;
+
 interface CardioExerciseCardProps {
   exerciseName: string;
   primaryMetric: "duration" | "distance";
@@ -31,7 +41,7 @@ interface CardioExerciseCardProps {
   distanceUnit?: "km" | "mi";
   defaultMinutes?: number;
   note?: string;
-  loggedData?: CardioLogData;
+  loggedData?: PersistedCardioLogData;
   onLog: (data: CardioLogData) => Promise<void>;
   onNoteChange?: (note: string) => void;
   onSelect?: () => void;
@@ -205,10 +215,12 @@ export function CardioExerciseCard({
   const totalSeconds = minutes * 60 + seconds;
   const canLog = primaryMetric === "duration" ? totalSeconds > 0 : distance > 0;
   const isLogged = loggedData !== undefined || hasAcknowledgedLog;
-  const loggedDurationSeconds = loggedData?.durationSeconds ?? totalSeconds;
-  const loggedDistance = loggedData?.distance ?? distance;
-  const loggedDistanceUnit = loggedData?.distanceUnit ?? distanceUnit;
-  const loggedRpe = loggedData?.rpe ?? rpe;
+  const loggedSummary = getCardioDisplaySummary(loggedData, {
+    durationSeconds: totalSeconds,
+    distance,
+    distanceUnit,
+    rpe,
+  });
   const loggedVestWeight = loggedData?.vestWeight ?? vestWeight;
   const loggedVestWeightUnit = loggedData?.vestWeightUnit ?? unit;
   const hasLoggedVest = loggedData
@@ -355,11 +367,13 @@ export function CardioExerciseCard({
 
             {displayStatus === "completed" && isLogged && (
               <span className="font-mono text-xs text-muted-foreground tabular-nums">
-                {formatDuration(loggedDurationSeconds)}
+                {formatDuration(loggedSummary.durationSeconds)}
                 {primaryMetric === "distance" &&
-                  loggedDistance > 0 &&
-                  ` · ${loggedDistance} ${loggedDistanceUnit}`}
-                {` · RPE ${loggedRpe}`}
+                  loggedSummary.distance !== undefined &&
+                  loggedSummary.distance > 0 &&
+                  ` · ${loggedSummary.distance} ${loggedSummary.distanceUnit}`}
+                {loggedSummary.rpe !== undefined &&
+                  ` · RPE ${loggedSummary.rpe}`}
               </span>
             )}
           </div>
@@ -390,20 +404,24 @@ export function CardioExerciseCard({
                 <div className="flex items-center justify-between">
                   <div className="space-y-1">
                     <div className="font-mono text-2xl tabular-nums">
-                      {formatDuration(loggedDurationSeconds)}
+                      {formatDuration(loggedSummary.durationSeconds)}
                     </div>
-                    {primaryMetric === "distance" && loggedDistance > 0 && (
-                      <div className="font-mono text-lg tabular-nums text-muted-foreground">
-                        {loggedDistance} {loggedDistanceUnit}
+                    {primaryMetric === "distance" &&
+                      loggedSummary.distance !== undefined &&
+                      loggedSummary.distance > 0 && (
+                        <div className="font-mono text-lg tabular-nums text-muted-foreground">
+                          {loggedSummary.distance} {loggedSummary.distanceUnit}
+                        </div>
+                      )}
+                  </div>
+                  {loggedSummary.rpe !== undefined && (
+                    <div className="text-right">
+                      <div className="text-sm text-muted-foreground">RPE</div>
+                      <div className="font-mono text-2xl tabular-nums">
+                        {loggedSummary.rpe}
                       </div>
-                    )}
-                  </div>
-                  <div className="text-right">
-                    <div className="text-sm text-muted-foreground">RPE</div>
-                    <div className="font-mono text-2xl tabular-nums">
-                      {loggedRpe}
                     </div>
-                  </div>
+                  )}
                 </div>
                 {hasLoggedVest && (
                   <div className="mt-3 flex items-center gap-2 text-sm text-muted-foreground border-t pt-3">

--- a/src/components/workout/cardio-exercise-card.tsx
+++ b/src/components/workout/cardio-exercise-card.tsx
@@ -371,6 +371,7 @@ export function CardioExerciseCard({
                 {primaryMetric === "distance" &&
                   loggedSummary.distance !== undefined &&
                   loggedSummary.distance > 0 &&
+                  loggedSummary.distanceUnit !== undefined &&
                   ` · ${loggedSummary.distance} ${loggedSummary.distanceUnit}`}
                 {loggedSummary.rpe !== undefined &&
                   ` · RPE ${loggedSummary.rpe}`}
@@ -408,7 +409,8 @@ export function CardioExerciseCard({
                     </div>
                     {primaryMetric === "distance" &&
                       loggedSummary.distance !== undefined &&
-                      loggedSummary.distance > 0 && (
+                      loggedSummary.distance > 0 &&
+                      loggedSummary.distanceUnit !== undefined && (
                         <div className="font-mono text-lg tabular-nums text-muted-foreground">
                           {loggedSummary.distance} {loggedSummary.distanceUnit}
                         </div>

--- a/src/components/workout/cardio-exercise-card.tsx
+++ b/src/components/workout/cardio-exercise-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, useId } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { RpeSlider } from "./rpe-slider";
@@ -8,9 +8,20 @@ import { NoteSheet } from "./note-sheet";
 import { SetStepper } from "./set-stepper";
 import { useHaptic } from "@/hooks/use-haptic";
 import { Check, ChevronDown, ChevronUp, Dumbbell, MessageSquare } from "lucide-react";
+import { CardioSaveBlockedError } from "@/lib/cardio-persistence";
 import { cn } from "@/lib/utils";
 
 type ExerciseStatus = "completed" | "current" | "upcoming";
+
+export type CardioLogData = {
+  durationSeconds: number;
+  distance?: number;
+  distanceUnit?: "km" | "mi";
+  rpe?: number;
+  vestWeight?: number;
+  vestWeightUnit?: "kg" | "lb";
+  intensity?: number;
+};
 
 interface CardioExerciseCardProps {
   exerciseName: string;
@@ -20,15 +31,8 @@ interface CardioExerciseCardProps {
   distanceUnit?: "km" | "mi";
   defaultMinutes?: number;
   note?: string;
-  onLog: (data: {
-    durationSeconds: number;
-    distance?: number;
-    distanceUnit?: "km" | "mi";
-    rpe?: number;
-    vestWeight?: number;
-    vestWeightUnit?: "kg" | "lb";
-    intensity?: number;
-  }) => void;
+  loggedData?: CardioLogData;
+  onLog: (data: CardioLogData) => Promise<void>;
   onNoteChange?: (note: string) => void;
   onSelect?: () => void;
 }
@@ -177,6 +181,7 @@ export function CardioExerciseCard({
   distanceUnit = "mi",
   defaultMinutes = 20,
   note,
+  loggedData,
   onLog,
   onNoteChange,
   onSelect,
@@ -190,11 +195,25 @@ export function CardioExerciseCard({
   const [showEquipment, setShowEquipment] = useState(false);
   const [useVest, setUseVest] = useState(false);
   const [vestWeight, setVestWeight] = useState(unit === "kg" ? 10 : 20);
-  const [isLogged, setIsLogged] = useState(false);
+  const [hasAcknowledgedLog, setHasAcknowledgedLog] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [logError, setLogError] = useState<string | null>(null);
   const [showNoteSheet, setShowNoteSheet] = useState(false);
+  const isSavingRef = useRef(false);
+  const logErrorId = useId();
 
   const totalSeconds = minutes * 60 + seconds;
   const canLog = primaryMetric === "duration" ? totalSeconds > 0 : distance > 0;
+  const isLogged = loggedData !== undefined || hasAcknowledgedLog;
+  const loggedDurationSeconds = loggedData?.durationSeconds ?? totalSeconds;
+  const loggedDistance = loggedData?.distance ?? distance;
+  const loggedDistanceUnit = loggedData?.distanceUnit ?? distanceUnit;
+  const loggedRpe = loggedData?.rpe ?? rpe;
+  const loggedVestWeight = loggedData?.vestWeight ?? vestWeight;
+  const loggedVestWeightUnit = loggedData?.vestWeightUnit ?? unit;
+  const hasLoggedVest = loggedData
+    ? loggedData.vestWeight !== undefined
+    : useVest;
 
   const isExpanded = status === "current";
   const displayStatus = isLogged && status !== "current" ? "completed" : status;
@@ -207,21 +226,37 @@ export function CardioExerciseCard({
     }
   };
 
-  const handleLog = () => {
-    if (!canLog) return;
-    vibrate("success");
+  const handleLog = async () => {
+    if (!canLog || isSavingRef.current) return;
 
-    onLog({
-      durationSeconds: totalSeconds,
-      distance: primaryMetric === "distance" ? distance : undefined,
-      distanceUnit: primaryMetric === "distance" ? distanceUnit : undefined,
-      rpe,
-      vestWeight: useVest ? vestWeight : undefined,
-      vestWeightUnit: useVest ? unit : undefined,
-      intensity: rpe,
-    });
+    isSavingRef.current = true;
+    setIsSaving(true);
+    setLogError(null);
 
-    setIsLogged(true);
+    try {
+      await onLog({
+        durationSeconds: totalSeconds,
+        distance: primaryMetric === "distance" ? distance : undefined,
+        distanceUnit: primaryMetric === "distance" ? distanceUnit : undefined,
+        rpe,
+        vestWeight: useVest ? vestWeight : undefined,
+        vestWeightUnit: useVest ? unit : undefined,
+        intensity: rpe,
+      });
+
+      setHasAcknowledgedLog(true);
+      vibrate("success");
+    } catch (error) {
+      setLogError(
+        error instanceof CardioSaveBlockedError
+          ? "The workout is already finishing, so this cardio wasn't saved."
+          : "Cardio wasn't saved. Check your connection and try again."
+      );
+      vibrate("warning");
+    } finally {
+      isSavingRef.current = false;
+      setIsSaving(false);
+    }
   };
 
   const handleSecondsChange = (newSeconds: number) => {
@@ -320,9 +355,11 @@ export function CardioExerciseCard({
 
             {displayStatus === "completed" && isLogged && (
               <span className="font-mono text-xs text-muted-foreground tabular-nums">
-                {formatDuration(totalSeconds)}
-                {distance > 0 && ` · ${distance} ${distanceUnit}`}
-                {` · RPE ${rpe}`}
+                {formatDuration(loggedDurationSeconds)}
+                {primaryMetric === "distance" &&
+                  loggedDistance > 0 &&
+                  ` · ${loggedDistance} ${loggedDistanceUnit}`}
+                {` · RPE ${loggedRpe}`}
               </span>
             )}
           </div>
@@ -353,23 +390,27 @@ export function CardioExerciseCard({
                 <div className="flex items-center justify-between">
                   <div className="space-y-1">
                     <div className="font-mono text-2xl tabular-nums">
-                      {formatDuration(totalSeconds)}
+                      {formatDuration(loggedDurationSeconds)}
                     </div>
-                    {distance > 0 && (
+                    {primaryMetric === "distance" && loggedDistance > 0 && (
                       <div className="font-mono text-lg tabular-nums text-muted-foreground">
-                        {distance} {distanceUnit}
+                        {loggedDistance} {loggedDistanceUnit}
                       </div>
                     )}
                   </div>
                   <div className="text-right">
                     <div className="text-sm text-muted-foreground">RPE</div>
-                    <div className="font-mono text-2xl tabular-nums">{rpe}</div>
+                    <div className="font-mono text-2xl tabular-nums">
+                      {loggedRpe}
+                    </div>
                   </div>
                 </div>
-                {useVest && (
+                {hasLoggedVest && (
                   <div className="mt-3 flex items-center gap-2 text-sm text-muted-foreground border-t pt-3">
                     <Dumbbell className="h-4 w-4" />
-                    <span>Vest: {vestWeight} {unit}</span>
+                    <span>
+                      Vest: {loggedVestWeight} {loggedVestWeightUnit}
+                    </span>
                   </div>
                 )}
               </div>
@@ -381,11 +422,21 @@ export function CardioExerciseCard({
               )}
               <div className="flex items-center justify-center pt-2">
                 <Check className="h-5 w-5 text-primary mr-2" />
-                <span className="text-sm font-medium text-muted-foreground">Logged</span>
+                <span
+                  className="text-sm font-medium text-muted-foreground"
+                  role="status"
+                >
+                  Logged
+                </span>
               </div>
             </div>
           ) : (
-          <div className="space-y-4 px-4 pb-4 pt-2">
+          <fieldset
+            className="space-y-4 px-4 pb-4 pt-2"
+            disabled={isSaving}
+            aria-describedby={logError ? logErrorId : undefined}
+          >
+            <legend className="sr-only">Log cardio for {exerciseName}</legend>
             {primaryMetric === "duration" ? (
               <div>
                 <label className="mb-2 block text-xs font-medium text-muted-foreground uppercase tracking-wide">
@@ -509,17 +560,24 @@ export function CardioExerciseCard({
             )}
 
             <Button
+              type="button"
               size="lg"
               className={cn(
                 "mt-2 h-14 w-full text-base font-semibold tracking-wide",
                 "transition-all duration-200"
               )}
               onClick={handleLog}
-              disabled={!canLog}
+              disabled={!canLog || isSaving}
+              aria-busy={isSaving}
             >
-              LOG CARDIO
+              {isSaving ? "SAVING CARDIO..." : "LOG CARDIO"}
             </Button>
-          </div>
+            {logError && (
+              <p id={logErrorId} className="text-sm text-destructive" role="alert">
+                {logError}
+              </p>
+            )}
+          </fieldset>
           )}
         </div>
       </div>

--- a/src/lib/cardio-display.test.ts
+++ b/src/lib/cardio-display.test.ts
@@ -35,7 +35,23 @@ describe("getCardioDisplaySummary", () => {
       getCardioDisplaySummary({ durationSeconds: 600 }, draft),
       {
         durationSeconds: 600,
+        distance: undefined,
         distanceUnit: undefined,
+      }
+    );
+  });
+
+  test("omits persisted distances whose unit is unknown", () => {
+    assert.deepEqual(
+      getCardioDisplaySummary(
+        { durationSeconds: 600, distance: 5, rpe: 6 },
+        draft
+      ),
+      {
+        durationSeconds: 600,
+        distance: undefined,
+        distanceUnit: undefined,
+        rpe: 6,
       }
     );
   });

--- a/src/lib/cardio-display.test.ts
+++ b/src/lib/cardio-display.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { getCardioDisplaySummary } from "./cardio-display";
+
+const draft = {
+  durationSeconds: 1_200,
+  distance: 1,
+  distanceUnit: "mi" as const,
+  rpe: 5,
+};
+
+describe("getCardioDisplaySummary", () => {
+  test("normalizes persisted meter distances to kilometers", () => {
+    assert.deepEqual(
+      getCardioDisplaySummary(
+        {
+          durationSeconds: 120,
+          distance: 400,
+          distanceUnit: "m",
+          rpe: 7,
+        },
+        draft
+      ),
+      {
+        durationSeconds: 120,
+        distance: 0.4,
+        distanceUnit: "km",
+        rpe: 7,
+      }
+    );
+  });
+
+  test("does not invent missing persisted distance or RPE values", () => {
+    assert.deepEqual(
+      getCardioDisplaySummary({ durationSeconds: 600 }, draft),
+      {
+        durationSeconds: 600,
+        distanceUnit: undefined,
+      }
+    );
+  });
+
+  test("uses draft values only for a newly acknowledged log", () => {
+    assert.deepEqual(getCardioDisplaySummary(undefined, draft), draft);
+  });
+});

--- a/src/lib/cardio-display.ts
+++ b/src/lib/cardio-display.ts
@@ -31,6 +31,14 @@ export function getCardioDisplaySummary(
     };
   }
 
+  if (distanceUnit === undefined) {
+    return {
+      ...summary,
+      distance: undefined,
+      distanceUnit: undefined,
+    };
+  }
+
   return {
     ...summary,
     distanceUnit,

--- a/src/lib/cardio-display.ts
+++ b/src/lib/cardio-display.ts
@@ -1,0 +1,38 @@
+export type CardioDistanceUnit = "m" | "km" | "mi";
+export type DisplayCardioDistanceUnit = Exclude<CardioDistanceUnit, "m">;
+
+export type PersistedCardioSummary = {
+  durationSeconds: number;
+  distance?: number;
+  distanceUnit?: CardioDistanceUnit;
+  rpe?: number;
+};
+
+export type DraftCardioSummary = {
+  durationSeconds: number;
+  distance: number;
+  distanceUnit: DisplayCardioDistanceUnit;
+  rpe: number;
+};
+
+export function getCardioDisplaySummary(
+  persisted: PersistedCardioSummary | undefined,
+  draft: DraftCardioSummary
+) {
+  const summary = persisted ?? draft;
+  const distanceUnit = summary.distanceUnit;
+
+  if (distanceUnit === "m") {
+    return {
+      ...summary,
+      distance:
+        summary.distance === undefined ? undefined : summary.distance / 1_000,
+      distanceUnit: "km" as const,
+    };
+  }
+
+  return {
+    ...summary,
+    distanceUnit,
+  };
+}

--- a/src/lib/cardio-persistence.test.ts
+++ b/src/lib/cardio-persistence.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import {
+  CardioSaveBlockedError,
+  createCardioPersistenceGate,
+} from "./cardio-persistence";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, resolve, reject };
+}
+
+describe("cardio persistence gate", () => {
+  test("tracks concurrent saves until each one is acknowledged", async () => {
+    const pendingCounts: number[] = [];
+    const gate = createCardioPersistenceGate((count) => pendingCounts.push(count));
+    const first = deferred<string>();
+    const second = deferred<string>();
+
+    const firstSave = gate.runSave(() => first.promise);
+    const secondSave = gate.runSave(() => second.promise);
+
+    assert.equal(gate.pendingCount, 2);
+    assert.equal(gate.tryStartCompletion(), "cardio_save_pending");
+
+    first.resolve("first");
+    assert.equal(await firstSave, "first");
+    assert.equal(gate.pendingCount, 1);
+    assert.equal(gate.tryStartCompletion(), "cardio_save_pending");
+
+    second.resolve("second");
+    assert.equal(await secondSave, "second");
+    assert.equal(gate.pendingCount, 0);
+    assert.deepEqual(pendingCounts, [1, 2, 1, 0]);
+  });
+
+  test("releases a failed save so it can be retried", async () => {
+    const gate = createCardioPersistenceGate();
+    const failure = new Error("offline");
+
+    await assert.rejects(gate.runSave(() => Promise.reject(failure)), failure);
+    assert.equal(gate.pendingCount, 0);
+    assert.equal(await gate.runSave(() => Promise.resolve("saved")), "saved");
+  });
+
+  test("prevents a new save once completion starts", async () => {
+    const gate = createCardioPersistenceGate();
+
+    assert.equal(gate.tryStartCompletion(), "started");
+    assert.equal(gate.tryStartCompletion(), "already_completing");
+    await assert.rejects(
+      gate.runSave(() => Promise.resolve()),
+      CardioSaveBlockedError
+    );
+
+    gate.finishCompletion();
+    assert.equal(await gate.runSave(() => Promise.resolve("saved")), "saved");
+  });
+});

--- a/src/lib/cardio-persistence.ts
+++ b/src/lib/cardio-persistence.ts
@@ -1,0 +1,64 @@
+export class CardioSaveBlockedError extends Error {
+  constructor() {
+    super("The workout is already finishing");
+    this.name = "CardioSaveBlockedError";
+  }
+}
+
+export type CompletionStartResult =
+  | "started"
+  | "cardio_save_pending"
+  | "already_completing";
+
+export function createCardioPersistenceGate(
+  onPendingCountChange?: (pendingCount: number) => void
+) {
+  let pendingCount = 0;
+  let completionInProgress = false;
+
+  const publishPendingCount = () => {
+    onPendingCountChange?.(pendingCount);
+  };
+
+  return {
+    async runSave<T>(save: () => Promise<T>): Promise<T> {
+      if (completionInProgress) {
+        throw new CardioSaveBlockedError();
+      }
+
+      pendingCount += 1;
+      publishPendingCount();
+
+      try {
+        return await save();
+      } finally {
+        pendingCount -= 1;
+        publishPendingCount();
+      }
+    },
+
+    tryStartCompletion(): CompletionStartResult {
+      if (completionInProgress) return "already_completing";
+      if (pendingCount > 0) return "cardio_save_pending";
+
+      completionInProgress = true;
+      return "started";
+    },
+
+    finishCompletion() {
+      completionInProgress = false;
+    },
+
+    get pendingCount() {
+      return pendingCount;
+    },
+
+    get completionInProgress() {
+      return completionInProgress;
+    },
+  };
+}
+
+export type CardioPersistenceGate = ReturnType<
+  typeof createCardioPersistenceGate
+>;


### PR DESCRIPTION
## Stack dependency

This PR is stacked on #45 (`fix/preferred-workout-units`), which is stacked on #44 (`feat/time-based-strength`). Review and merge #44, then #45, before this PR; retarget this PR to `main` after its base merges.

## What does this PR do?

Fixes a cardio-entry persistence race observed in production. A March 4 report described 60 minutes split across stair stepper and weighted-vest stair stepper, while the completed workout contained only one 1,800-second custom cardio entry. The active UI previously called an async mutation through a callback typed as `void`, immediately displayed `Logged`, and allowed Finish to race the write.

- Makes `CardioExerciseCard.onLog` return and await a Promise.
- Shows a disabled `SAVING CARDIO...` state, blocks rapid duplicate submits synchronously, and only marks the card logged after Convex acknowledges the mutation.
- Keeps the inputs retryable after failure and announces the inline error with `role="alert"`; existing toast feedback remains.
- Adds a synchronous cardio-persistence gate that tracks multiple concurrent saves, blocks completion while any are pending, and blocks new saves once completion has started.
- Applies the same completion guard to normal and edited-time completion paths; the header exposes an accessible live pending status.
- Hydrates completed cardio cards from persisted entry data after refresh instead of presenting a no-op logger/default-value summary.
- Normalizes legacy meter distances to kilometers and omits absent persisted distance, distance unit, or RPE values instead of showing draft defaults.
- Captures `cardio_logged` only after mutation success and captures `cardio_log_failed` with a non-sensitive reason only.

Compatibility: no Convex schema or stored-record changes. This preserves the preferred vest-weight unit behavior from #45 and the timed-strength workflow from #44.

No deployment or production-data mutation was performed.

## Related issue

N/A (production feedback record; no GitHub issue discovered)

## How to test

Automated checks:

- `bun run lint` — passes with 0 errors and 7 pre-existing warnings.
- `bunx tsc --noEmit` — passes.
- `bun run build` — passes.
- `bun test src/lib/cardio-display.test.ts src/lib/cardio-persistence.test.ts src/lib/units.test.ts src/lib/progression.test.ts src/lib/workout-exercise-group.test.ts convex/lib/routineMeasurements.test.ts` — 20 passing.
- `git diff --check` — passes.

Manual concurrency cases:

1. Start an active workout with a cardio exercise and submit it over a throttled connection. Confirm the card says `SAVING CARDIO...`, its controls are disabled, and Finish says `Saving...` and is disabled until the mutation resolves.
2. Rapidly activate Log Cardio twice. Confirm only one mutation is submitted and one entry appears.
3. Force the cardio mutation to reject. Confirm the card does not show Logged, the inline error is announced, the inputs remain intact, and retry can succeed.
4. Start saves from two cardio cards before either resolves. Confirm Finish stays blocked until both have settled.
5. Attempt Finish and Log Cardio in the same rapid interaction window. Confirm only the operation that acquired the gate first proceeds.
6. Reload an in-progress workout with an existing cardio entry. Confirm the card displays the persisted duration, distance, RPE, and vest weight.

## Checklist

- [x] I have tested this locally
- [x] `bun run lint` passes
- [x] I have updated docs if needed (no user-facing docs change required)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/house-of-giants/codesmith/opentrainer/pr/46"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787255414&installation_model_id=19704&pr_number=46&repository=house-of-giants%2Fopentrainer&return_to=https%3A%2F%2Fgithub.com%2Fhouse-of-giants%2Fopentrainer%2Fpull%2F46&signature=d5e6f7e689151434b34e4052f6f7920f5792f98a116bd792106aaff84c96a393"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->