### PR TITLE
feat(updates): notify users about new deployments

### DIFF
--- a/docs/version-update-notice.md
+++ b/docs/version-update-notice.md
@@ -9,9 +9,10 @@ The client checks on mount, every five minutes, and after reconnecting, focusing
 or returning to a visible tab. Successful checks are shared across tabs for one
 minute. Failures are silent and do not advance the retry clock. The notice never
 reloads the page automatically; the user chooses Refresh or Later, including
-during an active workout. Later is stored against only the detected release for
-24 hours. The same release can remind the user after that window, and a subsequent
-deployment can notify immediately.
+during an active workout. Later is stored in a separate key for each detected
+release for 24 hours, so tabs tracking different releases cannot overwrite each
+other's dismissal. The same release can remind the user after that window, and a
+subsequent deployment can notify immediately.
 
 ## Why the signal does not use Convex
 

--- a/docs/version-update-notice.md
+++ b/docs/version-update-notice.md
@@ -1,0 +1,61 @@
+# Version update notice
+
+OpenTrainer detects new production frontend deployments without a manual release
+marker. Each production build embeds Vercel's `VERCEL_DEPLOYMENT_ID`, while an
+uncached `/api/version` route reads the deployment ID currently serving the
+production alias. A mismatch means the open tab is running an older deployment.
+
+The client checks on mount, every five minutes, and after reconnecting, focusing,
+or returning to a visible tab. Successful checks are shared across tabs for one
+minute. Failures are silent and do not advance the retry clock. The notice never
+reloads the page automatically; the user chooses Refresh or Later, including
+during an active workout. Later is stored against only the detected release for
+24 hours. The same release can remind the user after that window, and a subsequent
+deployment can notify immediately.
+
+## Why the signal does not use Convex
+
+[Convex queries are automatically realtime](https://docs.convex.dev/realtime),
+so a singleton release record would deliver changes quickly. However, deploying
+Convex functions does not itself mutate that record. The Vercel build would need
+an authenticated post-deploy mutation with rollback, preview isolation, and
+deployment-order handling. That is more operational state than this signal needs.
+
+Vercel already supplies a unique deployment ID at build and runtime. A small
+same-origin endpoint therefore makes release publication automatic with no
+database writes. Custom `fetch()` calls are not pinned by Vercel Skew Protection
+unless the application adds a deployment header or query parameter, so the
+version request intentionally adds neither and resolves against the current
+production alias. See [Vercel Skew Protection](https://vercel.com/docs/skew-protection).
+
+## Vercel configuration
+
+As a one-time project setting, open Project Settings > Environment Variables and
+enable **Automatically expose System Environment Variables**. This makes
+`VERCEL_DEPLOYMENT_ID` and `VERCEL_ENV` available during the build and at
+runtime. Vercel documents both variables in [System environment
+variables](https://vercel.com/docs/environment-variables/system-environment-variables).
+
+If the setting is absent or either identifier is missing, detection fails closed:
+the client makes no comparison and shows no notice.
+
+No Convex schema, environment variable, release mutation, or deployment hook is
+required. Preview and development builds intentionally embed no release ID, so
+they never show production mismatch notices.
+
+## Synthetic verification
+
+Build an old client and start its dynamic route with a different current ID:
+
+```sh
+VERCEL_ENV=production VERCEL_DEPLOYMENT_ID=release-a bun run build
+VERCEL_ENV=production VERCEL_DEPLOYMENT_ID=release-b bun run start
+```
+
+Open the local app and confirm that the notice appears. Start with `release-a`
+again to confirm equality stays silent. Use Later, then restart with `release-c`
+to confirm dismissal is scoped to only `release-b`.
+
+The endpoint sends browser and CDN `no-store` headers. Do not add an
+`x-deployment-id` header or `dpl` query parameter to its fetch: those would pin
+the request to the old deployment and prevent detection.

--- a/next.config.ts
+++ b/next.config.ts
@@ -1,6 +1,14 @@
 import type { NextConfig } from "next";
 
+const clientReleaseId =
+  process.env.VERCEL_ENV === "production"
+    ? (process.env.VERCEL_DEPLOYMENT_ID ?? "")
+    : "";
+
 const nextConfig: NextConfig = {
+  env: {
+    NEXT_PUBLIC_OPENTRAINER_RELEASE_ID: clientReleaseId,
+  },
   /* config options here */
   async rewrites() {
     return [

--- a/src/app/api/version/route.ts
+++ b/src/app/api/version/route.ts
@@ -1,0 +1,19 @@
+import { NextResponse } from "next/server";
+
+export const dynamic = "force-dynamic";
+
+const NO_STORE_HEADERS = {
+	"Cache-Control": "private, no-store, max-age=0, must-revalidate",
+	"CDN-Cache-Control": "no-store",
+	"Vercel-CDN-Cache-Control": "no-store",
+	"X-Robots-Tag": "noindex, nofollow",
+};
+
+export function GET() {
+	const releaseId =
+		process.env.VERCEL_ENV === "production"
+			? (process.env.VERCEL_DEPLOYMENT_ID ?? null)
+			: null;
+
+	return NextResponse.json({ releaseId }, { headers: NO_STORE_HEADERS });
+}

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -4,6 +4,7 @@ import "./globals.css";
 import { ConvexClientProvider } from "@/components/providers/convex-client-provider";
 import { ThemeProvider } from "@/components/providers/theme-provider";
 import { Toaster } from "@/components/ui/sonner";
+import { VersionUpdateNotice } from "@/components/version-update-notice";
 import PlausibleProvider from "next-plausible";
 
 const geistSans = Geist({
@@ -73,6 +74,7 @@ export default function RootLayout({
 							{children}
 							<Toaster position="top-center" richColors />
 						</ConvexClientProvider>
+						<VersionUpdateNotice />
 					</PlausibleProvider>
 				</ThemeProvider>
 			</body>

--- a/src/components/version-update-notice.tsx
+++ b/src/components/version-update-notice.tsx
@@ -1,0 +1,226 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { usePathname } from "next/navigation";
+import { RefreshCw } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import {
+	getActiveDismissedReleaseId,
+	getReleaseStatus,
+	normalizeReleaseId,
+	parseStoredReleaseCheck,
+	shouldCheckForRelease,
+} from "@/lib/release-version";
+
+const CURRENT_RELEASE_ID = normalizeReleaseId(
+	process.env.NEXT_PUBLIC_OPENTRAINER_RELEASE_ID
+);
+const CHECK_INTERVAL_MS = 5 * 60 * 1000;
+const MINIMUM_RECHECK_MS = 60 * 1000;
+const REQUEST_TIMEOUT_MS = 10 * 1000;
+const DISMISSAL_DURATION_MS = 24 * 60 * 60 * 1000;
+const DISMISSED_RELEASE_KEY = "opentrainer:dismissed-release";
+const RELEASE_CHECK_KEY = CURRENT_RELEASE_ID
+	? `opentrainer:release-check:${CURRENT_RELEASE_ID}`
+	: null;
+
+function readStorage(key: string): string | null {
+	try {
+		return window.localStorage.getItem(key);
+	} catch {
+		return null;
+	}
+}
+
+function writeStorage(key: string, value: string) {
+	try {
+		window.localStorage.setItem(key, value);
+	} catch {
+		// Storage can be unavailable in private or restricted browsing contexts.
+	}
+}
+
+function readLatestRelease(payload: unknown): string | null {
+	if (!payload || typeof payload !== "object") return null;
+	return normalizeReleaseId(
+		(payload as { releaseId?: string | null }).releaseId
+	);
+}
+
+export function VersionUpdateNotice() {
+	const pathname = usePathname();
+	const [availableReleaseId, setAvailableReleaseId] = useState<string | null>(
+		null
+	);
+
+	useEffect(() => {
+		if (!CURRENT_RELEASE_ID || !RELEASE_CHECK_KEY) return;
+
+		let latestReleaseId: string | null = null;
+		let requestController: AbortController | null = null;
+		let requestTimeout: number | null = null;
+		let stopped = false;
+
+		const updateNotice = (releaseId: string) => {
+			latestReleaseId = releaseId;
+			const dismissedReleaseId = getActiveDismissedReleaseId({
+				value: readStorage(DISMISSED_RELEASE_KEY),
+				now: Date.now(),
+				maximumAgeMs: DISMISSAL_DURATION_MS,
+			});
+			const status = getReleaseStatus({
+				currentReleaseId: CURRENT_RELEASE_ID,
+				latestReleaseId: releaseId,
+				dismissedReleaseId,
+			});
+			setAvailableReleaseId(status === "available" ? releaseId : null);
+		};
+
+		const checkForRelease = async () => {
+			if (stopped || requestController) return;
+
+			const cachedCheck = parseStoredReleaseCheck(
+				readStorage(RELEASE_CHECK_KEY)
+			);
+			const now = Date.now();
+			const shouldCheck = shouldCheckForRelease({
+				now,
+				lastCheckedAt: cachedCheck?.checkedAt ?? null,
+				minimumIntervalMs: MINIMUM_RECHECK_MS,
+				isOnline: navigator.onLine,
+				isVisible: document.visibilityState === "visible",
+			});
+
+			if (!shouldCheck) {
+				if (cachedCheck) updateNotice(cachedCheck.releaseId);
+				return;
+			}
+
+			requestController = new AbortController();
+			requestTimeout = window.setTimeout(
+				() => requestController?.abort(),
+				REQUEST_TIMEOUT_MS
+			);
+
+			try {
+				const response = await fetch(`/api/version?t=${now}`, {
+					cache: "no-store",
+					headers: { Accept: "application/json" },
+					signal: requestController.signal,
+				});
+				if (!response.ok) return;
+
+				const releaseId = readLatestRelease(await response.json());
+				if (!releaseId || stopped) return;
+
+				writeStorage(
+					RELEASE_CHECK_KEY,
+					JSON.stringify({ releaseId, checkedAt: Date.now() })
+				);
+				updateNotice(releaseId);
+			} catch {
+				// A version check should never interrupt the user when offline or blocked.
+			} finally {
+				if (requestTimeout !== null) window.clearTimeout(requestTimeout);
+				requestTimeout = null;
+				requestController = null;
+			}
+		};
+
+		const handleVisibilityChange = () => {
+			if (document.visibilityState === "visible") void checkForRelease();
+		};
+		const handleStorage = (event: StorageEvent) => {
+			if (event.key === RELEASE_CHECK_KEY) {
+				const storedCheck = parseStoredReleaseCheck(event.newValue);
+				if (storedCheck) updateNotice(storedCheck.releaseId);
+			}
+			if (event.key === DISMISSED_RELEASE_KEY && latestReleaseId) {
+				updateNotice(latestReleaseId);
+			}
+		};
+
+		void checkForRelease();
+		const interval = window.setInterval(
+			() => void checkForRelease(),
+			CHECK_INTERVAL_MS
+		);
+		window.addEventListener("focus", checkForRelease);
+		window.addEventListener("online", checkForRelease);
+		window.addEventListener("storage", handleStorage);
+		document.addEventListener("visibilitychange", handleVisibilityChange);
+
+		return () => {
+			stopped = true;
+			window.clearInterval(interval);
+			if (requestTimeout !== null) window.clearTimeout(requestTimeout);
+			requestController?.abort();
+			window.removeEventListener("focus", checkForRelease);
+			window.removeEventListener("online", checkForRelease);
+			window.removeEventListener("storage", handleStorage);
+			document.removeEventListener("visibilitychange", handleVisibilityChange);
+		};
+	}, []);
+
+	const isActiveWorkout = pathname.startsWith("/workout/active");
+	const handleDismiss = () => {
+		if (!availableReleaseId) return;
+		writeStorage(
+			DISMISSED_RELEASE_KEY,
+			JSON.stringify({
+				releaseId: availableReleaseId,
+				dismissedAt: Date.now(),
+			})
+		);
+		setAvailableReleaseId(null);
+	};
+
+	return (
+		<div
+			role="status"
+			aria-live="polite"
+			aria-atomic="true"
+			className="pointer-events-none fixed inset-x-0 z-50 flex justify-center px-3"
+			style={{
+				top: "max(0.75rem, env(safe-area-inset-top))",
+				paddingLeft: "max(0.75rem, env(safe-area-inset-left))",
+				paddingRight: "max(0.75rem, env(safe-area-inset-right))",
+			}}
+		>
+			{availableReleaseId && (
+				<div className="pointer-events-auto flex w-full max-w-lg flex-col gap-3 rounded-xl border bg-popover p-3 text-popover-foreground shadow-lg motion-safe:animate-in motion-safe:fade-in motion-safe:slide-in-from-top-2 motion-safe:duration-200 sm:flex-row sm:items-center">
+					<div className="flex min-w-0 flex-1 items-start gap-3">
+						<div className="mt-0.5 flex size-8 shrink-0 items-center justify-center rounded-full bg-primary/10 text-primary">
+							<RefreshCw className="size-4" aria-hidden="true" />
+						</div>
+						<div className="min-w-0">
+							<p className="text-sm font-semibold">New version available</p>
+							<p className="text-sm text-muted-foreground">
+								Refresh to get the latest OpenTrainer updates.
+								{isActiveWorkout &&
+									" Your workout will not refresh automatically."}
+							</p>
+						</div>
+					</div>
+					<div className="flex shrink-0 items-center justify-end gap-1">
+						<Button
+							type="button"
+							variant="ghost"
+							className="h-11 px-3 sm:h-9"
+							onClick={handleDismiss}
+						>
+							Later
+						</Button>
+						<Button
+							type="button"
+							className="h-11 px-4 sm:h-9"
+							onClick={() => window.location.reload()}
+						>
+							Refresh
+						</Button>
+					</div>
+				</div>
+			)}
+		</div>
+	);
+}

--- a/src/components/version-update-notice.tsx
+++ b/src/components/version-update-notice.tsx
@@ -6,6 +6,7 @@ import { RefreshCw } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import {
 	getActiveDismissedReleaseId,
+	getDismissedReleaseStorageKey,
 	getReleaseStatus,
 	normalizeReleaseId,
 	parseStoredReleaseCheck,
@@ -19,7 +20,6 @@ const CHECK_INTERVAL_MS = 5 * 60 * 1000;
 const MINIMUM_RECHECK_MS = 60 * 1000;
 const REQUEST_TIMEOUT_MS = 10 * 1000;
 const DISMISSAL_DURATION_MS = 24 * 60 * 60 * 1000;
-const DISMISSED_RELEASE_KEY = "opentrainer:dismissed-release";
 const RELEASE_CHECK_KEY = CURRENT_RELEASE_ID
 	? `opentrainer:release-check:${CURRENT_RELEASE_ID}`
 	: null;
@@ -63,8 +63,9 @@ export function VersionUpdateNotice() {
 
 		const updateNotice = (releaseId: string) => {
 			latestReleaseId = releaseId;
+			const dismissalKey = getDismissedReleaseStorageKey(releaseId);
 			const dismissedReleaseId = getActiveDismissedReleaseId({
-				value: readStorage(DISMISSED_RELEASE_KEY),
+				value: dismissalKey ? readStorage(dismissalKey) : null,
 				now: Date.now(),
 				maximumAgeMs: DISMISSAL_DURATION_MS,
 			});
@@ -135,7 +136,10 @@ export function VersionUpdateNotice() {
 				const storedCheck = parseStoredReleaseCheck(event.newValue);
 				if (storedCheck) updateNotice(storedCheck.releaseId);
 			}
-			if (event.key === DISMISSED_RELEASE_KEY && latestReleaseId) {
+			if (
+				latestReleaseId &&
+				event.key === getDismissedReleaseStorageKey(latestReleaseId)
+			) {
 				updateNotice(latestReleaseId);
 			}
 		};
@@ -165,8 +169,10 @@ export function VersionUpdateNotice() {
 	const isActiveWorkout = pathname.startsWith("/workout/active");
 	const handleDismiss = () => {
 		if (!availableReleaseId) return;
+		const dismissalKey = getDismissedReleaseStorageKey(availableReleaseId);
+		if (!dismissalKey) return;
 		writeStorage(
-			DISMISSED_RELEASE_KEY,
+			dismissalKey,
 			JSON.stringify({
 				releaseId: availableReleaseId,
 				dismissedAt: Date.now(),

--- a/src/lib/release-version.test.ts
+++ b/src/lib/release-version.test.ts
@@ -1,0 +1,178 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import {
+	getActiveDismissedReleaseId,
+	getReleaseStatus,
+	parseStoredReleaseCheck,
+	shouldCheckForRelease,
+} from "./release-version";
+
+describe("getReleaseStatus", () => {
+	test("does not compare missing release identifiers", () => {
+		assert.equal(
+			getReleaseStatus({
+				currentReleaseId: null,
+				latestReleaseId: "release-b",
+			}),
+			"unavailable"
+		);
+		assert.equal(
+			getReleaseStatus({
+				currentReleaseId: "release-a",
+				latestReleaseId: " ",
+			}),
+			"unavailable"
+		);
+	});
+
+	test("recognizes the current release", () => {
+		assert.equal(
+			getReleaseStatus({
+				currentReleaseId: "release-a",
+				latestReleaseId: "release-a",
+			}),
+			"current"
+		);
+	});
+
+	test("recognizes a different current production release", () => {
+		assert.equal(
+			getReleaseStatus({
+				currentReleaseId: "release-a",
+				latestReleaseId: "release-b",
+			}),
+			"available"
+		);
+	});
+
+	test("scopes dismissal to one release", () => {
+		assert.equal(
+			getReleaseStatus({
+				currentReleaseId: "release-a",
+				latestReleaseId: "release-b",
+				dismissedReleaseId: "release-b",
+			}),
+			"dismissed"
+		);
+		assert.equal(
+			getReleaseStatus({
+				currentReleaseId: "release-a",
+				latestReleaseId: "release-c",
+				dismissedReleaseId: "release-b",
+			}),
+			"available"
+		);
+	});
+});
+
+describe("shouldCheckForRelease", () => {
+	const baseInput = {
+		now: 120_000,
+		lastCheckedAt: 60_000,
+		minimumIntervalMs: 60_000,
+		isOnline: true,
+		isVisible: true,
+	};
+
+	test("checks at the scheduling boundary", () => {
+		assert.equal(shouldCheckForRelease(baseInput), true);
+		assert.equal(
+			shouldCheckForRelease({ ...baseInput, lastCheckedAt: 60_001 }),
+			false
+		);
+	});
+
+	test("waits while offline or hidden", () => {
+		assert.equal(
+			shouldCheckForRelease({ ...baseInput, isOnline: false }),
+			false
+		);
+		assert.equal(
+			shouldCheckForRelease({ ...baseInput, isVisible: false }),
+			false
+		);
+	});
+
+	test("retries when no valid successful check exists", () => {
+		assert.equal(
+			shouldCheckForRelease({ ...baseInput, lastCheckedAt: null }),
+			true
+		);
+		assert.equal(
+			shouldCheckForRelease({ ...baseInput, lastCheckedAt: Number.NaN }),
+			true
+		);
+		assert.equal(
+			shouldCheckForRelease({ ...baseInput, lastCheckedAt: 180_000 }),
+			true
+		);
+	});
+});
+
+describe("parseStoredReleaseCheck", () => {
+	test("accepts valid shared check results", () => {
+		assert.deepEqual(
+			parseStoredReleaseCheck(
+				JSON.stringify({ releaseId: "release-b", checkedAt: 123 })
+			),
+			{ releaseId: "release-b", checkedAt: 123 }
+		);
+	});
+
+	test("rejects missing and malformed check results", () => {
+		assert.equal(parseStoredReleaseCheck(null), null);
+		assert.equal(parseStoredReleaseCheck("not json"), null);
+		assert.equal(
+			parseStoredReleaseCheck(JSON.stringify({ releaseId: "", checkedAt: 123 })),
+			null
+		);
+	});
+});
+
+describe("getActiveDismissedReleaseId", () => {
+	const dismissal = JSON.stringify({
+		releaseId: "release-b",
+		dismissedAt: 1_000,
+	});
+
+	test("returns a release while its reminder window is active", () => {
+		assert.equal(
+			getActiveDismissedReleaseId({
+				value: dismissal,
+				now: 1_999,
+				maximumAgeMs: 1_000,
+			}),
+			"release-b"
+		);
+	});
+
+	test("expires a dismissal at the reminder boundary", () => {
+		assert.equal(
+			getActiveDismissedReleaseId({
+				value: dismissal,
+				now: 2_000,
+				maximumAgeMs: 1_000,
+			}),
+			null
+		);
+	});
+
+	test("rejects malformed and future dismissals", () => {
+		assert.equal(
+			getActiveDismissedReleaseId({
+				value: "not json",
+				now: 1_500,
+				maximumAgeMs: 1_000,
+			}),
+			null
+		);
+		assert.equal(
+			getActiveDismissedReleaseId({
+				value: dismissal,
+				now: 999,
+				maximumAgeMs: 1_000,
+			}),
+			null
+		);
+	});
+});

--- a/src/lib/release-version.test.ts
+++ b/src/lib/release-version.test.ts
@@ -2,10 +2,36 @@ import assert from "node:assert/strict";
 import { describe, test } from "node:test";
 import {
 	getActiveDismissedReleaseId,
+	getDismissedReleaseStorageKey,
 	getReleaseStatus,
 	parseStoredReleaseCheck,
 	shouldCheckForRelease,
 } from "./release-version";
+
+describe("getDismissedReleaseStorageKey", () => {
+	test("gives each release an independent dismissal slot", () => {
+		assert.equal(
+			getDismissedReleaseStorageKey("release-b"),
+			"opentrainer:dismissed-release:release-b"
+		);
+		assert.equal(
+			getDismissedReleaseStorageKey("release-c"),
+			"opentrainer:dismissed-release:release-c"
+		);
+		assert.notEqual(
+			getDismissedReleaseStorageKey("release-b"),
+			getDismissedReleaseStorageKey("release-c")
+		);
+	});
+
+	test("normalizes valid identifiers and rejects missing identifiers", () => {
+		assert.equal(
+			getDismissedReleaseStorageKey(" release/b "),
+			"opentrainer:dismissed-release:release%2Fb"
+		);
+		assert.equal(getDismissedReleaseStorageKey(" "), null);
+	});
+});
 
 describe("getReleaseStatus", () => {
 	test("does not compare missing release identifiers", () => {

--- a/src/lib/release-version.ts
+++ b/src/lib/release-version.ts
@@ -28,11 +28,22 @@ export interface StoredReleaseDismissal {
 	dismissedAt: number;
 }
 
+const DISMISSED_RELEASE_KEY_PREFIX = "opentrainer:dismissed-release";
+
 export function normalizeReleaseId(
 	releaseId: string | null | undefined
 ): string | null {
 	const normalized = releaseId?.trim();
 	return normalized ? normalized : null;
+}
+
+export function getDismissedReleaseStorageKey(
+	releaseId: string | null | undefined
+): string | null {
+	const normalized = normalizeReleaseId(releaseId);
+	return normalized
+		? `${DISMISSED_RELEASE_KEY_PREFIX}:${encodeURIComponent(normalized)}`
+		: null;
 }
 
 export function getReleaseStatus({

--- a/src/lib/release-version.ts
+++ b/src/lib/release-version.ts
@@ -1,0 +1,114 @@
+export type ReleaseStatus =
+	| "unavailable"
+	| "current"
+	| "dismissed"
+	| "available";
+
+interface ReleaseStatusInput {
+	currentReleaseId: string | null | undefined;
+	latestReleaseId: string | null | undefined;
+	dismissedReleaseId?: string | null;
+}
+
+interface ReleaseCheckInput {
+	now: number;
+	lastCheckedAt: number | null;
+	minimumIntervalMs: number;
+	isOnline: boolean;
+	isVisible: boolean;
+}
+
+export interface StoredReleaseCheck {
+	releaseId: string;
+	checkedAt: number;
+}
+
+export interface StoredReleaseDismissal {
+	releaseId: string;
+	dismissedAt: number;
+}
+
+export function normalizeReleaseId(
+	releaseId: string | null | undefined
+): string | null {
+	const normalized = releaseId?.trim();
+	return normalized ? normalized : null;
+}
+
+export function getReleaseStatus({
+	currentReleaseId,
+	latestReleaseId,
+	dismissedReleaseId,
+}: ReleaseStatusInput): ReleaseStatus {
+	const current = normalizeReleaseId(currentReleaseId);
+	const latest = normalizeReleaseId(latestReleaseId);
+	const dismissed = normalizeReleaseId(dismissedReleaseId);
+
+	if (!current || !latest) return "unavailable";
+	if (current === latest) return "current";
+	if (latest === dismissed) return "dismissed";
+	return "available";
+}
+
+export function shouldCheckForRelease({
+	now,
+	lastCheckedAt,
+	minimumIntervalMs,
+	isOnline,
+	isVisible,
+}: ReleaseCheckInput): boolean {
+	if (!isOnline || !isVisible) return false;
+	if (lastCheckedAt === null || !Number.isFinite(lastCheckedAt)) return true;
+
+	const elapsed = now - lastCheckedAt;
+	if (elapsed < 0) return true;
+
+	return elapsed >= Math.max(0, minimumIntervalMs);
+}
+
+export function parseStoredReleaseCheck(
+	value: string | null
+): StoredReleaseCheck | null {
+	if (!value) return null;
+
+	try {
+		const parsed: unknown = JSON.parse(value);
+		if (!parsed || typeof parsed !== "object") return null;
+
+		const candidate = parsed as Partial<StoredReleaseCheck>;
+		const releaseId = normalizeReleaseId(candidate.releaseId);
+		if (!releaseId || !Number.isFinite(candidate.checkedAt)) return null;
+
+		return { releaseId, checkedAt: candidate.checkedAt as number };
+	} catch {
+		return null;
+	}
+}
+
+export function getActiveDismissedReleaseId({
+	value,
+	now,
+	maximumAgeMs,
+}: {
+	value: string | null;
+	now: number;
+	maximumAgeMs: number;
+}): string | null {
+	if (!value) return null;
+
+	try {
+		const parsed: unknown = JSON.parse(value);
+		if (!parsed || typeof parsed !== "object") return null;
+
+		const candidate = parsed as Partial<StoredReleaseDismissal>;
+		const releaseId = normalizeReleaseId(candidate.releaseId);
+		if (!releaseId || !Number.isFinite(candidate.dismissedAt)) return null;
+
+		const elapsed = now - (candidate.dismissedAt as number);
+		if (elapsed < 0 || elapsed >= Math.max(0, maximumAgeMs)) return null;
+
+		return releaseId;
+	} catch {
+		return null;
+	}
+}

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -5,6 +5,7 @@ const isPublicRoute = createRouteMatcher([
   "/sign-in(.*)",
   "/sign-up(.*)",
   "/api/webhooks(.*)",
+  "/api/version",
   "/manifest.json",
   "/privacy",
   "/terms",


### PR DESCRIPTION
## What does this PR do?

Adds an automatic, persistent in-app notice when an open production tab is running an older OpenTrainer deployment.

### Architecture decision

- Each production client build embeds the Vercel-provided `VERCEL_DEPLOYMENT_ID`.
- A public, dynamic `/api/version` route returns the deployment ID currently serving the production alias with browser and CDN `no-store` headers.
- The old client compares those identifiers on mount, every five minutes, and after focus, visibility, or online events. Successful checks are shared across same-release tabs for one minute.
- Missing IDs fail closed. Development and preview builds intentionally embed no release ID, so they make no request and cannot produce production mismatch noise.

Convex queries would distribute a singleton release record in realtime, but a deployment does not automatically mutate that record. That approach would require an authenticated post-deploy write plus ordering, rollback, and preview-isolation logic. The Vercel ID is already generated at build and runtime, so release publication is automatic and requires no production data mutation or release hook.

### UX behavior

- Shows one compact, persistent, safe-area-aware notice with polite live-region semantics.
- Provides explicit Refresh and Later controls with mobile touch targets and keyboard focus behavior.
- Never reloads automatically, including during active workouts; active workouts get additional reassurance in the copy.
- Later is scoped to the detected release for 24 hours. The same stale tab is reminded after that window, while a different release can notify immediately.
- Offline and failed checks stay silent and retry after reconnect or the next scheduled/visibility check.
- Uses reduced-motion-safe entry styling and the existing OpenTrainer tokens/components.

### Deployment automation and compatibility

One-time Vercel project setting is required: enable **Automatically expose System Environment Variables**. Vercel then supplies `VERCEL_ENV` and `VERCEL_DEPLOYMENT_ID` at build and runtime for every deployment. No Convex schema, environment variable, database write, or deploy hook is required.

The custom version fetch intentionally does not include a skew-protection deployment header or `dpl` query parameter; adding either would pin it to the old deployment and prevent detection. The endpoint exposes only Vercel's opaque deployment identifier, which is not a secret.

Residual risk: detection is polling-based, so a continuously visible tab can take up to five minutes to see a new deployment. If the one-time Vercel setting is disabled, the feature remains silent rather than showing a false update.

## Related issue

N/A

## How to test

Automated checks:

- [x] `bun test src/lib/release-version.test.ts` — 12 passed
- [x] `bunx tsc --noEmit`
- [x] `bun run lint` — 0 errors, 7 pre-existing warnings
- [x] `bun run build`
- [x] `git diff --check`

Synthetic two-version verification completed locally:

1. Build the old client: `VERCEL_ENV=production VERCEL_DEPLOYMENT_ID=release-a bun run build`.
2. Start the dynamic route as the new deployment: `VERCEL_ENV=production VERCEL_DEPLOYMENT_ID=release-b bun run start`.
3. Confirm `/api/version` returns `release-b` with all no-store headers while the static client bundle contains `release-a` and not `release-b`.
4. Start with matching IDs or omit the IDs to confirm the notice stays hidden.
5. Choose Later, then verify release C can notify immediately and release B can remind after the bounded dismissal window.

## Checklist

- [x] I've tested this locally
- [x] `bun run lint` passes with no errors
- [x] I've updated docs

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/house-of-giants/codesmith/opentrainer/pr/47"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787256612&installation_model_id=19704&pr_number=47&repository=house-of-giants%2Fopentrainer&return_to=https%3A%2F%2Fgithub.com%2Fhouse-of-giants%2Fopentrainer%2Fpull%2F47&signature=cf0275687eac9207f7a14febf8e9304539ce9e8a2feedd110837a908faf937ee"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic detection of new app releases.
  * Displays a dismissible “New version available” notice with options to refresh immediately or later.
  * Checks for updates when opening the app, periodically, and after reconnecting or returning to the tab.
  * Shares successful update checks across browser tabs.

* **Documentation**
  * Added guidance for release detection configuration and verification.

* **Tests**
  * Added coverage for release detection, scheduling, dismissal, and stored update data validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->