### PR TITLE
chore(release): ship reviewed feedback fixes

### DIFF
--- a/convex/ai/aggregators.ts
+++ b/convex/ai/aggregators.ts
@@ -962,7 +962,7 @@ export const getExerciseContext = internalQuery({
       .take(9);
 
     const recentSessions = recentEntries
-      .filter((e) => e.kind === "lifting" && e.lifting)
+      .filter((e) => e.kind === "lifting" && e.lifting && e.lifting.durationSeconds === undefined)
       .slice(0, 3)
       .map((e) => ({
         wt: e.lifting!.weight ?? 0,

--- a/convex/ai/aggregators.ts
+++ b/convex/ai/aggregators.ts
@@ -1,6 +1,7 @@
 import { v } from "convex/values";
 import { internalQuery } from "../_generated/server";
 import type { Id, Doc } from "../_generated/dataModel";
+import { getMondayWeekKey, getMondayWeekStartUtc, WEEK_IN_MS } from "../lib/week";
 
 const MODALITY_METS: Record<string, number> = {
   run: 9.8,
@@ -164,11 +165,12 @@ export const aggregateWorkoutData = internalQuery({
   args: {
     userId: v.id("users"),
     days: v.number(),
+    periodStart: v.optional(v.number()),
     includeHistoricalContext: v.optional(v.boolean()),
   },
   handler: async (ctx, args): Promise<AggregatedWorkoutData> => {
     const now = Date.now();
-    const periodStart = now - args.days * 24 * 60 * 60 * 1000;
+    const periodStart = args.periodStart ?? now - args.days * 24 * 60 * 60 * 1000;
 
     const workouts = await ctx.db
       .query("workouts")
@@ -364,7 +366,7 @@ function computeConsistency(
 
   const weeklyWorkouts = new Map<string, number>();
   for (const workout of workouts) {
-    const weekKey = getWeekStart(workout.startedAt);
+    const weekKey = getMondayWeekKey(workout.startedAt);
     weeklyWorkouts.set(weekKey, (weeklyWorkouts.get(weekKey) ?? 0) + 1);
   }
 
@@ -377,16 +379,16 @@ function computeConsistency(
   let longestStreak = 0;
   let tempStreak = 0;
 
-  const now = new Date();
-  const currentWeek = getWeekStart(now.getTime());
-  const lastWeek = getWeekStart(now.getTime() - 7 * 24 * 60 * 60 * 1000);
+  const now = Date.now();
+  const currentWeekStart = getMondayWeekStartUtc(now);
+  const currentWeek = getMondayWeekKey(now);
+  const lastWeek = getMondayWeekKey(currentWeekStart - WEEK_IN_MS);
 
   const allWeeks: string[] = [];
   if (weeks.length > 0) {
-    const startDate = new Date(weeks[0]);
-    const endDate = new Date(currentWeek);
-    for (let d = startDate; d <= endDate; d.setDate(d.getDate() + 7)) {
-      allWeeks.push(getWeekStart(d.getTime()));
+    const firstWeekStart = Date.parse(`${weeks[0]}T00:00:00.000Z`);
+    for (let weekStart = firstWeekStart; weekStart <= currentWeekStart; weekStart += WEEK_IN_MS) {
+      allWeeks.push(getMondayWeekKey(weekStart));
     }
   }
 
@@ -524,7 +526,7 @@ function aggregateVolumeByMuscleOverTime(
     const workoutDate = workoutDateMap.get(entry.workoutId);
     if (!workoutDate) continue;
 
-    const weekStart = getWeekStart(workoutDate);
+    const weekStart = getMondayWeekKey(workoutDate);
     const exercise = exerciseMap.get(entry.exerciseName);
     const muscleGroups = exercise?.muscleGroups ?? ["other"];
 
@@ -917,14 +919,6 @@ function calculateTrend(
   if (percentChange > 5) return "up";
   if (percentChange < -5) return "down";
   return "flat";
-}
-
-function getWeekStart(timestamp: number): string {
-  const date = new Date(timestamp);
-  const dayOfWeek = date.getDay();
-  date.setDate(date.getDate() - dayOfWeek);
-  date.setHours(0, 0, 0, 0);
-  return date.toISOString().split("T")[0];
 }
 
 export const getLastAssessmentSummary = internalQuery({

--- a/convex/ai/prompts.ts
+++ b/convex/ai/prompts.ts
@@ -211,7 +211,9 @@ SCHEMA:
       "reasoning": "string (1-2 sentences explaining biomechanical similarity)",
       "equipmentNeeded": ["string"],
       "muscleEmphasis": "string (how stimulus compares to original)",
-      "difficultyAdjustment": "easier|similar|harder"
+      "difficultyAdjustment": "easier|similar|harder",
+      "measurementType": "reps|duration",
+      "targetHoldSeconds": "number|null (required for timed holds)"
     }
   ],
   "note": "string|null (optional insight about the swap pattern)"
@@ -230,6 +232,7 @@ GUIDELINES:
 5. Consider the user's recent training volume to identify potential imbalances.
 6. Order alternatives from most to least recommended.
 7. Keep reasoning concise but informative.
+8. Use measurementType "duration" and targetHoldSeconds for timed isometric holds.
 
 MOVEMENT PATTERN MATCHING:
 - Horizontal push → horizontal push (bench → push-up, dumbbell press)
@@ -250,7 +253,9 @@ SCHEMA:
       "exercise": "string (standard exercise name)",
       "reasoning": "string (1-2 sentences explaining why this is a good substitute)",
       "equipmentNeeded": ["string"],
-      "difficultyAdjustment": "easier|similar|harder"
+      "difficultyAdjustment": "easier|similar|harder",
+      "measurementType": "reps|duration",
+      "targetHoldSeconds": "number|null (required for timed holds)"
     }
   ]
 }
@@ -267,6 +272,7 @@ GUIDELINES:
 4. Consider the routine context (other exercises in the same day) to avoid redundancy.
 5. Order alternatives from most to least recommended.
 6. Keep reasoning concise.
+7. Use measurementType "duration" and targetHoldSeconds for timed isometric holds.
 
 COMMON EXERCISE NAMES (use these exact names):
 - Chest: Bench Press, Incline Bench Press, Dumbbell Bench Press, Push Up, Cable Fly, Dumbbell Fly, Machine Chest Press
@@ -330,6 +336,8 @@ SCHEMA:
           "kind": "lifting|cardio|mobility",
           "targetSets": number (typically 3-5 for lifting),
           "targetReps": "string (e.g., '8-12', '5x5', '3x8-10')",
+          "measurementType": "reps|duration (use duration for timed strength holds such as Plank)",
+          "targetHoldSeconds": "number|null (required when measurementType is duration)",
           "notes": "string|null (brief coaching cue or note)"
         }
       ]
@@ -372,6 +380,7 @@ PROGRAM DESIGN GUIDELINES:
    - Include both push and pull movements each session
    - For beginners: stick to basics, fewer exercises per session
    - For advanced: add variation and isolation work
+   - Use measurementType "duration" and targetHoldSeconds for timed isometric holds; do not prescribe reps for them
 
 4. GOAL-SPECIFIC ADJUSTMENTS:
    - Strength: Lower rep ranges (3-6), longer rest, compound focus

--- a/convex/ai/routineGenerator.ts
+++ b/convex/ai/routineGenerator.ts
@@ -13,6 +13,8 @@ export interface RoutineSwapAlternative {
   reasoning: string;
   equipmentNeeded: string[];
   difficultyAdjustment: "easier" | "similar" | "harder";
+  measurementType?: "reps" | "duration";
+  targetHoldSeconds?: number;
 }
 
 export interface RoutineSwapResponse {
@@ -29,6 +31,8 @@ export interface GeneratedRoutineDay {
     kind: "lifting" | "cardio" | "mobility";
     targetSets: number;
     targetReps: string;
+    measurementType?: "reps" | "duration";
+    targetHoldSeconds?: number;
     notes?: string;
   }>;
 }
@@ -199,6 +203,14 @@ export const generateRoutine = action({
         if (typeof exercise.targetReps !== "string") {
           exercise.targetReps = "8-12";
         }
+        if (exercise.measurementType === "duration") {
+          exercise.targetHoldSeconds =
+            typeof exercise.targetHoldSeconds === "number" && exercise.targetHoldSeconds > 0
+              ? Math.min(exercise.targetHoldSeconds, 3600)
+              : 30;
+        } else {
+          exercise.measurementType = "reps";
+        }
       }
     }
 
@@ -309,6 +321,15 @@ export const getRoutineSwapAlternatives = action({
       ) {
         logger.fail(new Error("Invalid alternative exercise name"));
         throw new Error("Invalid alternative exercise name");
+      }
+      if (alt.measurementType === "duration") {
+        alt.targetHoldSeconds =
+          typeof alt.targetHoldSeconds === "number" && alt.targetHoldSeconds > 0
+            ? Math.min(alt.targetHoldSeconds, 3600)
+            : 30;
+      } else {
+        alt.measurementType = "reps";
+        alt.targetHoldSeconds = undefined;
       }
     }
 

--- a/convex/ai/smartSwap.ts
+++ b/convex/ai/smartSwap.ts
@@ -16,6 +16,8 @@ export interface SmartSwapResponse {
     equipmentNeeded: string[];
     muscleEmphasis: string;
     difficultyAdjustment?: "easier" | "similar" | "harder";
+    measurementType?: "reps" | "duration";
+    targetHoldSeconds?: number;
   }>;
   note?: string;
   swapId?: Id<"exerciseSwaps">;
@@ -119,6 +121,18 @@ export const getAlternatives = action({
     });
 
     const result = JSON.parse(response.text) as SmartSwapResponse;
+
+    for (const alternative of result.alternatives) {
+      if (alternative.measurementType === "duration") {
+        alternative.targetHoldSeconds =
+          typeof alternative.targetHoldSeconds === "number" && alternative.targetHoldSeconds > 0
+            ? Math.min(alternative.targetHoldSeconds, 3600)
+            : 30;
+      } else {
+        alternative.measurementType = "reps";
+        alternative.targetHoldSeconds = undefined;
+      }
+    }
 
     const swapId = await ctx.runMutation((internal.ai as any).swapMutations.recordSwap, {
       userId: user._id,

--- a/convex/ai/trainingLab.ts
+++ b/convex/ai/trainingLab.ts
@@ -9,6 +9,7 @@ import type { Doc } from "../_generated/dataModel";
 import type { AggregatedWorkoutData } from "./aggregators";
 import type { TrainingLabReport, TrainingSnapshot } from "./trainingLabTypes";
 import { createConvexLogger, truncateId } from "../lib/logger";
+import { getMondayWeekStartUtc } from "../lib/week";
 
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
@@ -117,10 +118,16 @@ export const generateReport = action({
     reportType: v.union(v.literal("snapshot"), v.literal("full")),
   },
   handler: async (ctx, args): Promise<TrainingLabReport | TrainingSnapshot> => {
+    const periodDays = args.periodDays ?? 7;
+    const now = Date.now();
+    const periodStart =
+      periodDays === 7
+        ? getMondayWeekStartUtc(now)
+        : now - periodDays * 24 * 60 * 60 * 1000;
     const logger = createConvexLogger("ai.trainingLab.generateReport");
     logger.set({
       ai: { action: "trainingLabReport", model: "gemini" },
-      request: { reportType: args.reportType, periodDays: args.periodDays ?? 7 },
+      request: { reportType: args.reportType, periodDays },
     });
 
     const identity = await ctx.auth.getUserIdentity();
@@ -166,7 +173,8 @@ export const generateReport = action({
 
     const aggregated = (await ctx.runQuery(internal.ai.aggregators.aggregateWorkoutData, {
       userId: user._id,
-      days: args.periodDays ?? 7,
+      days: periodDays,
+      periodStart,
       includeHistoricalContext: true,
     })) as AggregatedWorkoutData;
 
@@ -176,7 +184,7 @@ export const generateReport = action({
       throw new Error("No workouts to analyze");
     }
 
-    logger.set({ data: { workoutCount, periodDays: args.periodDays ?? 7 } });
+    logger.set({ data: { workoutCount, periodDays } });
 
     const systemPrompt =
       args.reportType === "full" ? TRAINING_LAB_FULL_PROMPT : TRAINING_LAB_SNAPSHOT_PROMPT;

--- a/convex/ai/trainingLabMutations.ts
+++ b/convex/ai/trainingLabMutations.ts
@@ -2,6 +2,7 @@ import { v } from "convex/values";
 import { query, internalMutation } from "../_generated/server";
 import { getCurrentUser } from "../auth";
 import type { TrainingLabReport, TrainingSnapshot, TrainingLabCTAState, TrainingLabDashboardStats } from "./trainingLabTypes";
+import { getMondayWeekKey, getMondayWeekStartUtc, WEEK_IN_MS } from "../lib/week";
 
 export const storeAssessment = internalMutation({
   args: {
@@ -85,6 +86,8 @@ export const getCtaState = query({
     const totalWorkouts = allWorkouts.length;
     
     const now = Date.now();
+    const weekStart = getMondayWeekStartUtc(now);
+    const currentWeekWorkouts = allWorkouts.filter((w) => w.startedAt >= weekStart);
     const oldestWorkout = allWorkouts.length > 0 
       ? Math.min(...allWorkouts.map(w => w.startedAt))
       : now;
@@ -113,18 +116,20 @@ export const getCtaState = query({
     const hasReport = !!lastAssessment;
     const lastAssessmentDate = lastAssessment?.createdAt ?? 0;
 
-    const workoutsSince = allWorkouts.filter((w) => w.startedAt > lastAssessmentDate);
+    const workoutsSince = currentWeekWorkouts.filter((w) => w.startedAt > lastAssessmentDate);
     const count = workoutsSince.length;
 
-    const canGenerate = hasReport ? count > 0 : totalWorkouts > 0;
+    const canGenerate = hasReport ? count > 0 : currentWeekWorkouts.length > 0;
 
     let message: string;
     if (totalWorkouts === 0) {
       message = "Complete your first workout to unlock insights";
+    } else if (currentWeekWorkouts.length === 0) {
+      message = "Complete a workout this week to generate your analysis";
     } else if (!hasReport) {
-      message = totalWorkouts === 1
+      message = currentWeekWorkouts.length === 1
         ? "Your first analysis is ready"
-        : `${totalWorkouts} workouts logged. Generate your analysis`;
+        : `${currentWeekWorkouts.length} workouts this week. Generate your analysis`;
     } else if (count === 0) {
       message = "Log a workout to refresh your analysis";
     } else {
@@ -176,14 +181,6 @@ export const getLatestReport = query({
   },
 });
 
-function getWeekStart(timestamp: number): string {
-  const date = new Date(timestamp);
-  const dayOfWeek = date.getDay();
-  date.setDate(date.getDate() - dayOfWeek);
-  date.setHours(0, 0, 0, 0);
-  return date.toISOString().split("T")[0];
-}
-
 export const getDashboardStats = query({
   args: {},
   handler: async (ctx): Promise<TrainingLabDashboardStats | null> => {
@@ -191,9 +188,9 @@ export const getDashboardStats = query({
     if (!user) return null;
 
     const now = Date.now();
-    const weekStart = new Date(getWeekStart(now)).getTime();
-    const twoWeeksAgo = weekStart - 7 * 24 * 60 * 60 * 1000;
-    const fourWeeksAgo = weekStart - 28 * 24 * 60 * 60 * 1000;
+    const weekStart = getMondayWeekStartUtc(now);
+    const twoWeeksAgo = weekStart - WEEK_IN_MS;
+    const fourWeeksAgo = weekStart - 4 * WEEK_IN_MS;
 
     const recentWorkouts = await ctx.db
       .query("workouts")
@@ -269,15 +266,15 @@ export const getDashboardStats = query({
 
     const weeklyWorkouts = new Map<string, number>();
     for (const workout of allWorkouts) {
-      const weekKey = getWeekStart(workout.startedAt);
+      const weekKey = getMondayWeekKey(workout.startedAt);
       weeklyWorkouts.set(weekKey, (weeklyWorkouts.get(weekKey) ?? 0) + 1);
     }
 
     let currentStreak = 0;
     let longestStreak = 0;
     let tempStreak = 0;
-    const currentWeek = getWeekStart(now);
-    const lastWeek = getWeekStart(now - 7 * 24 * 60 * 60 * 1000);
+    const currentWeek = getMondayWeekKey(now);
+    const lastWeek = getMondayWeekKey(weekStart - WEEK_IN_MS);
 
     const weeks = Array.from(weeklyWorkouts.keys()).sort().reverse();
     for (const week of weeks) {

--- a/convex/entries.ts
+++ b/convex/entries.ts
@@ -8,6 +8,7 @@ const liftingDataValidator = v.object({
   setNumber: v.number(),
   reps: v.optional(v.number()),
   weight: v.optional(v.number()),
+  durationSeconds: v.optional(v.number()),
   unit: v.union(v.literal("kg"), v.literal("lb")),
   rpe: v.optional(v.number()),
   rir: v.optional(v.number()),
@@ -99,6 +100,17 @@ export const addLiftingEntry = mutation({
     if (workout.status !== "in_progress") {
       logger.fail(new Error("Cannot add entries to a completed workout"));
       throw new Error("Cannot add entries to a completed workout");
+    }
+
+    const { durationSeconds, reps } = args.lifting;
+    if (durationSeconds !== undefined && (!Number.isFinite(durationSeconds) || durationSeconds <= 0)) {
+      throw new Error("Duration must be greater than zero");
+    }
+    if (durationSeconds !== undefined && reps !== undefined) {
+      throw new Error("A lifting set cannot use both duration and reps");
+    }
+    if (durationSeconds === undefined && (reps === undefined || !Number.isFinite(reps) || reps <= 0)) {
+      throw new Error("Reps must be greater than zero");
     }
 
     const existingEntry = await ctx.db
@@ -223,6 +235,19 @@ export const updateLiftingEntry = mutation({
 
     if (entry.kind !== "lifting") {
       throw new Error("Entry is not a lifting entry");
+    }
+
+    if (args.lifting) {
+      const { durationSeconds, reps } = args.lifting;
+      if (durationSeconds !== undefined && (!Number.isFinite(durationSeconds) || durationSeconds <= 0)) {
+        throw new Error("Duration must be greater than zero");
+      }
+      if (durationSeconds !== undefined && reps !== undefined) {
+        throw new Error("A lifting set cannot use both duration and reps");
+      }
+      if (durationSeconds === undefined && (reps === undefined || !Number.isFinite(reps) || reps <= 0)) {
+        throw new Error("Reps must be greater than zero");
+      }
     }
 
     await ctx.db.patch(args.entryId, {
@@ -463,7 +488,7 @@ export const getExerciseHistory = query({
       );
 
       const sets = sessionEntries
-        .filter((e) => e.lifting)
+        .filter((e) => e.lifting && e.lifting.durationSeconds === undefined)
         .map((e) => ({
           setNumber: e.lifting!.setNumber,
           weight: e.lifting!.weight ?? 0,
@@ -485,6 +510,64 @@ export const getExerciseHistory = query({
         date: new Date(workout.completedAt ?? workout.startedAt).toISOString(),
         sets,
         bestSet,
+      });
+    }
+
+    return sessions;
+  },
+});
+
+export const getTimedExerciseHistory = query({
+  args: {
+    exerciseName: v.string(),
+    sessionCount: v.optional(v.number()),
+  },
+  handler: async (ctx, args) => {
+    const user = await getCurrentUser(ctx, { requireAuth: false, requireUser: false });
+    if (!user) return [];
+
+    const limit = args.sessionCount ?? 3;
+    const entries = await ctx.db
+      .query("entries")
+      .withIndex("by_user_created", (q) => q.eq("userId", user._id))
+      .order("desc")
+      .filter((q) =>
+        q.and(
+          q.eq(q.field("exerciseName"), args.exerciseName),
+          q.eq(q.field("kind"), "lifting")
+        )
+      )
+      .collect();
+
+    const sessionMap = new Map<Id<"workouts">, (typeof entries)[number][]>();
+    for (const entry of entries) {
+      if (!entry.lifting?.durationSeconds) continue;
+      const existing = sessionMap.get(entry.workoutId) ?? [];
+      existing.push(entry);
+      sessionMap.set(entry.workoutId, existing);
+    }
+
+    const sessions = [];
+    for (const [workoutId, sessionEntries] of sessionMap) {
+      if (sessions.length >= limit) break;
+      const workout = await ctx.db.get(workoutId);
+      if (!workout || workout.status !== "completed") continue;
+
+      const sets = sessionEntries
+        .filter((entry) => entry.lifting?.durationSeconds)
+        .sort((a, b) => (a.lifting?.setNumber ?? 0) - (b.lifting?.setNumber ?? 0))
+        .map((entry) => ({
+          setNumber: entry.lifting!.setNumber,
+          durationSeconds: entry.lifting!.durationSeconds!,
+          rpe: entry.lifting!.rpe ?? null,
+        }));
+
+      if (sets.length === 0) continue;
+      sessions.push({
+        workoutId,
+        date: new Date(workout.completedAt ?? workout.startedAt).toISOString(),
+        sets,
+        longestHoldSeconds: Math.max(...sets.map((set) => set.durationSeconds)),
       });
     }
 
@@ -564,7 +647,7 @@ export const getExerciseHistoryInternal = internalQuery({
       );
 
       const sets = sessionEntries
-        .filter((e) => e.lifting)
+        .filter((e) => e.lifting && e.lifting.durationSeconds === undefined)
         .map((e) => ({
           setNumber: e.lifting!.setNumber,
           weight: e.lifting!.weight ?? 0,
@@ -592,5 +675,3 @@ export const getExerciseHistoryInternal = internalQuery({
     return sessions;
   },
 });
-
-

--- a/convex/exercises.ts
+++ b/convex/exercises.ts
@@ -99,7 +99,7 @@ const SYSTEM_EXERCISES = [
   // --------------------------------------------------------------------------
   // Core
   // --------------------------------------------------------------------------
-  { name: "Plank", aliases: ["Front Plank"], category: "lifting", muscleGroups: ["core"], equipment: ["bodyweight"] },
+  { name: "Plank", aliases: ["Front Plank"], category: "lifting", muscleGroups: ["core"], equipment: ["bodyweight"], measurementType: "duration" },
   { name: "Crunch", aliases: ["Ab Crunch"], category: "lifting", muscleGroups: ["core"], equipment: ["bodyweight"] },
   { name: "Leg Raise", aliases: ["Hanging Leg Raise", "Lying Leg Raise"], category: "lifting", muscleGroups: ["core"], equipment: ["bodyweight"] },
   { name: "Russian Twist", aliases: ["Seated Russian Twist"], category: "lifting", muscleGroups: ["core"], equipment: ["bodyweight", "dumbbell"] },
@@ -242,6 +242,7 @@ export const seedSystemExercises = mutation({
         equipment: exercise.equipment?.length ? [...exercise.equipment] : undefined,
         modality: "modality" in exercise ? exercise.modality : undefined,
         primaryMetric: "primaryMetric" in exercise ? (exercise.primaryMetric as "duration" | "distance") : undefined,
+        measurementType: "measurementType" in exercise ? (exercise.measurementType as "duration") : undefined,
         isSystemExercise: true,
         createdAt: now,
       });
@@ -279,7 +280,8 @@ export const updateSystemExercises = mutation({
         JSON.stringify(existingExercise.aliases ?? []) !== JSON.stringify(exercise.aliases ?? []) ||
         JSON.stringify(existingExercise.equipment ?? []) !== JSON.stringify(exercise.equipment ?? []) ||
         JSON.stringify(existingExercise.muscleGroups ?? []) !== JSON.stringify(exercise.muscleGroups ?? []) ||
-        existingExercise.category !== exercise.category;
+        existingExercise.category !== exercise.category ||
+        existingExercise.measurementType !== ("measurementType" in exercise ? exercise.measurementType : undefined);
 
       if (needsUpdate) {
         await ctx.db.patch(existingExercise._id, {
@@ -287,6 +289,7 @@ export const updateSystemExercises = mutation({
           equipment: exercise.equipment?.length ? [...exercise.equipment] : undefined,
           muscleGroups: exercise.muscleGroups?.length ? [...exercise.muscleGroups] : undefined,
           category: exercise.category as "lifting" | "cardio" | "mobility" | "other",
+          measurementType: "measurementType" in exercise ? (exercise.measurementType as "duration") : undefined,
         });
         updated++;
       }
@@ -313,6 +316,7 @@ export const createExercise = mutation({
     equipment: v.optional(v.array(v.string())),
     modality: v.optional(v.string()),
     primaryMetric: v.optional(v.union(v.literal("duration"), v.literal("distance"))),
+    measurementType: v.optional(v.union(v.literal("reps"), v.literal("duration"))),
   },
   handler: async (ctx, args) => {
     const user = await getCurrentUser(ctx);
@@ -327,6 +331,7 @@ export const createExercise = mutation({
       equipment: args.equipment,
       modality: args.modality,
       primaryMetric: args.primaryMetric,
+      measurementType: args.measurementType,
       isSystemExercise: false,
       createdAt: Date.now(),
     });
@@ -344,6 +349,7 @@ export const updateExercise = mutation({
     id: v.id("exercises"),
     muscleGroups: v.optional(v.array(v.string())),
     name: v.optional(v.string()),
+    measurementType: v.optional(v.union(v.literal("reps"), v.literal("duration"))),
   },
   handler: async (ctx, args) => {
     const user = await getCurrentUser(ctx);
@@ -364,6 +370,7 @@ export const updateExercise = mutation({
     const updates: Partial<{
       muscleGroups?: string[];
       name?: string;
+      measurementType?: "reps" | "duration";
     }> = {};
 
     if (args.muscleGroups !== undefined) {
@@ -372,6 +379,10 @@ export const updateExercise = mutation({
 
     if (args.name !== undefined) {
       updates.name = args.name;
+    }
+
+    if (args.measurementType !== undefined) {
+      updates.measurementType = args.measurementType;
     }
 
     await ctx.db.patch(args.id, updates);

--- a/convex/lib/routineMeasurements.test.ts
+++ b/convex/lib/routineMeasurements.test.ts
@@ -1,0 +1,121 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import {
+  convertWorkoutEntriesToRoutineFormat,
+  convertWorkoutExercisesToRoutineFormat,
+} from "./routineMeasurements";
+
+describe("convertWorkoutExercisesToRoutineFormat", () => {
+  test("keeps rep and timed prescriptions when an exported exercise mixes modes", () => {
+    const result = convertWorkoutExercisesToRoutineFormat([{
+      name: "Plank",
+      kind: "lifting",
+      sets: [
+        { reps: 12, weight: 20, rpe: 7 },
+        { durationSeconds: 30, rpe: 8 },
+        { durationSeconds: 60, rpe: 9 },
+      ],
+    }]);
+
+    assert.deepEqual(result, [
+      {
+        name: "Plank",
+        kind: "lifting",
+        targetSets: 1,
+        targetReps: "12",
+        targetRpe: 7,
+      },
+      {
+        name: "Plank",
+        kind: "lifting",
+        targetSets: 2,
+        targetRpe: 9,
+        measurementType: "duration",
+        targetHoldSeconds: 45,
+      },
+    ]);
+  });
+
+  test("preserves the first source mode when splitting a mixed export", () => {
+    const result = convertWorkoutExercisesToRoutineFormat([{
+      name: "Plank",
+      kind: "lifting",
+      sets: [
+        { durationSeconds: 30 },
+        { reps: 10 },
+      ],
+    }]);
+
+    assert.deepEqual(
+      result.map((exercise) => exercise.measurementType ?? "reps"),
+      ["duration", "reps"]
+    );
+  });
+
+  test("does not count warmups in either working prescription", () => {
+    const result = convertWorkoutExercisesToRoutineFormat([{
+      name: "Plank",
+      kind: "lifting",
+      sets: [
+        { reps: 5, isWarmup: true },
+        { durationSeconds: 40 },
+      ],
+    }]);
+
+    assert.deepEqual(result, [{
+      name: "Plank",
+      kind: "lifting",
+      targetSets: 1,
+      measurementType: "duration",
+      targetHoldSeconds: 40,
+    }]);
+  });
+});
+
+describe("convertWorkoutEntriesToRoutineFormat", () => {
+  test("creates separate routine rows for rep and timed entries with the same name", () => {
+    const result = convertWorkoutEntriesToRoutineFormat([
+      {
+        exerciseId: "exercise-1",
+        exerciseName: "Plank",
+        kind: "lifting",
+        lifting: {},
+      },
+      {
+        exerciseId: "exercise-1",
+        exerciseName: "Plank",
+        kind: "lifting",
+        lifting: { durationSeconds: 30 },
+      },
+      {
+        exerciseId: "exercise-1",
+        exerciseName: "Plank",
+        kind: "lifting",
+        lifting: { durationSeconds: 60 },
+      },
+    ]);
+
+    assert.deepEqual(result, [
+      {
+        exerciseId: "exercise-1",
+        exerciseName: "Plank",
+        kind: "lifting",
+        targetSets: 1,
+        targetReps: "8-12",
+        measurementType: undefined,
+        targetDuration: undefined,
+        targetHoldSeconds: undefined,
+      },
+      {
+        exerciseId: "exercise-1",
+        exerciseName: "Plank",
+        kind: "lifting",
+        targetSets: 2,
+        targetReps: undefined,
+        measurementType: "duration",
+        targetDuration: undefined,
+        targetHoldSeconds: 45,
+      },
+    ]);
+  });
+});

--- a/convex/lib/routineMeasurements.ts
+++ b/convex/lib/routineMeasurements.ts
@@ -1,0 +1,196 @@
+export type WorkoutExerciseForRoutine = {
+  name?: string;
+  kind?: string;
+  sets?: Array<{
+    weight?: number;
+    reps?: number;
+    durationSeconds?: number;
+    rpe?: number;
+    isWarmup?: boolean;
+  }>;
+  cardio?: unknown;
+};
+
+export type ConvertedRoutineExercise = {
+  name: string;
+  kind: string;
+  targetSets?: number;
+  targetReps?: string;
+  targetRpe?: number;
+  targetDuration?: number;
+  measurementType?: "reps" | "duration";
+  targetHoldSeconds?: number;
+};
+
+export type WorkoutEntryForRoutine<TExerciseId = string> = {
+  exerciseId?: TExerciseId;
+  exerciseName: string;
+  kind: "lifting" | "cardio" | "mobility";
+  lifting?: {
+    durationSeconds?: number;
+  };
+};
+
+export type StoredRoutineExercise<TExerciseId = string> = {
+  exerciseId?: TExerciseId;
+  exerciseName: string;
+  kind: "lifting" | "cardio" | "mobility";
+  targetSets?: number;
+  targetReps?: string;
+  measurementType?: "duration";
+  targetDuration?: number;
+  targetHoldSeconds?: number;
+};
+
+type WorkoutSet = NonNullable<WorkoutExerciseForRoutine["sets"]>[number];
+
+function average(values: number[]): number | undefined {
+  if (values.length === 0) return undefined;
+  return Math.round(values.reduce((sum, value) => sum + value, 0) / values.length);
+}
+
+function averageRpe(sets: WorkoutSet[]): number | undefined {
+  return average(
+    sets.flatMap((set) => (set.rpe === undefined ? [] : [set.rpe]))
+  );
+}
+
+function convertLiftingSets(name: string, sets: WorkoutSet[]): ConvertedRoutineExercise[] {
+  const workingSets = sets.filter((set) => !set.isWarmup);
+
+  if (workingSets.length === 0) {
+    return [{
+      name,
+      kind: "lifting",
+      targetSets: sets.length,
+      targetReps: "8-12",
+    }];
+  }
+
+  const timedSets = workingSets.filter((set) => (set.durationSeconds ?? 0) > 0);
+  const repSets = workingSets.filter((set) => (set.durationSeconds ?? 0) <= 0);
+  const converted: ConvertedRoutineExercise[] = [];
+
+  // Keep the source ordering when a workout contains both measurement modes.
+  // Each routine row still has exactly one logger, preserving the existing model.
+  const firstTimedIndex = workingSets.findIndex((set) => (set.durationSeconds ?? 0) > 0);
+  const firstRepIndex = workingSets.findIndex((set) => (set.durationSeconds ?? 0) <= 0);
+  const modes = [
+    { mode: "reps" as const, index: firstRepIndex },
+    { mode: "duration" as const, index: firstTimedIndex },
+  ].filter(({ index }) => index >= 0).sort((a, b) => a.index - b.index);
+
+  for (const { mode } of modes) {
+    if (mode === "duration") {
+      const targetRpe = averageRpe(timedSets);
+      converted.push({
+        name,
+        kind: "lifting",
+        targetSets: timedSets.length,
+        ...(targetRpe === undefined ? {} : { targetRpe }),
+        measurementType: "duration",
+        targetHoldSeconds: average(
+          timedSets.map((set) => set.durationSeconds ?? 0)
+        ),
+      });
+      continue;
+    }
+
+    const averageReps = average(repSets.map((set) => set.reps ?? 0)) ?? 0;
+    const targetRpe = averageRpe(repSets);
+    converted.push({
+      name,
+      kind: "lifting",
+      targetSets: repSets.length,
+      targetReps: averageReps > 0 ? `${averageReps}` : "8-12",
+      ...(targetRpe === undefined ? {} : { targetRpe }),
+    });
+  }
+
+  return converted;
+}
+
+export function convertWorkoutExercisesToRoutineFormat(
+  exercises: WorkoutExerciseForRoutine[]
+): ConvertedRoutineExercise[] {
+  return exercises.flatMap((exercise) => {
+    if (!exercise.name || typeof exercise.name !== "string") {
+      throw new Error(
+        "Workout export contains an exercise without a name. This might be corrupted. Try exporting the workout again."
+      );
+    }
+
+    const kind = exercise.kind === "cardio"
+      ? "cardio"
+      : exercise.kind === "mobility"
+        ? "mobility"
+        : "lifting";
+
+    if (kind === "lifting" && Array.isArray(exercise.sets)) {
+      return convertLiftingSets(exercise.name, exercise.sets);
+    }
+
+    return [{
+      name: exercise.name,
+      kind,
+      targetDuration: kind === "cardio" ? 15 : undefined,
+    }];
+  });
+}
+
+export function convertWorkoutEntriesToRoutineFormat<TExerciseId>(
+  entries: WorkoutEntryForRoutine<TExerciseId>[]
+): StoredRoutineExercise<TExerciseId>[] {
+  const exerciseMap = new Map<string, {
+    exerciseId?: TExerciseId;
+    exerciseName: string;
+    kind: "lifting" | "cardio" | "mobility";
+    sets: number;
+    durations: number[];
+  }>();
+
+  for (const entry of entries) {
+    const measurementType = entry.kind === "lifting" && entry.lifting?.durationSeconds !== undefined
+      ? "duration"
+      : "reps";
+    const key = JSON.stringify([entry.exerciseName, entry.kind, measurementType]);
+    const existing = exerciseMap.get(key);
+
+    if (!existing) {
+      exerciseMap.set(key, {
+        exerciseId: entry.exerciseId,
+        exerciseName: entry.exerciseName,
+        kind: entry.kind,
+        sets: 1,
+        durations: entry.lifting?.durationSeconds !== undefined
+          ? [entry.lifting.durationSeconds]
+          : [],
+      });
+      continue;
+    }
+
+    exerciseMap.set(key, {
+      ...existing,
+      sets: existing.sets + 1,
+      durations: entry.lifting?.durationSeconds !== undefined
+        ? [...existing.durations, entry.lifting.durationSeconds]
+        : existing.durations,
+    });
+  }
+
+  return Array.from(exerciseMap.values()).map((data) => {
+    const isTimedStrength = data.kind === "lifting" && data.durations.length > 0;
+    return {
+      exerciseId: data.exerciseId,
+      exerciseName: data.exerciseName,
+      kind: data.kind,
+      targetSets: data.kind === "lifting" || data.kind === "mobility" ? data.sets : undefined,
+      targetReps: data.kind === "lifting" && !isTimedStrength ? "8-12" : undefined,
+      measurementType: isTimedStrength ? "duration" as const : undefined,
+      targetDuration: data.kind === "cardio" ? 15 : undefined,
+      targetHoldSeconds: isTimedStrength
+        ? average(data.durations)
+        : data.kind === "mobility" ? 30 : undefined,
+    };
+  });
+}

--- a/convex/lib/week.ts
+++ b/convex/lib/week.ts
@@ -1,0 +1,23 @@
+export const WEEK_IN_MS = 7 * 24 * 60 * 60 * 1000;
+
+/**
+ * Returns 00:00 UTC on the Monday that contains the supplied timestamp.
+ *
+ * OpenTrainer does not currently persist a user time zone, so server-side
+ * calendar periods use UTC consistently rather than depending on the runtime's
+ * local time zone.
+ */
+export function getMondayWeekStartUtc(timestamp: number): number {
+  const date = new Date(timestamp);
+  const daysSinceMonday = (date.getUTCDay() + 6) % 7;
+
+  return Date.UTC(
+    date.getUTCFullYear(),
+    date.getUTCMonth(),
+    date.getUTCDate() - daysSinceMonday
+  );
+}
+
+export function getMondayWeekKey(timestamp: number): string {
+  return new Date(getMondayWeekStartUtc(timestamp)).toISOString().split("T")[0];
+}

--- a/convex/routines.ts
+++ b/convex/routines.ts
@@ -1,6 +1,11 @@
 import { v } from "convex/values";
 import { mutation, query } from "./_generated/server";
 import { getCurrentUser } from "./auth";
+import {
+  convertWorkoutEntriesToRoutineFormat,
+  convertWorkoutExercisesToRoutineFormat,
+  type WorkoutExerciseForRoutine,
+} from "./lib/routineMeasurements";
 
 const routineExerciseValidator = v.object({
   exerciseId: v.optional(v.id("exercises")),
@@ -21,79 +26,6 @@ const routineDayValidator = v.object({
   name: v.string(),
   exercises: v.array(routineExerciseValidator),
 });
-
-type WorkoutExercise = {
-  name?: string;
-  kind?: string;
-  sets?: Array<{
-    weight?: number;
-    reps?: number;
-    durationSeconds?: number;
-    rpe?: number;
-    isWarmup?: boolean;
-  }>;
-  cardio?: unknown;
-};
-
-type RoutineExercise = {
-  name: string;
-  kind: string;
-  targetSets?: number;
-  targetReps?: string;
-  targetRpe?: number;
-  targetDuration?: number;
-  measurementType?: "reps" | "duration";
-  targetHoldSeconds?: number;
-};
-
-function convertWorkoutExercisesToRoutineFormat(exercises: WorkoutExercise[]): RoutineExercise[] {
-  return exercises.map((ex) => {
-    if (!ex.name || typeof ex.name !== "string") {
-      throw new Error(
-        "Workout export contains an exercise without a name. This might be corrupted. Try exporting the workout again."
-      );
-    }
-
-    const kind = ex.kind === "cardio" ? "cardio" : (ex.kind === "mobility" ? "mobility" : "lifting");
-
-    const exercise: RoutineExercise = {
-      name: ex.name,
-      kind,
-    };
-
-    if (kind === "lifting" && ex.sets && Array.isArray(ex.sets)) {
-      const workingSets = ex.sets.filter((s) => !s.isWarmup);
-      if (workingSets.length > 0) {
-        exercise.targetSets = workingSets.length;
-        const durationSets = workingSets.filter((s) => (s.durationSeconds ?? 0) > 0);
-        if (durationSets.length > 0) {
-          exercise.measurementType = "duration";
-          exercise.targetHoldSeconds = Math.round(
-            durationSets.reduce((sum, s) => sum + (s.durationSeconds ?? 0), 0) / durationSets.length
-          );
-        } else {
-          const avgReps = Math.round(
-            workingSets.reduce((sum, s) => sum + (s.reps ?? 0), 0) / workingSets.length
-          );
-          exercise.targetReps = avgReps > 0 ? `${avgReps}` : "8-12";
-        }
-        const rpes = workingSets.map((s) => s.rpe).filter((r) => r !== undefined);
-        if (rpes.length > 0) {
-          exercise.targetRpe = Math.round(
-            rpes.reduce((sum, r) => sum + (r ?? 0), 0) / rpes.length
-          );
-        }
-      } else {
-        exercise.targetSets = ex.sets.length;
-        exercise.targetReps = "8-12";
-      }
-    } else if (kind === "cardio") {
-      exercise.targetDuration = 15;
-    }
-
-    return exercise;
-  });
-}
 
 export const createRoutine = mutation({
   args: {
@@ -145,45 +77,7 @@ export const createRoutineFromWorkout = mutation({
       .withIndex("by_workout", (q) => q.eq("workoutId", args.workoutId))
       .collect();
 
-    const exerciseMap = new Map<string, {
-      kind: "lifting" | "cardio" | "mobility";
-      sets: number;
-      durations: number[];
-    }>();
-    
-    for (const entry of entries) {
-      const existing = exerciseMap.get(entry.exerciseName);
-      if (!existing) {
-        exerciseMap.set(entry.exerciseName, {
-          kind: entry.kind,
-          sets: 1,
-          durations: entry.lifting?.durationSeconds ? [entry.lifting.durationSeconds] : [],
-        });
-      } else {
-        exerciseMap.set(entry.exerciseName, {
-          ...existing,
-          sets: existing.sets + 1,
-          durations: entry.lifting?.durationSeconds
-            ? [...existing.durations, entry.lifting.durationSeconds]
-            : existing.durations,
-        });
-      }
-    }
-
-    const exercises = Array.from(exerciseMap.entries()).map(([name, data]) => {
-      const isTimedStrength = data.kind === "lifting" && data.durations.length > 0;
-      return {
-        exerciseName: name,
-        kind: data.kind,
-        targetSets: data.kind === "lifting" || data.kind === "mobility" ? data.sets : undefined,
-        targetReps: data.kind === "lifting" && !isTimedStrength ? "8-12" : undefined,
-        measurementType: isTimedStrength ? ("duration" as const) : undefined,
-        targetDuration: data.kind === "cardio" ? 15 : undefined,
-        targetHoldSeconds: isTimedStrength
-          ? Math.round(data.durations.reduce((sum, duration) => sum + duration, 0) / data.durations.length)
-          : data.kind === "mobility" ? 30 : undefined,
-      };
-    });
+    const exercises = convertWorkoutEntriesToRoutineFormat(entries);
 
     const now = Date.now();
 
@@ -307,18 +201,7 @@ export const importRoutineFromJson = mutation({
       description?: string;
       workout?: {
         title?: string;
-        exercises?: Array<{
-          name?: string;
-          kind?: string;
-          sets?: Array<{
-            weight?: number;
-            reps?: number;
-            durationSeconds?: number;
-            rpe?: number;
-            isWarmup?: boolean;
-          }>;
-          cardio?: unknown;
-        }>;
+        exercises?: WorkoutExerciseForRoutine[];
       };
       days?: Array<{
         name?: string;
@@ -480,18 +363,7 @@ export const importDayToRoutine = mutation({
       name?: string;
       workout?: {
         title?: string;
-        exercises?: Array<{
-          name?: string;
-          kind?: string;
-          sets?: Array<{
-            weight?: number;
-            reps?: number;
-            durationSeconds?: number;
-            rpe?: number;
-            isWarmup?: boolean;
-          }>;
-          cardio?: unknown;
-        }>;
+        exercises?: WorkoutExerciseForRoutine[];
       };
       exercises?: Array<{
         name?: string;

--- a/convex/routines.ts
+++ b/convex/routines.ts
@@ -9,6 +9,7 @@ const routineExerciseValidator = v.object({
   targetSets: v.optional(v.number()),
   targetReps: v.optional(v.string()),
   targetRpe: v.optional(v.number()),
+  measurementType: v.optional(v.union(v.literal("reps"), v.literal("duration"))),
   targetDuration: v.optional(v.number()),
   targetIntensity: v.optional(v.number()),
   targetHoldSeconds: v.optional(v.number()),
@@ -27,6 +28,7 @@ type WorkoutExercise = {
   sets?: Array<{
     weight?: number;
     reps?: number;
+    durationSeconds?: number;
     rpe?: number;
     isWarmup?: boolean;
   }>;
@@ -40,6 +42,8 @@ type RoutineExercise = {
   targetReps?: string;
   targetRpe?: number;
   targetDuration?: number;
+  measurementType?: "reps" | "duration";
+  targetHoldSeconds?: number;
 };
 
 function convertWorkoutExercisesToRoutineFormat(exercises: WorkoutExercise[]): RoutineExercise[] {
@@ -61,10 +65,18 @@ function convertWorkoutExercisesToRoutineFormat(exercises: WorkoutExercise[]): R
       const workingSets = ex.sets.filter((s) => !s.isWarmup);
       if (workingSets.length > 0) {
         exercise.targetSets = workingSets.length;
-        const avgReps = Math.round(
-          workingSets.reduce((sum, s) => sum + (s.reps ?? 0), 0) / workingSets.length
-        );
-        exercise.targetReps = avgReps > 0 ? `${avgReps}` : "8-12";
+        const durationSets = workingSets.filter((s) => (s.durationSeconds ?? 0) > 0);
+        if (durationSets.length > 0) {
+          exercise.measurementType = "duration";
+          exercise.targetHoldSeconds = Math.round(
+            durationSets.reduce((sum, s) => sum + (s.durationSeconds ?? 0), 0) / durationSets.length
+          );
+        } else {
+          const avgReps = Math.round(
+            workingSets.reduce((sum, s) => sum + (s.reps ?? 0), 0) / workingSets.length
+          );
+          exercise.targetReps = avgReps > 0 ? `${avgReps}` : "8-12";
+        }
         const rpes = workingSets.map((s) => s.rpe).filter((r) => r !== undefined);
         if (rpes.length > 0) {
           exercise.targetRpe = Math.round(
@@ -133,25 +145,45 @@ export const createRoutineFromWorkout = mutation({
       .withIndex("by_workout", (q) => q.eq("workoutId", args.workoutId))
       .collect();
 
-    const exerciseMap = new Map<string, { kind: "lifting" | "cardio" | "mobility"; sets: number }>();
+    const exerciseMap = new Map<string, {
+      kind: "lifting" | "cardio" | "mobility";
+      sets: number;
+      durations: number[];
+    }>();
     
     for (const entry of entries) {
       const existing = exerciseMap.get(entry.exerciseName);
       if (!existing) {
-        exerciseMap.set(entry.exerciseName, { kind: entry.kind, sets: 1 });
+        exerciseMap.set(entry.exerciseName, {
+          kind: entry.kind,
+          sets: 1,
+          durations: entry.lifting?.durationSeconds ? [entry.lifting.durationSeconds] : [],
+        });
       } else {
-        exerciseMap.set(entry.exerciseName, { ...existing, sets: existing.sets + 1 });
+        exerciseMap.set(entry.exerciseName, {
+          ...existing,
+          sets: existing.sets + 1,
+          durations: entry.lifting?.durationSeconds
+            ? [...existing.durations, entry.lifting.durationSeconds]
+            : existing.durations,
+        });
       }
     }
 
-    const exercises = Array.from(exerciseMap.entries()).map(([name, data]) => ({
-      exerciseName: name,
-      kind: data.kind,
-      targetSets: data.kind === "lifting" ? data.sets : (data.kind === "mobility" ? data.sets : undefined),
-      targetReps: data.kind === "lifting" ? "8-12" : undefined,
-      targetDuration: data.kind === "cardio" ? 15 : undefined,
-      targetHoldSeconds: data.kind === "mobility" ? 30 : undefined,
-    }));
+    const exercises = Array.from(exerciseMap.entries()).map(([name, data]) => {
+      const isTimedStrength = data.kind === "lifting" && data.durations.length > 0;
+      return {
+        exerciseName: name,
+        kind: data.kind,
+        targetSets: data.kind === "lifting" || data.kind === "mobility" ? data.sets : undefined,
+        targetReps: data.kind === "lifting" && !isTimedStrength ? "8-12" : undefined,
+        measurementType: isTimedStrength ? ("duration" as const) : undefined,
+        targetDuration: data.kind === "cardio" ? 15 : undefined,
+        targetHoldSeconds: isTimedStrength
+          ? Math.round(data.durations.reduce((sum, duration) => sum + duration, 0) / data.durations.length)
+          : data.kind === "mobility" ? 30 : undefined,
+      };
+    });
 
     const now = Date.now();
 
@@ -281,6 +313,7 @@ export const importRoutineFromJson = mutation({
           sets?: Array<{
             weight?: number;
             reps?: number;
+            durationSeconds?: number;
             rpe?: number;
             isWarmup?: boolean;
           }>;
@@ -295,6 +328,7 @@ export const importRoutineFromJson = mutation({
           targetSets?: number;
           targetReps?: string;
           targetRpe?: number;
+          measurementType?: string;
           targetDuration?: number;
           targetIntensity?: number;
           targetHoldSeconds?: number;
@@ -364,6 +398,7 @@ export const importRoutineFromJson = mutation({
           targetSets: typeof ex.targetSets === "number" ? ex.targetSets : undefined,
           targetReps: typeof ex.targetReps === "string" ? ex.targetReps : undefined,
           targetRpe: typeof ex.targetRpe === "number" ? ex.targetRpe : undefined,
+          measurementType: ex.measurementType === "duration" ? "duration" as const : undefined,
           targetDuration: typeof ex.targetDuration === "number" ? ex.targetDuration : undefined,
           targetIntensity: typeof ex.targetIntensity === "number" ? ex.targetIntensity : undefined,
           targetHoldSeconds: typeof ex.targetHoldSeconds === "number" ? ex.targetHoldSeconds : undefined,
@@ -451,6 +486,7 @@ export const importDayToRoutine = mutation({
           sets?: Array<{
             weight?: number;
             reps?: number;
+            durationSeconds?: number;
             rpe?: number;
             isWarmup?: boolean;
           }>;
@@ -463,6 +499,7 @@ export const importDayToRoutine = mutation({
         targetSets?: number;
         targetReps?: string;
         targetRpe?: number;
+        measurementType?: string;
         targetDuration?: number;
         targetIntensity?: number;
         targetHoldSeconds?: number;
@@ -509,6 +546,7 @@ export const importDayToRoutine = mutation({
         targetSets: typeof ex.targetSets === "number" ? ex.targetSets : undefined,
         targetReps: typeof ex.targetReps === "string" ? ex.targetReps : undefined,
         targetRpe: typeof ex.targetRpe === "number" ? ex.targetRpe : undefined,
+        measurementType: ex.measurementType === "duration" ? "duration" as const : undefined,
         targetDuration: typeof ex.targetDuration === "number" ? ex.targetDuration : undefined,
         targetIntensity: typeof ex.targetIntensity === "number" ? ex.targetIntensity : undefined,
         targetHoldSeconds: typeof ex.targetHoldSeconds === "number" ? ex.targetHoldSeconds : undefined,

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -88,6 +88,8 @@ export default defineSchema({
     // For lifting exercises
     muscleGroups: v.optional(v.array(v.string())),
     equipment: v.optional(v.array(v.string())),
+    // Defaults to reps for backward compatibility. Duration is for timed holds.
+    measurementType: v.optional(v.union(v.literal("reps"), v.literal("duration"))),
     
     // For cardio exercises
     modality: v.optional(v.string()), // run, bike, row, stairstepper, etc.
@@ -170,6 +172,7 @@ export default defineSchema({
       setNumber: v.number(),
       reps: v.optional(v.number()),
       weight: v.optional(v.number()),
+      durationSeconds: v.optional(v.number()),
       unit: v.union(v.literal("kg"), v.literal("lb")),
       rpe: v.optional(v.number()), // 1-10 scale
       rir: v.optional(v.number()), // Reps in reserve
@@ -274,10 +277,11 @@ export default defineSchema({
         targetSets: v.optional(v.number()),
         targetReps: v.optional(v.string()), // e.g., "8-12"
         targetRpe: v.optional(v.number()),
+        measurementType: v.optional(v.union(v.literal("reps"), v.literal("duration"))),
         // Target for cardio
         targetDuration: v.optional(v.number()), // minutes
         targetIntensity: v.optional(v.number()),
-        // Target for mobility
+        // Target for mobility or duration-based lifting holds
         targetHoldSeconds: v.optional(v.number()),
         perSide: v.optional(v.boolean()),
         notes: v.optional(v.string()),

--- a/convex/workouts.ts
+++ b/convex/workouts.ts
@@ -591,17 +591,33 @@ export const getRoutineExercisesForWorkout = query({
 
     const exercisesWithEquipment = await Promise.all(
       exercises.map(async (ex) => {
-        const exerciseData = ex.exerciseId
-          ? await ctx.db.get(ex.exerciseId)
-          : await ctx.db
-              .query("exercises")
-              .withIndex("by_name", (query) => query.eq("name", ex.exerciseName))
-              .first();
+        let exerciseData = ex.exerciseId ? await ctx.db.get(ex.exerciseId) : null;
+
+        if (exerciseData?.userId && exerciseData.userId !== user._id) {
+          exerciseData = null;
+        }
+
+        if (!ex.exerciseId) {
+          const accessibleMatches = (await ctx.db
+            .query("exercises")
+            .withIndex("by_name", (query) => query.eq("name", ex.exerciseName))
+            .collect())
+            .filter((candidate) => !candidate.userId || candidate.userId === user._id);
+
+          // A legacy or imported routine may not have an exerciseId. Only enrich
+          // it when the name identifies one accessible catalog row; otherwise its
+          // explicit routine metadata (or the legacy reps default) is authoritative.
+          exerciseData = accessibleMatches.length === 1 ? accessibleMatches[0] : null;
+        }
+
         if (exerciseData) {
           return {
             ...ex,
-            equipment: exerciseData?.equipment,
-            measurementType: ex.measurementType ?? exerciseData?.measurementType,
+            equipment: exerciseData.equipment,
+            // A catalog mode is authoritative only when the routine stores that
+            // catalog row's id. Name-only legacy rows retain the reps default.
+            measurementType: ex.measurementType
+              ?? (ex.exerciseId ? exerciseData.measurementType : undefined),
           };
         }
         return ex;

--- a/convex/workouts.ts
+++ b/convex/workouts.ts
@@ -591,11 +591,17 @@ export const getRoutineExercisesForWorkout = query({
 
     const exercisesWithEquipment = await Promise.all(
       exercises.map(async (ex) => {
-        if (ex.exerciseId) {
-          const exerciseData = await ctx.db.get(ex.exerciseId);
+        const exerciseData = ex.exerciseId
+          ? await ctx.db.get(ex.exerciseId)
+          : await ctx.db
+              .query("exercises")
+              .withIndex("by_name", (query) => query.eq("name", ex.exerciseName))
+              .first();
+        if (exerciseData) {
           return {
             ...ex,
             equipment: exerciseData?.equipment,
+            measurementType: ex.measurementType ?? exerciseData?.measurementType,
           };
         }
         return ex;
@@ -872,6 +878,7 @@ export const exportWorkoutAsJson = query({
               setNumber: number;
               weight?: number;
               reps?: number;
+              durationSeconds?: number;
               unit: "kg" | "lb";
               rpe?: number;
               isWarmup?: boolean;
@@ -882,6 +889,7 @@ export const exportWorkoutAsJson = query({
             };
             if (e.lifting.weight !== undefined) set.weight = e.lifting.weight;
             if (e.lifting.reps !== undefined) set.reps = e.lifting.reps;
+            if (e.lifting.durationSeconds !== undefined) set.durationSeconds = e.lifting.durationSeconds;
             if (e.lifting.rpe !== undefined) set.rpe = e.lifting.rpe;
             if (e.lifting.isWarmup) set.isWarmup = true;
             if (e.lifting.isBodyweight) set.isBodyweight = true;

--- a/convex/workouts.ts
+++ b/convex/workouts.ts
@@ -4,6 +4,7 @@ import type { MutationCtx } from "./_generated/server";
 import { mutation, query } from "./_generated/server";
 import { getCurrentUser } from "./auth";
 import { createConvexLogger, truncateId } from "./lib/logger";
+import { getMondayWeekStartUtc, WEEK_IN_MS } from "./lib/week";
 
 type WorkoutSummary = NonNullable<Doc<"workouts">["summary"]>;
 
@@ -686,24 +687,17 @@ export const getDashboardStats = query({
     }
 
     // Calculate start of current week (Monday)
-    const now = new Date();
-    const dayOfWeek = now.getDay();
-    // getDay() returns 0 for Sunday, 1 for Monday, etc.
-    // We want Monday as day 0, so we adjust: (dayOfWeek + 6) % 7 gives us days since Monday
-    const daysSinceMonday = (dayOfWeek + 6) % 7;
-    const mondayOfThisWeek = new Date(now);
-    mondayOfThisWeek.setDate(now.getDate() - daysSinceMonday);
-    mondayOfThisWeek.setHours(0, 0, 0, 0);
+    const now = Date.now();
+    const mondayOfThisWeek = getMondayWeekStartUtc(now);
 
     // Get current week (Monday through Sunday) for activity dots
     const currentWeek: { date: string; dayName: string; hasWorkout: boolean }[] = [];
 
     for (let i = 0; i < 7; i++) {
-      const date = new Date(mondayOfThisWeek);
-      date.setDate(mondayOfThisWeek.getDate() + i);
+      const date = new Date(mondayOfThisWeek + i * 24 * 60 * 60 * 1000);
       currentWeek.push({
         date: date.toISOString().split("T")[0],
-        dayName: date.toLocaleDateString("en-US", { weekday: "short" }),
+        dayName: date.toLocaleDateString("en-US", { weekday: "short", timeZone: "UTC" }),
         hasWorkout: false,
       });
     }
@@ -715,7 +709,7 @@ export const getDashboardStats = query({
       .filter((q) =>
         q.and(
           q.eq(q.field("status"), "completed"),
-          q.gte(q.field("startedAt"), mondayOfThisWeek.getTime())
+          q.gte(q.field("startedAt"), mondayOfThisWeek)
         )
       )
       .collect();
@@ -731,7 +725,7 @@ export const getDashboardStats = query({
 
     // Calculate this week's stats
     const thisWeekWorkouts = recentWorkouts.filter(
-      (w) => w.startedAt >= mondayOfThisWeek.getTime()
+      (w) => w.startedAt >= mondayOfThisWeek
     );
 
     const weeklyWorkoutCount = thisWeekWorkouts.length;
@@ -746,9 +740,7 @@ export const getDashboardStats = query({
     }
 
     // Get weekly trend data (last 4 weeks)
-    const fourWeeksAgo = new Date(now);
-    fourWeeksAgo.setDate(now.getDate() - 28);
-    fourWeeksAgo.setHours(0, 0, 0, 0);
+    const fourWeeksAgo = mondayOfThisWeek - 3 * WEEK_IN_MS;
 
     const trendWorkouts = await ctx.db
       .query("workouts")
@@ -756,7 +748,7 @@ export const getDashboardStats = query({
       .filter((q) =>
         q.and(
           q.eq(q.field("status"), "completed"),
-          q.gte(q.field("startedAt"), fourWeeksAgo.getTime())
+          q.gte(q.field("startedAt"), fourWeeksAgo)
         )
       )
       .collect();
@@ -764,15 +756,11 @@ export const getDashboardStats = query({
     // Group by week for trend chart
     const weeklyTrend: { week: string; volume: number; workouts: number; duration: number }[] = [];
     for (let i = 3; i >= 0; i--) {
-      const weekStart = new Date(now);
-      weekStart.setDate(now.getDate() - (i * 7 + dayOfWeek));
-      weekStart.setHours(0, 0, 0, 0);
-
-      const weekEnd = new Date(weekStart);
-      weekEnd.setDate(weekStart.getDate() + 7);
+      const weekStart = mondayOfThisWeek - i * WEEK_IN_MS;
+      const weekEnd = weekStart + WEEK_IN_MS;
 
       const weekWorkouts = trendWorkouts.filter(
-        (w) => w.startedAt >= weekStart.getTime() && w.startedAt < weekEnd.getTime()
+        (w) => w.startedAt >= weekStart && w.startedAt < weekEnd
       );
 
       let volume = 0;
@@ -783,7 +771,11 @@ export const getDashboardStats = query({
       }
 
       weeklyTrend.push({
-        week: weekStart.toLocaleDateString("en-US", { month: "short", day: "numeric" }),
+        week: new Date(weekStart).toLocaleDateString("en-US", {
+          month: "short",
+          day: "numeric",
+          timeZone: "UTC",
+        }),
         volume,
         workouts: weekWorkouts.length,
         duration,

--- a/src/app/routines/[id]/edit/page.tsx
+++ b/src/app/routines/[id]/edit/page.tsx
@@ -113,6 +113,9 @@ function SortableExerciseItem({
 				: `${exercise.targetSets}×${exercise.targetReps}`;
 			return exercise.perSide ? `${base} /side` : base;
 		}
+		if (exercise.measurementType === "duration") {
+			return `${exercise.targetSets}×${exercise.targetHoldSeconds ?? 30}s`;
+		}
 		return `${exercise.targetSets}×${exercise.targetReps}`;
 	};
 	const summary = getSummary();
@@ -183,13 +186,17 @@ export default function EditRoutinePage() {
 	const [showImportDayDialog, setShowImportDayDialog] = useState(false);
 
 	useEffect(() => {
-		if (routine && !isInitialized) {
+		if (routine && exercises && !isInitialized) {
 			setRoutineName(routine.name);
 			setDescription(routine.description || "");
 			const parsedDays = routine.days.map((day) => ({
 				id: crypto.randomUUID(),
 				name: day.name,
 				exercises: day.exercises.map((ex) => {
+					const catalogExercise = exercises.find(
+						(catalogEntry) =>
+							catalogEntry._id === ex.exerciseId || catalogEntry.name === ex.exerciseName
+					);
 					let targetDuration = ex.targetDuration;
 					if (ex.kind === "cardio" && !targetDuration && ex.targetReps) {
 						const match = ex.targetReps.match(/(\d+)/);
@@ -204,6 +211,7 @@ export default function EditRoutinePage() {
 						kind: ex.kind,
 						targetSets: ex.targetSets || 3,
 						targetReps: ex.targetReps || "8-12",
+						measurementType: ex.measurementType ?? catalogExercise?.measurementType,
 						targetDuration: targetDuration || 20,
 						targetHoldSeconds: ex.targetHoldSeconds || 30,
 						perSide: ex.perSide || false,
@@ -217,7 +225,7 @@ export default function EditRoutinePage() {
 			}
 			setIsInitialized(true);
 		}
-	}, [routine, isInitialized]);
+	}, [routine, exercises, isInitialized]);
 
 	const sensors = useSensors(
 		useSensor(PointerSensor, { activationConstraint: { distance: 8 } }),
@@ -311,7 +319,8 @@ export default function EditRoutinePage() {
 	const addExerciseToDay = (
 		exerciseName: string,
 		exerciseId?: Id<"exercises">,
-		kind: "lifting" | "cardio" | "mobility" = "lifting"
+		kind: "lifting" | "cardio" | "mobility" = "lifting",
+		measurementType?: "reps" | "duration"
 	) => {
 		if (!activeDayId) return;
 		vibrate("medium");
@@ -321,6 +330,8 @@ export default function EditRoutinePage() {
 			exerciseName,
 			...DEFAULT_EXERCISE,
 			kind,
+			measurementType,
+			targetHoldSeconds: measurementType === "duration" ? 30 : DEFAULT_EXERCISE.targetHoldSeconds,
 		};
 		setDays(
 			days.map((d) =>
@@ -389,12 +400,15 @@ export default function EditRoutinePage() {
 						targetSets:
 							e.kind === "lifting" || e.kind === "mobility" ? e.targetSets : 1,
 						targetReps:
-							e.kind === "lifting" || e.kind === "mobility"
+							(e.kind === "lifting" && e.measurementType !== "duration") || e.kind === "mobility"
 								? e.targetReps
 								: undefined,
+						measurementType: e.kind === "lifting" ? e.measurementType : undefined,
 						targetDuration: e.kind === "cardio" ? e.targetDuration : undefined,
 						targetHoldSeconds:
-							e.kind === "mobility" ? e.targetHoldSeconds : undefined,
+							e.kind === "mobility" || e.measurementType === "duration"
+								? e.targetHoldSeconds
+								: undefined,
 						perSide: e.kind === "mobility" ? e.perSide : undefined,
 					})),
 				})),
@@ -771,7 +785,8 @@ export default function EditRoutinePage() {
 												? "cardio"
 												: exercise.category === "mobility"
 													? "mobility"
-													: "lifting"
+													: "lifting",
+											exercise.measurementType
 										)
 									}
 								>

--- a/src/app/routines/new/ai/page.tsx
+++ b/src/app/routines/new/ai/page.tsx
@@ -190,7 +190,9 @@ export default function AIRoutineGeneratorPage() {
             exerciseName: ex.exerciseName,
             kind: ex.kind,
             targetSets: ex.targetSets,
-            targetReps: ex.targetReps,
+            targetReps: ex.measurementType === "duration" ? undefined : ex.targetReps,
+            measurementType: ex.measurementType,
+            targetHoldSeconds: ex.targetHoldSeconds,
           })),
         })),
       });
@@ -265,7 +267,7 @@ export default function AIRoutineGeneratorPage() {
     }
   };
   
-  const handleSelectAlternative = (newExerciseName: string) => {
+  const handleSelectAlternative = (alternative: RoutineSwapAlternative) => {
     if (!generatedRoutine) return;
     
     vibrate("medium");
@@ -278,14 +280,25 @@ export default function AIRoutineGeneratorPage() {
           ...day,
           exercises: day.exercises.map((ex, ei) => {
             if (ei !== swapSheet.exerciseIndex) return ex;
-            return { ...ex, exerciseName: newExerciseName };
+            return {
+              ...ex,
+              exerciseName: alternative.exercise,
+              measurementType: alternative.measurementType,
+              targetHoldSeconds: alternative.targetHoldSeconds,
+              targetReps:
+                alternative.measurementType === "duration"
+                  ? ""
+                  : ex.measurementType === "duration"
+                    ? "8-12"
+                    : ex.targetReps,
+            };
           }),
         };
       }),
     };
     
     setGeneratedRoutine(updatedRoutine);
-    toast.success(`Swapped to ${newExerciseName}`);
+    toast.success(`Swapped to ${alternative.exercise}`);
     setSwapSheet((prev) => ({ ...prev, open: false }));
   };
   
@@ -612,7 +625,9 @@ export default function AIRoutineGeneratorPage() {
                             </div>
                             <div className="flex items-center gap-2 shrink-0">
                               <Badge variant="outline" className="text-xs font-mono">
-                                {exercise.targetSets} × {exercise.targetReps}
+                                {exercise.targetSets} × {exercise.measurementType === "duration"
+                                  ? `${exercise.targetHoldSeconds ?? 30}s`
+                                  : exercise.targetReps}
                               </Badge>
                               <RefreshCw className="h-3.5 w-3.5 text-muted-foreground" />
                             </div>
@@ -762,7 +777,7 @@ export default function AIRoutineGeneratorPage() {
                           )}
                         </div>
                       </div>
-                      <Button size="sm" onClick={() => handleSelectAlternative(alt.exercise)}>
+                      <Button size="sm" onClick={() => handleSelectAlternative(alt)}>
                         <Check className="h-4 w-4 mr-1.5" />
                         Use
                       </Button>

--- a/src/app/routines/new/page.tsx
+++ b/src/app/routines/new/page.tsx
@@ -65,6 +65,8 @@ type RoutineExercise = {
   kind: "lifting" | "cardio";
   targetSets: number;
   targetReps: string;
+  measurementType?: "reps" | "duration";
+  targetHoldSeconds?: number;
   restSeconds: number;
 };
 
@@ -157,17 +159,36 @@ function SortableExerciseItem({
           />
         </div>
         <div className="flex-1">
-          <Label className="text-xs text-muted-foreground">Reps</Label>
-          <Input
-            value={exercise.targetReps}
-            onChange={(e) =>
-              onUpdate(dayId, exercise.id, {
-                targetReps: e.target.value,
-              })
-            }
-            placeholder="8-12"
-            className="h-8 text-center"
-          />
+          <Label className="text-xs text-muted-foreground">
+            {exercise.measurementType === "duration" ? "Seconds" : "Reps"}
+          </Label>
+          {exercise.measurementType === "duration" ? (
+            <Input
+              type="number"
+              inputMode="numeric"
+              value={exercise.targetHoldSeconds ?? 30}
+              onChange={(e) => {
+                const parsed = Number.parseInt(e.target.value, 10);
+                onUpdate(dayId, exercise.id, {
+                  targetHoldSeconds: Number.isNaN(parsed) ? 1 : Math.max(1, parsed),
+                });
+              }}
+              className="h-8 text-center"
+              min={1}
+              max={3600}
+            />
+          ) : (
+            <Input
+              value={exercise.targetReps}
+              onChange={(e) =>
+                onUpdate(dayId, exercise.id, {
+                  targetReps: e.target.value,
+                })
+              }
+              placeholder="8-12"
+              className="h-8 text-center"
+            />
+          )}
         </div>
         <div className="flex-1">
           <Label className="text-xs text-muted-foreground">Rest (s)</Label>
@@ -331,7 +352,8 @@ export default function NewRoutinePage() {
   const addExerciseToDay = (
     exerciseName: string,
     exerciseId?: Id<"exercises">,
-    kind: "lifting" | "cardio" = "lifting"
+    kind: "lifting" | "cardio" = "lifting",
+    measurementType?: "reps" | "duration"
   ) => {
     if (!activeDayId) return;
 
@@ -342,6 +364,8 @@ export default function NewRoutinePage() {
       exerciseName,
       ...DEFAULT_EXERCISE,
       kind,
+      measurementType,
+      targetHoldSeconds: measurementType === "duration" ? 30 : undefined,
     };
 
     setDays(
@@ -414,7 +438,9 @@ export default function NewRoutinePage() {
             exerciseName: e.exerciseName,
             kind: e.kind,
             targetSets: e.targetSets || 1,
-            targetReps: e.targetReps,
+            targetReps: e.measurementType === "duration" ? undefined : e.targetReps,
+            measurementType: e.measurementType,
+            targetHoldSeconds: e.measurementType === "duration" ? e.targetHoldSeconds : undefined,
           })),
         })),
       });
@@ -692,7 +718,8 @@ export default function NewRoutinePage() {
                     addExerciseToDay(
                       exercise.name,
                       exercise._id,
-                      exercise.category === "cardio" ? "cardio" : "lifting"
+                      exercise.category === "cardio" ? "cardio" : "lifting",
+                      exercise.measurementType
                     )
                   }
                 >

--- a/src/app/workout/[id]/page.tsx
+++ b/src/app/workout/[id]/page.tsx
@@ -33,6 +33,11 @@ import { ExportWorkoutDialog } from "@/components/workout/export-workout-dialog"
 import { WorkoutTimeEditorDialog } from "@/components/workout/workout-time-editor-dialog";
 import { toast } from "sonner";
 import posthog from "posthog-js";
+import {
+  calculateVolumeInUnit,
+  displayWeight,
+  type WeightUnit,
+} from "@/lib/units";
 
 type LiftingEntry = {
   _id: string;
@@ -58,6 +63,8 @@ type CardioEntry = {
     mode: "steady" | "intervals";
     durationSeconds: number;
     intensity?: number;
+    vestWeight?: number;
+    vestWeightUnit?: "kg" | "lb";
   };
   createdAt: number;
 };
@@ -84,6 +91,7 @@ export default function WorkoutDetailsPage() {
   const updateWorkoutTimes = useMutation(api.workouts.updateWorkoutTimes);
   const deleteWorkout = useMutation(api.workouts.deleteWorkout);
   const isPro = user?.tier === "pro";
+  const preferredUnit: WeightUnit = user?.preferredUnits ?? "lb";
 
   const formatDate = (timestamp: number) => {
     return new Date(timestamp).toLocaleDateString("en-US", {
@@ -148,7 +156,7 @@ export default function WorkoutDetailsPage() {
     }));
   };
 
-  if (workout === undefined) {
+  if (workout === undefined || user === undefined) {
     return (
       <div className="flex min-h-screen flex-col">
         <header className="sticky top-0 z-40 border-b bg-background/95 backdrop-blur">
@@ -185,6 +193,14 @@ export default function WorkoutDetailsPage() {
   }
 
   const groupedExercises = groupEntriesByExercise(workout.entries as Entry[]);
+  const displayedVolume = calculateVolumeInUnit(
+    (workout.entries as Entry[]).flatMap((entry) =>
+      entry.kind === "lifting" && entry.lifting.durationSeconds === undefined
+        ? [entry.lifting]
+        : []
+    ),
+    preferredUnit
+  );
   const editableCompletedAt =
     workout.completedAt ??
     workout.startedAt + Math.max(workout.summary?.totalDurationMinutes ?? 60, 1) * 60000;
@@ -306,13 +322,13 @@ export default function WorkoutDetailsPage() {
               </div>
             )}
             {(() => {
-              const volume = workout.summary?.totalVolume;
+              const volume = displayedVolume;
               return volume && volume > 0 ? (
                 <div>
                   <p className="text-muted-foreground">Volume</p>
                   <p className="font-medium font-mono tabular-nums flex items-center gap-1">
                     <Weight className="h-4 w-4" />
-                    {volume.toLocaleString()} lb
+                    {Math.round(volume).toLocaleString()} {preferredUnit}
                   </p>
                 </div>
               ) : null;
@@ -388,7 +404,11 @@ export default function WorkoutDetailsPage() {
                               ) : (
                                 <>
                                   <span className="font-medium font-mono tabular-nums">
-                                    {entry.lifting.weight ?? 0} {entry.lifting.unit}
+                                    {displayWeight(
+                                      entry.lifting.weight ?? 0,
+                                      entry.lifting.unit,
+                                      preferredUnit
+                                    )} {preferredUnit}
                                   </span>
                                   <span className="text-muted-foreground">x</span>
                                   <span className="font-medium font-mono tabular-nums">
@@ -423,6 +443,15 @@ export default function WorkoutDetailsPage() {
                                 <Badge variant="secondary" className="text-xs">
                                   Level {entry.cardio.intensity}
                                 </Badge>
+                              )}
+                              {entry.cardio.vestWeight !== undefined && (
+                                <span className="font-medium font-mono tabular-nums">
+                                  Vest {displayWeight(
+                                    entry.cardio.vestWeight,
+                                    entry.cardio.vestWeightUnit ?? "lb",
+                                    preferredUnit
+                                  )} {preferredUnit}
+                                </span>
                               )}
                             </div>
                           </div>

--- a/src/app/workout/[id]/page.tsx
+++ b/src/app/workout/[id]/page.tsx
@@ -42,6 +42,7 @@ type LiftingEntry = {
     setNumber: number;
     reps?: number;
     weight?: number;
+    durationSeconds?: number;
     unit: "kg" | "lb";
     rpe?: number;
     isWarmup?: boolean;
@@ -380,13 +381,21 @@ export default function WorkoutDetailsPage() {
                               )}
                             </span>
                             <div className="flex items-center gap-3">
-                              <span className="font-medium font-mono tabular-nums">
-                                {entry.lifting.weight ?? 0} {entry.lifting.unit}
-                              </span>
-                              <span className="text-muted-foreground">x</span>
-                              <span className="font-medium font-mono tabular-nums">
-                                {entry.lifting.reps ?? 0} reps
-                              </span>
+                              {entry.lifting.durationSeconds !== undefined ? (
+                                <span className="font-medium font-mono tabular-nums">
+                                  {formatCardioDuration(entry.lifting.durationSeconds)} hold
+                                </span>
+                              ) : (
+                                <>
+                                  <span className="font-medium font-mono tabular-nums">
+                                    {entry.lifting.weight ?? 0} {entry.lifting.unit}
+                                  </span>
+                                  <span className="text-muted-foreground">x</span>
+                                  <span className="font-medium font-mono tabular-nums">
+                                    {entry.lifting.reps ?? 0} reps
+                                  </span>
+                                </>
+                              )}
                               {entry.lifting.rpe && (
                                 <Badge variant="secondary" className="text-xs">
                                   RPE {entry.lifting.rpe}

--- a/src/app/workout/active/page.tsx
+++ b/src/app/workout/active/page.tsx
@@ -6,6 +6,10 @@ import { useQuery, useMutation } from "convex/react";
 import { api } from "../../../../convex/_generated/api";
 import { Button } from "@/components/ui/button";
 import { ExerciseAccordion } from "@/components/workout/exercise-accordion";
+import {
+	TimedExerciseAccordion,
+	type TimedSetData,
+} from "@/components/workout/timed-exercise-accordion";
 import { CardioExerciseCard } from "@/components/workout/cardio-exercise-card";
 import { RestTimerOverlay } from "@/components/workout/rest-timer-overlay";
 import {
@@ -42,6 +46,7 @@ type EntryData = {
 		setNumber: number;
 		reps?: number;
 		weight?: number;
+		durationSeconds?: number;
 		unit: "kg" | "lb";
 		isBodyweight?: boolean;
 		rpe?: number;
@@ -91,6 +96,21 @@ function ExerciseAccordionWithHistory({
 	);
 }
 
+function TimedExerciseAccordionWithHistory({
+	exerciseName,
+	...props
+}: Omit<React.ComponentProps<typeof TimedExerciseAccordion>, "lastSession">) {
+	const history = useQuery(api.entries.getTimedExerciseHistory, { exerciseName });
+
+	return (
+		<TimedExerciseAccordion
+			exerciseName={exerciseName}
+			lastSession={history?.[0]}
+			{...props}
+		/>
+	);
+}
+
 type PendingExercise = {
 	name: string;
 	category: "lifting" | "cardio" | "mobility" | "other";
@@ -98,6 +118,8 @@ type PendingExercise = {
 	targetSets?: number;
 	targetReps?: string;
 	targetDurationMinutes?: number;
+	measurementType?: "reps" | "duration";
+	targetHoldSeconds?: number;
 	equipment?: string[];
 	muscleGroups?: string[];
 };
@@ -220,6 +242,7 @@ export default function ActiveWorkoutPage() {
 							name: entry.exerciseName,
 							category: entry.kind === "cardio" ? "cardio" : "lifting",
 							primaryMetric: entry.kind === "cardio" ? "duration" : undefined,
+							measurementType: entry.lifting?.durationSeconds ? "duration" : undefined,
 						},
 					});
 				}
@@ -254,6 +277,8 @@ export default function ActiveWorkoutPage() {
 					targetSets: ex.targetSets,
 					targetReps: ex.targetReps,
 					targetDurationMinutes: ex.targetDuration,
+					measurementType: ex.measurementType,
+					targetHoldSeconds: ex.targetHoldSeconds,
 					equipment: exerciseWithEquipment.equipment,
 				};
 			});
@@ -301,7 +326,13 @@ export default function ActiveWorkoutPage() {
 			return;
 		}
 
-		const liftingEntries = groupEntries.filter((e) => e.kind === "lifting");
+		const liftingEntries = groupEntries.filter(
+			(e) =>
+				e.kind === "lifting" &&
+				(meta.measurementType === "duration"
+					? e.lifting?.durationSeconds !== undefined
+					: e.lifting?.durationSeconds === undefined)
+		);
 		const isComplete =
 			meta.targetSets !== undefined && liftingEntries.length >= meta.targetSets;
 
@@ -383,6 +414,42 @@ export default function ActiveWorkoutPage() {
 		}
 	};
 
+	const handleAddTimedSet = async (
+		exerciseName: string,
+		set: { durationSeconds: number; rpe?: number | null }
+	) => {
+		const group = exerciseGroups.get(exerciseName);
+		const existingSets = group?.entries.filter(
+			(entry) => entry.kind === "lifting" && entry.lifting?.durationSeconds !== undefined
+		) ?? [];
+		const setNumber = existingSets.length + 1;
+
+		try {
+			await addLiftingEntry({
+				workoutId: workout._id,
+				clientId: generateClientId(),
+				exerciseName,
+				lifting: {
+					setNumber,
+					durationSeconds: set.durationSeconds,
+					unit: "lb",
+					rpe: set.rpe ?? undefined,
+				},
+			});
+			posthog.capture("set_logged", {
+				exercise_name: exerciseName,
+				set_number: setNumber,
+				measurement_type: "duration",
+				duration_seconds: set.durationSeconds,
+				rpe: set.rpe ?? null,
+			});
+			setShowRestTimer(true);
+		} catch (error) {
+			posthog.captureException(error);
+			throw error;
+		}
+	};
+
 	const handleLogCardio = async (
 		exerciseName: string,
 		data: {
@@ -440,6 +507,7 @@ export default function ActiveWorkoutPage() {
 						category: exercise.category,
 						muscleGroups: exercise.muscleGroups,
 						primaryMetric: exercise.primaryMetric,
+						measurementType: exercise.measurementType,
 					});
 				} catch (error) {
 					console.error("Failed to create exercise:", error);
@@ -450,7 +518,15 @@ export default function ActiveWorkoutPage() {
 		setShowAddExercise(false);
 	};
 
-	const handleSwapComplete = (oldExercise: string, newExercise: string) => {
+	const handleSwapComplete = (
+		oldExercise: string,
+		selection: {
+			name: string;
+			measurementType: "reps" | "duration";
+			targetHoldSeconds?: number;
+		}
+	) => {
+		const newExercise = selection.name;
 		const isPendingExercise = pendingExercises.some(
 			(p) => p.name === oldExercise
 		);
@@ -458,13 +534,32 @@ export default function ActiveWorkoutPage() {
 		if (isPendingExercise) {
 			setPendingExercises((prev) =>
 				prev.map((p) =>
-					p.name === oldExercise ? { ...p, name: newExercise } : p
+					p.name === oldExercise
+						? {
+								...p,
+								name: newExercise,
+								measurementType: selection.measurementType,
+								targetHoldSeconds:
+									selection.measurementType === "duration"
+										? selection.targetHoldSeconds ?? 30
+										: undefined,
+								targetReps:
+									selection.measurementType === "duration"
+										? undefined
+										: p.targetReps ?? "8-12",
+							}
+						: p
 				)
 			);
 		} else if (!exerciseGroups.has(newExercise)) {
 			setPendingExercises((prev) => [
 				...prev,
-				{ name: newExercise, category: "lifting" as const },
+				{
+					name: newExercise,
+					category: "lifting" as const,
+					measurementType: selection.measurementType,
+					targetHoldSeconds: selection.targetHoldSeconds,
+				},
 			]);
 		}
 		posthog.capture("exercise_swapped", {
@@ -607,23 +702,45 @@ export default function ActiveWorkoutPage() {
 		});
 	};
 
+	const handleEditTimedSet = (exerciseName: string, set: TimedSetData) => {
+		if (!set.entryId) return;
+		setEditingSet({
+			entryId: set.entryId,
+			exerciseName,
+			setNumber: set.setNumber,
+			reps: 0,
+			weight: 0,
+			unit: "lb",
+			durationSeconds: set.durationSeconds,
+			rpe: set.rpe,
+		});
+	};
+
 	const handleUpdateSet = async (
 		entryId: string,
-		data: { reps: number; weight: number; rpe?: number | null }
+		data: { reps?: number; weight?: number; durationSeconds?: number; rpe?: number | null }
 	) => {
 		if (!editingSet) return;
 		try {
 			await updateLiftingEntry({
 				entryId:
 					entryId as unknown as import("../../../../convex/_generated/dataModel").Id<"entries">,
-				lifting: {
-					setNumber: editingSet.setNumber,
-					reps: data.reps,
-					weight: data.weight,
-					unit: editingSet.unit,
-					isBodyweight: editingSet.isBodyweight,
-					rpe: data.rpe ?? undefined,
-				},
+				lifting:
+					data.durationSeconds !== undefined
+						? {
+								setNumber: editingSet.setNumber,
+								durationSeconds: data.durationSeconds,
+								unit: editingSet.unit,
+								rpe: data.rpe ?? undefined,
+							}
+						: {
+								setNumber: editingSet.setNumber,
+								reps: data.reps,
+								weight: data.weight,
+								unit: editingSet.unit,
+								isBodyweight: editingSet.isBodyweight,
+								rpe: data.rpe ?? undefined,
+							},
 			});
 			vibrate("success");
 			toast.success("Set updated");
@@ -785,6 +902,47 @@ export default function ActiveWorkoutPage() {
 							);
 						}
 
+						if (meta.measurementType === "duration") {
+							const timedSets = groupEntries
+								.filter(
+									(entry) =>
+										entry.kind === "lifting" &&
+										entry.lifting?.durationSeconds !== undefined
+								)
+								.map((entry) => ({
+									entryId: entry._id,
+									setNumber: entry.lifting!.setNumber,
+									durationSeconds: entry.lifting!.durationSeconds!,
+									rpe: entry.lifting!.rpe ?? null,
+								}));
+
+							return (
+								<div
+									key={name}
+									ref={(element) => {
+										if (element) exerciseRefs.current.set(name, element);
+									}}
+								>
+									<TimedExerciseAccordionWithHistory
+										exerciseName={name}
+										sets={timedSets}
+										status={getExerciseStatus()}
+										targetSets={meta.targetSets}
+										targetDurationSeconds={meta.targetHoldSeconds}
+										note={getExerciseNote(name)}
+										onAddSet={(set) => handleAddTimedSet(name, set)}
+										onEditSet={(set) => handleEditTimedSet(name, set)}
+										onSwap={() => setSwapExercise(name)}
+										onNoteChange={(note) => handleNoteChange(name, note)}
+										onSelect={() => {
+											setManualNavigation(true);
+											setCurrentExerciseIndex(index);
+										}}
+									/>
+								</div>
+							);
+						}
+
 						const sets = groupEntries
 							.filter((e) => e.kind === "lifting" && e.lifting)
 							.map((e) => ({
@@ -881,8 +1039,8 @@ export default function ActiveWorkoutPage() {
 					onOpenChange={(open) => !open && setSwapExercise(null)}
 					workoutId={workout._id}
 					exerciseName={swapExercise}
-					onSwapComplete={(newExercise) =>
-						handleSwapComplete(swapExercise, newExercise)
+					onSwapComplete={(selection) =>
+						handleSwapComplete(swapExercise, selection)
 					}
 				/>
 			)}

--- a/src/app/workout/active/page.tsx
+++ b/src/app/workout/active/page.tsx
@@ -41,6 +41,10 @@ import {
 	editedWeightForStorage,
 	type WeightUnit,
 } from "@/lib/units";
+import {
+	CardioSaveBlockedError,
+	createCardioPersistenceGate,
+} from "@/lib/cardio-persistence";
 import posthog from "posthog-js";
 
 type EntryData = {
@@ -168,6 +172,11 @@ export default function ActiveWorkoutPage() {
 	);
 	const [isCompletingWithEditedTime, setIsCompletingWithEditedTime] =
 		useState(false);
+	const [isCompleting, setIsCompleting] = useState(false);
+	const [pendingCardioSaveCount, setPendingCardioSaveCount] = useState(0);
+	const [cardioPersistenceGate] = useState(() =>
+		createCardioPersistenceGate(setPendingCardioSaveCount)
+	);
 	const exerciseRefs = useRef<Map<string, HTMLDivElement>>(new Map());
 
 	const workout = useQuery(api.workouts.getActiveWorkout);
@@ -465,38 +474,50 @@ export default function ActiveWorkoutPage() {
 		}
 	) => {
 		try {
-			await addCardioEntry({
-				workoutId: workout._id,
-				clientId: generateClientId(),
-				exerciseName,
-				cardio: {
-					mode: "steady",
-					durationSeconds: data.durationSeconds,
+			await cardioPersistenceGate.runSave(async () => {
+				await addCardioEntry({
+					workoutId: workout._id,
+					clientId: generateClientId(),
+					exerciseName,
+					cardio: {
+						mode: "steady",
+						durationSeconds: data.durationSeconds,
+						distance: data.distance,
+						distanceUnit:
+							data.distanceUnit === "km"
+								? "km"
+								: data.distanceUnit === "mi"
+									? "mi"
+									: undefined,
+						rpe: data.rpe,
+						vestWeight: data.vestWeight,
+						vestWeightUnit: data.vestWeightUnit,
+						intensity: data.intensity,
+					},
+				});
+				posthog.capture("cardio_logged", {
+					exercise_name: exerciseName,
+					duration_seconds: data.durationSeconds,
 					distance: data.distance,
-					distanceUnit:
-						data.distanceUnit === "km"
-							? "km"
-							: data.distanceUnit === "mi"
-								? "mi"
-								: undefined,
+					distance_unit: data.distanceUnit,
 					rpe: data.rpe,
-					vestWeight: data.vestWeight,
-					vestWeightUnit: data.vestWeightUnit,
-					intensity: data.intensity,
-				},
-			});
-			posthog.capture("cardio_logged", {
-				exercise_name: exerciseName,
-				duration_seconds: data.durationSeconds,
-				distance: data.distance,
-				distance_unit: data.distanceUnit,
-				rpe: data.rpe,
+				});
 			});
 			// Don't remove from pendingExercises - we need to preserve order and metadata
 			toast.success("Cardio logged!");
 		} catch (error) {
-			toast.error("Failed to log cardio");
+			const reason =
+				error instanceof CardioSaveBlockedError
+					? "workout_completing"
+					: "mutation_failed";
+			posthog.capture("cardio_log_failed", { reason });
+			toast.error(
+				reason === "workout_completing"
+					? "Workout is already finishing"
+					: "Failed to log cardio"
+			);
 			console.error(error);
+			throw error;
 		}
 	};
 
@@ -596,6 +617,15 @@ export default function ActiveWorkoutPage() {
 	};
 
 	const handleComplete = async () => {
+		const completionStart = cardioPersistenceGate.tryStartCompletion();
+		if (completionStart !== "started") {
+			if (completionStart === "cardio_save_pending") {
+				toast.info("Wait for cardio to finish saving");
+			}
+			return;
+		}
+
+		setIsCompleting(true);
 		vibrate("success");
 		try {
 			await completeWorkout({ workoutId: workout._id });
@@ -604,10 +634,17 @@ export default function ActiveWorkoutPage() {
 			toast.error("Failed to complete workout");
 			posthog.captureException(error);
 			console.error(error);
+		} finally {
+			setIsCompleting(false);
+			cardioPersistenceGate.finishCompletion();
 		}
 	};
 
 	const handleOpenTimeEditor = () => {
+		if (cardioPersistenceGate.pendingCount > 0) {
+			toast.info("Wait for cardio to finish saving");
+			return;
+		}
 		setTimeEditorInitialEnd(Date.now());
 		setShowTimeEditor(true);
 	};
@@ -616,6 +653,15 @@ export default function ActiveWorkoutPage() {
 		startedAt: number,
 		completedAt: number
 	) => {
+		const completionStart = cardioPersistenceGate.tryStartCompletion();
+		if (completionStart !== "started") {
+			throw new Error(
+				completionStart === "cardio_save_pending"
+					? "Wait for cardio to finish saving"
+					: "Workout completion is already in progress"
+			);
+		}
+
 		setIsCompletingWithEditedTime(true);
 		vibrate("success");
 		try {
@@ -631,6 +677,7 @@ export default function ActiveWorkoutPage() {
 			throw error;
 		} finally {
 			setIsCompletingWithEditedTime(false);
+			cardioPersistenceGate.finishCompletion();
 		}
 	};
 
@@ -810,6 +857,8 @@ export default function ActiveWorkoutPage() {
 
 	const currentExerciseName = exerciseList[currentExerciseIndex]?.[0];
 	const nextExerciseName = exerciseList[currentExerciseIndex + 1]?.[0];
+	const hasPendingCardioSaves = pendingCardioSaveCount > 0;
+	const isWorkoutCompleting = isCompleting || isCompletingWithEditedTime;
 
 	const jumpToCurrentExercise = () => {
 		if (!currentExerciseName) return;
@@ -836,6 +885,7 @@ export default function ActiveWorkoutPage() {
 								size="sm"
 								className="h-auto px-1.5 py-0 text-xs text-muted-foreground"
 								onClick={handleOpenTimeEditor}
+								disabled={hasPendingCardioSaves || isWorkoutCompleting}
 							>
 								Edit time
 							</Button>
@@ -850,9 +900,32 @@ export default function ActiveWorkoutPage() {
 						>
 							Cancel
 						</Button>
-						<Button size="sm" onClick={handleComplete}>
-							Finish
+						<Button
+							size="sm"
+							onClick={handleComplete}
+							disabled={hasPendingCardioSaves || isWorkoutCompleting}
+							aria-describedby={
+								hasPendingCardioSaves ? "cardio-save-status" : undefined
+							}
+						>
+							{hasPendingCardioSaves
+								? "Saving..."
+								: isWorkoutCompleting
+									? "Finishing..."
+									: "Finish"}
 						</Button>
+						<span
+							id="cardio-save-status"
+							className="sr-only"
+							role="status"
+							aria-live="polite"
+						>
+							{hasPendingCardioSaves
+								? `${pendingCardioSaveCount} cardio ${
+										pendingCardioSaveCount === 1 ? "entry is" : "entries are"
+									} still saving.`
+								: ""}
+						</span>
 					</div>
 				</div>
 			</header>
@@ -884,7 +957,9 @@ export default function ActiveWorkoutPage() {
 						};
 
 						if (meta.category === "cardio") {
-							const hasLogged = groupEntries.some((e) => e.kind === "cardio");
+							const loggedCardioEntry = groupEntries.find(
+								(entry) => entry.kind === "cardio"
+							);
 							const status = getExerciseStatus();
 
 							return (
@@ -901,11 +976,8 @@ export default function ActiveWorkoutPage() {
 										status={status}
 										defaultMinutes={meta.targetDurationMinutes}
 										note={getExerciseNote(name)}
-										onLog={
-											hasLogged
-												? () => {}
-												: (data) => handleLogCardio(name, data)
-										}
+										loggedData={loggedCardioEntry?.cardio}
+										onLog={(data) => handleLogCardio(name, data)}
 										onNoteChange={(note: string) =>
 											handleNoteChange(name, note)
 										}

--- a/src/app/workout/active/page.tsx
+++ b/src/app/workout/active/page.tsx
@@ -64,7 +64,7 @@ type EntryData = {
 	cardio?: {
 		durationSeconds: number;
 		distance?: number;
-		distanceUnit?: "km" | "mi";
+		distanceUnit?: "m" | "km" | "mi";
 		rpe?: number;
 		vestWeight?: number;
 		vestWeightUnit?: "kg" | "lb";

--- a/src/app/workout/active/page.tsx
+++ b/src/app/workout/active/page.tsx
@@ -36,6 +36,7 @@ import { Skeleton } from "@/components/ui/skeleton";
 import { toast } from "sonner";
 import { calculateProgressionSuggestion } from "@/lib/progression";
 import { convertWeight, type WeightUnit } from "@/lib/units";
+import { getExerciseGroupKey } from "@/lib/workout-exercise-group";
 import posthog from "posthog-js";
 
 type EntryData = {
@@ -124,6 +125,17 @@ type PendingExercise = {
 	muscleGroups?: string[];
 };
 
+function getEntryGroupKey(entry: EntryData) {
+	return getExerciseGroupKey({
+		name: entry.exerciseName,
+		category: entry.kind === "cardio" ? "cardio" : "lifting",
+		measurementType:
+			entry.kind === "lifting" && entry.lifting?.durationSeconds !== undefined
+				? "duration"
+				: "reps",
+	});
+}
+
 function useDuration(startedAt: number | undefined) {
 	const [duration, setDuration] = useState("");
 
@@ -155,7 +167,10 @@ export default function ActiveWorkoutPage() {
 	const [pendingExercises, setPendingExercises] = useState<PendingExercise[]>(
 		[]
 	);
-	const [swapExercise, setSwapExercise] = useState<string | null>(null);
+	const [swapExercise, setSwapExercise] = useState<{
+		groupKey: string;
+		name: string;
+	} | null>(null);
 	const [showSwapFollowUp, setShowSwapFollowUp] = useState(false);
 	const [editingSet, setEditingSet] = useState<EditableSet | null>(null);
 	const [currentExerciseIndex, setCurrentExerciseIndex] = useState(0);
@@ -224,25 +239,29 @@ export default function ActiveWorkoutPage() {
 
 		// First, add all pending exercises to establish stable order and meta (targetSets, targetReps, etc.)
 		for (const pending of pendingExercises) {
-			groups.set(pending.name, { entries: [], meta: pending });
+			groups.set(getExerciseGroupKey(pending), { entries: [], meta: pending });
 		}
 
 		// Then, add entries to their groups (entries may exist for exercises in pendingExercises)
 		if (entries) {
 			for (const entry of entries) {
-				const existing = groups.get(entry.exerciseName);
+				const groupKey = getEntryGroupKey(entry as EntryData);
+				const existing = groups.get(groupKey);
 				if (existing) {
 					existing.entries.push(entry as EntryData);
 				} else {
 					// Entry for an exercise not in pendingExercises (edge case: old data or manual add)
 					// Add at the end to preserve stable ordering of pending exercises
-					groups.set(entry.exerciseName, {
+					groups.set(groupKey, {
 						entries: [entry as EntryData],
 						meta: {
 							name: entry.exerciseName,
 							category: entry.kind === "cardio" ? "cardio" : "lifting",
 							primaryMetric: entry.kind === "cardio" ? "duration" : undefined,
-							measurementType: entry.lifting?.durationSeconds ? "duration" : undefined,
+							measurementType:
+								entry.lifting?.durationSeconds !== undefined
+									? "duration"
+									: undefined,
 						},
 					});
 				}
@@ -350,8 +369,8 @@ export default function ActiveWorkoutPage() {
 		const currentExercise = exerciseList[currentExerciseIndex];
 		if (!currentExercise) return;
 
-		const [name] = currentExercise;
-		const element = exerciseRefs.current.get(name);
+		const [groupKey] = currentExercise;
+		const element = exerciseRefs.current.get(groupKey);
 
 		if (element) {
 			setTimeout(() => {
@@ -380,7 +399,11 @@ export default function ActiveWorkoutPage() {
 			rpe?: number | null;
 		}
 	) => {
-		const group = exerciseGroups.get(exerciseName);
+		const group = exerciseGroups.get(getExerciseGroupKey({
+			name: exerciseName,
+			category: "lifting",
+			measurementType: "reps",
+		}));
 		const existingSets = group?.entries ?? [];
 		const setNumber = existingSets.length + 1;
 
@@ -418,7 +441,11 @@ export default function ActiveWorkoutPage() {
 		exerciseName: string,
 		set: { durationSeconds: number; rpe?: number | null }
 	) => {
-		const group = exerciseGroups.get(exerciseName);
+		const group = exerciseGroups.get(getExerciseGroupKey({
+			name: exerciseName,
+			category: "lifting",
+			measurementType: "duration",
+		}));
 		const existingSets = group?.entries.filter(
 			(entry) => entry.kind === "lifting" && entry.lifting?.durationSeconds !== undefined
 		) ?? [];
@@ -499,7 +526,8 @@ export default function ActiveWorkoutPage() {
 	};
 
 	const handleAddExercise = async (exercise: ExerciseSelection) => {
-		if (!exerciseGroups.has(exercise.name)) {
+		const groupKey = getExerciseGroupKey(exercise);
+		if (!exerciseGroups.has(groupKey)) {
 			if (exercise.muscleGroups && exercise.muscleGroups.length > 0) {
 				try {
 					await createExercise({
@@ -519,7 +547,7 @@ export default function ActiveWorkoutPage() {
 	};
 
 	const handleSwapComplete = (
-		oldExercise: string,
+		oldExercise: { groupKey: string; name: string },
 		selection: {
 			name: string;
 			measurementType: "reps" | "duration";
@@ -528,13 +556,13 @@ export default function ActiveWorkoutPage() {
 	) => {
 		const newExercise = selection.name;
 		const isPendingExercise = pendingExercises.some(
-			(p) => p.name === oldExercise
+			(p) => getExerciseGroupKey(p) === oldExercise.groupKey
 		);
 
 		if (isPendingExercise) {
 			setPendingExercises((prev) =>
 				prev.map((p) =>
-					p.name === oldExercise
+					getExerciseGroupKey(p) === oldExercise.groupKey
 						? {
 								...p,
 								name: newExercise,
@@ -551,7 +579,11 @@ export default function ActiveWorkoutPage() {
 						: p
 				)
 			);
-		} else if (!exerciseGroups.has(newExercise)) {
+		} else if (!exerciseGroups.has(getExerciseGroupKey({
+			name: newExercise,
+			category: "lifting",
+			measurementType: selection.measurementType,
+		}))) {
 			setPendingExercises((prev) => [
 				...prev,
 				{
@@ -563,7 +595,7 @@ export default function ActiveWorkoutPage() {
 			]);
 		}
 		posthog.capture("exercise_swapped", {
-			old_exercise: oldExercise,
+			old_exercise: oldExercise.name,
 			new_exercise: newExercise,
 			workout_id: workout._id,
 		});
@@ -793,12 +825,13 @@ export default function ActiveWorkoutPage() {
 		return { loggedSets, targetSets, totalVolume, unit };
 	})();
 
-	const currentExerciseName = exerciseList[currentExerciseIndex]?.[0];
-	const nextExerciseName = exerciseList[currentExerciseIndex + 1]?.[0];
+	const currentExerciseName = exerciseList[currentExerciseIndex]?.[1].meta.name;
+	const nextExerciseName = exerciseList[currentExerciseIndex + 1]?.[1].meta.name;
 
 	const jumpToCurrentExercise = () => {
-		if (!currentExerciseName) return;
-		const element = exerciseRefs.current.get(currentExerciseName);
+		const currentExerciseKey = exerciseList[currentExerciseIndex]?.[0];
+		if (!currentExerciseKey) return;
+		const element = exerciseRefs.current.get(currentExerciseKey);
 		if (element) {
 			element.scrollIntoView({ behavior: "smooth", block: "center" });
 		}
@@ -858,7 +891,8 @@ export default function ActiveWorkoutPage() {
 
 			<main className="flex-1 space-y-4 p-4">
 				{Array.from(exerciseGroups.entries()).map(
-					([name, { entries: groupEntries, meta }], index) => {
+					([groupKey, { entries: groupEntries, meta }], index) => {
+						const name = meta.name;
 						const getExerciseStatus = ():
 							| "completed"
 							| "current"
@@ -874,9 +908,9 @@ export default function ActiveWorkoutPage() {
 
 							return (
 								<div
-									key={name}
+									key={groupKey}
 									ref={(el) => {
-										if (el) exerciseRefs.current.set(name, el);
+										if (el) exerciseRefs.current.set(groupKey, el);
 									}}
 								>
 									<CardioExerciseCard
@@ -918,9 +952,9 @@ export default function ActiveWorkoutPage() {
 
 							return (
 								<div
-									key={name}
+									key={groupKey}
 									ref={(element) => {
-										if (element) exerciseRefs.current.set(name, element);
+										if (element) exerciseRefs.current.set(groupKey, element);
 									}}
 								>
 									<TimedExerciseAccordionWithHistory
@@ -932,7 +966,7 @@ export default function ActiveWorkoutPage() {
 										note={getExerciseNote(name)}
 										onAddSet={(set) => handleAddTimedSet(name, set)}
 										onEditSet={(set) => handleEditTimedSet(name, set)}
-										onSwap={() => setSwapExercise(name)}
+										onSwap={() => setSwapExercise({ groupKey, name })}
 										onNoteChange={(note) => handleNoteChange(name, note)}
 										onSelect={() => {
 											setManualNavigation(true);
@@ -967,9 +1001,9 @@ export default function ActiveWorkoutPage() {
 
 						return (
 							<div
-								key={name}
+								key={groupKey}
 								ref={(el) => {
-									if (el) exerciseRefs.current.set(name, el);
+									if (el) exerciseRefs.current.set(groupKey, el);
 								}}
 							>
 								<ExerciseAccordionWithHistory
@@ -997,7 +1031,7 @@ export default function ActiveWorkoutPage() {
 										isBodyweight?: boolean;
 										rpe?: number | null;
 									}) => handleEditSet(name, set)}
-									onSwap={() => setSwapExercise(name)}
+									onSwap={() => setSwapExercise({ groupKey, name })}
 									onNoteChange={(note: string) => handleNoteChange(name, note)}
 									onSelect={() => {
 										setManualNavigation(true);
@@ -1038,7 +1072,7 @@ export default function ActiveWorkoutPage() {
 					open={!!swapExercise}
 					onOpenChange={(open) => !open && setSwapExercise(null)}
 					workoutId={workout._id}
-					exerciseName={swapExercise}
+					exerciseName={swapExercise.name}
 					onSwapComplete={(selection) =>
 						handleSwapComplete(swapExercise, selection)
 					}

--- a/src/app/workout/active/page.tsx
+++ b/src/app/workout/active/page.tsx
@@ -35,7 +35,12 @@ import { useHaptic } from "@/hooks/use-haptic";
 import { Skeleton } from "@/components/ui/skeleton";
 import { toast } from "sonner";
 import { calculateProgressionSuggestion } from "@/lib/progression";
-import { convertWeight, type WeightUnit } from "@/lib/units";
+import {
+	calculateVolumeInUnit,
+	displayWeight,
+	editedWeightForStorage,
+	type WeightUnit,
+} from "@/lib/units";
 import posthog from "posthog-js";
 
 type EntryData = {
@@ -75,13 +80,8 @@ function ExerciseAccordionWithHistory({
 
 	const ghostData = useMemo(() => {
 		if (!history || history.length === 0) return null;
-		return calculateProgressionSuggestion(history, targetReps);
-	}, [history, targetReps]);
-
-	const resolvedUnit =
-		sets.length > 0
-			? sets[sets.length - 1].unit
-			: ghostData?.lastSession.unit ?? unit;
+		return calculateProgressionSuggestion(history, targetReps, unit);
+	}, [history, targetReps, unit]);
 
 	return (
 		<ExerciseAccordion
@@ -90,7 +90,7 @@ function ExerciseAccordionWithHistory({
 			sets={sets}
 			lastSession={ghostData?.lastSession}
 			progressionSuggestion={ghostData?.suggestion}
-			unit={resolvedUnit}
+			unit={unit}
 			{...rest}
 		/>
 	);
@@ -171,6 +171,8 @@ export default function ActiveWorkoutPage() {
 	const exerciseRefs = useRef<Map<string, HTMLDivElement>>(new Map());
 
 	const workout = useQuery(api.workouts.getActiveWorkout);
+	const user = useQuery(api.users.getCurrentUser);
+	const preferredUnit: WeightUnit = user?.preferredUnits ?? "lb";
 	const entries = useQuery(
 		api.entries.getEntriesByWorkout,
 		workout ? { workoutId: workout._id } : "skip"
@@ -360,7 +362,7 @@ export default function ActiveWorkoutPage() {
 		}
 	}, [currentExerciseIndex, exerciseList]);
 
-	if (workout === undefined || workout === null) {
+	if (workout === undefined || workout === null || user === undefined) {
 		return (
 			<div className="flex min-h-screen flex-col p-4">
 				<Skeleton className="mb-4 h-8 w-48" />
@@ -393,7 +395,7 @@ export default function ActiveWorkoutPage() {
 					setNumber,
 					reps: set.reps,
 					weight: set.weight,
-					unit: set.unit,
+					unit: preferredUnit,
 					isBodyweight: set.isBodyweight,
 					rpe: set.rpe ?? undefined,
 				},
@@ -403,7 +405,7 @@ export default function ActiveWorkoutPage() {
 				set_number: setNumber,
 				reps: set.reps,
 				weight: set.weight,
-				unit: set.unit,
+				unit: preferredUnit,
 				is_bodyweight: set.isBodyweight ?? false,
 				rpe: set.rpe ?? null,
 			});
@@ -690,6 +692,9 @@ export default function ActiveWorkoutPage() {
 		}
 	) => {
 		if (!set.entryId) return;
+		const storedSet = exerciseGroups
+			.get(exerciseName)
+			?.entries.find((entry) => entry._id === set.entryId)?.lifting;
 		setEditingSet({
 			entryId: set.entryId,
 			exerciseName,
@@ -697,6 +702,8 @@ export default function ActiveWorkoutPage() {
 			reps: set.reps,
 			weight: set.weight,
 			unit: set.unit,
+			storedWeight: storedSet?.weight,
+			storedUnit: storedSet?.unit,
 			isBodyweight: set.isBodyweight,
 			rpe: set.rpe,
 		});
@@ -736,8 +743,18 @@ export default function ActiveWorkoutPage() {
 						: {
 								setNumber: editingSet.setNumber,
 								reps: data.reps,
-								weight: data.weight,
-								unit: editingSet.unit,
+								weight:
+									data.weight === undefined
+										? undefined
+										: editedWeightForStorage({
+												displayedWeight: data.weight,
+												displayUnit: editingSet.unit,
+												storedUnit:
+													editingSet.storedUnit ?? editingSet.unit,
+												originalDisplayedWeight: editingSet.weight,
+												originalStoredWeight: editingSet.storedWeight,
+											}),
+								unit: editingSet.storedUnit ?? editingSet.unit,
 								isBodyweight: editingSet.isBodyweight,
 								rpe: data.rpe ?? undefined,
 							},
@@ -768,8 +785,6 @@ export default function ActiveWorkoutPage() {
 		let loggedSets = 0;
 		let targetSets = 0;
 		let totalVolume = 0;
-		// Normalize all lifting volume to lb so mixed-unit workouts sum correctly.
-		const unit: WeightUnit = "lb";
 
 		for (const [, { entries: groupEntries, meta }] of exerciseGroups) {
 			if (meta.category === "cardio") {
@@ -782,15 +797,15 @@ export default function ActiveWorkoutPage() {
 			loggedSets += liftingEntries.length;
 			targetSets += meta.targetSets ?? Math.max(liftingEntries.length, 1);
 
-			for (const entry of liftingEntries) {
-				if (!entry.lifting) continue;
-				const weight = entry.lifting.weight ?? 0;
-				const weightLb = convertWeight(weight, entry.lifting.unit ?? unit, unit);
-				totalVolume += weightLb * (entry.lifting.reps ?? 0);
-			}
+			totalVolume += calculateVolumeInUnit(
+				liftingEntries.flatMap((entry) =>
+					entry.lifting ? [entry.lifting] : []
+				),
+				preferredUnit
+			);
 		}
 
-		return { loggedSets, targetSets, totalVolume, unit };
+		return { loggedSets, targetSets, totalVolume, unit: preferredUnit };
 	})();
 
 	const currentExerciseName = exerciseList[currentExerciseIndex]?.[0];
@@ -882,6 +897,7 @@ export default function ActiveWorkoutPage() {
 									<CardioExerciseCard
 										exerciseName={name}
 										primaryMetric={meta.primaryMetric ?? "duration"}
+										unit={preferredUnit}
 										status={status}
 										defaultMinutes={meta.targetDurationMinutes}
 										note={getExerciseNote(name)}
@@ -945,15 +961,22 @@ export default function ActiveWorkoutPage() {
 
 						const sets = groupEntries
 							.filter((e) => e.kind === "lifting" && e.lifting)
-							.map((e) => ({
-								entryId: e._id,
-								setNumber: e.lifting!.setNumber,
-								reps: e.lifting!.reps ?? 0,
-								weight: e.lifting!.weight ?? 0,
-								unit: (e.lifting!.unit ?? "lb") as "lb" | "kg",
-								isBodyweight: e.lifting!.isBodyweight,
-								rpe: e.lifting!.rpe ?? null,
-							}));
+							.map((e) => {
+								const sourceUnit = e.lifting!.unit ?? "lb";
+								return {
+									entryId: e._id,
+									setNumber: e.lifting!.setNumber,
+									reps: e.lifting!.reps ?? 0,
+									weight: displayWeight(
+										e.lifting!.weight ?? 0,
+										sourceUnit,
+										preferredUnit
+									),
+									unit: preferredUnit,
+									isBodyweight: e.lifting!.isBodyweight,
+									rpe: e.lifting!.rpe ?? null,
+								};
+							});
 
 						const parseTargetReps = (
 							targetReps?: string
@@ -976,6 +999,7 @@ export default function ActiveWorkoutPage() {
 									exerciseName={name}
 									sets={sets}
 									status={status}
+									unit={preferredUnit}
 									equipment={meta.equipment}
 									defaultReps={parseTargetReps(meta.targetReps)}
 									targetSets={meta.targetSets}

--- a/src/components/workout/add-exercise-sheet.tsx
+++ b/src/components/workout/add-exercise-sheet.tsx
@@ -21,6 +21,7 @@ export interface ExerciseSelection {
   name: string;
   category: "lifting" | "cardio" | "mobility" | "other";
   primaryMetric?: "duration" | "distance";
+  measurementType?: "reps" | "duration";
   equipment?: string[];
   muscleGroups?: string[];
 }
@@ -41,6 +42,7 @@ export function AddExerciseSheet({
   const [activeTab, setActiveTab] = useState<"lifting" | "cardio">("lifting");
   const [selectedMuscleGroups, setSelectedMuscleGroups] = useState<string[]>([]);
   const [showMuscleGroupPicker, setShowMuscleGroupPicker] = useState(false);
+  const [customMeasurementType, setCustomMeasurementType] = useState<"reps" | "duration">("reps");
   const { vibrate } = useHaptic();
 
   const exercises = useQuery(api.exercises.getExercises, {
@@ -57,6 +59,7 @@ export function AddExerciseSheet({
     setSearchQuery("");
     setSelectedMuscleGroups([]);
     setShowMuscleGroupPicker(false);
+    setCustomMeasurementType("reps");
   };
 
   const toggleMuscleGroup = (muscle: string) => {
@@ -80,6 +83,7 @@ export function AddExerciseSheet({
         name: customExercise.trim(),
         category: activeTab,
         primaryMetric: activeTab === "cardio" ? "duration" : undefined,
+        measurementType: activeTab === "lifting" ? customMeasurementType : undefined,
         muscleGroups: selectedMuscleGroups.length > 0 ? selectedMuscleGroups : undefined,
       });
     }
@@ -142,6 +146,18 @@ export function AddExerciseSheet({
 
             {customExercise.trim() && activeTab === "lifting" && (
               <div className="flex flex-col gap-2">
+				<div className="space-y-2">
+				  <span className="text-sm font-medium">Measure By</span>
+				  <Tabs
+					value={customMeasurementType}
+					onValueChange={(value) => setCustomMeasurementType(value as "reps" | "duration")}
+				  >
+					<TabsList className="grid w-full grid-cols-2">
+					  <TabsTrigger value="reps">Reps</TabsTrigger>
+					  <TabsTrigger value="duration">Time</TabsTrigger>
+					</TabsList>
+				  </Tabs>
+				</div>
                 <div className="flex items-center justify-between">
                   <span className="text-sm font-medium">
                     Muscle Groups {showMuscleGroupPicker && <span className="text-destructive">*</span>}
@@ -197,6 +213,7 @@ export function AddExerciseSheet({
                       name: exercise.name,
                       category: exercise.category,
                       primaryMetric: exercise.primaryMetric,
+                      measurementType: exercise.measurementType,
                       equipment: exercise.equipment,
                       muscleGroups: exercise.muscleGroups,
                     })
@@ -207,6 +224,9 @@ export function AddExerciseSheet({
                     <span className="text-xs text-muted-foreground ml-2 shrink-0">
                       {exercise.primaryMetric === "distance" ? "Distance" : "Time"}
                     </span>
+                  )}
+                  {exercise.category === "lifting" && exercise.measurementType === "duration" && (
+                    <span className="text-xs text-muted-foreground ml-2 shrink-0">Time</span>
                   )}
                 </button>
               ))}

--- a/src/components/workout/cardio-exercise-card.tsx
+++ b/src/components/workout/cardio-exercise-card.tsx
@@ -189,7 +189,7 @@ export function CardioExerciseCard({
   const [rpe, setRpe] = useState(5);
   const [showEquipment, setShowEquipment] = useState(false);
   const [useVest, setUseVest] = useState(false);
-  const [vestWeight, setVestWeight] = useState(20);
+  const [vestWeight, setVestWeight] = useState(unit === "kg" ? 10 : 20);
   const [isLogged, setIsLogged] = useState(false);
   const [showNoteSheet, setShowNoteSheet] = useState(false);
 

--- a/src/components/workout/cardio-exercise-card.tsx
+++ b/src/components/workout/cardio-exercise-card.tsx
@@ -9,6 +9,10 @@ import { SetStepper } from "./set-stepper";
 import { useHaptic } from "@/hooks/use-haptic";
 import { Check, ChevronDown, ChevronUp, Dumbbell, MessageSquare } from "lucide-react";
 import { CardioSaveBlockedError } from "@/lib/cardio-persistence";
+import {
+  getCardioDisplaySummary,
+  type PersistedCardioSummary,
+} from "@/lib/cardio-display";
 import { cn } from "@/lib/utils";
 
 type ExerciseStatus = "completed" | "current" | "upcoming";
@@ -23,6 +27,12 @@ export type CardioLogData = {
   intensity?: number;
 };
 
+export type PersistedCardioLogData = Omit<
+  CardioLogData,
+  "distanceUnit"
+> &
+  PersistedCardioSummary;
+
 interface CardioExerciseCardProps {
   exerciseName: string;
   primaryMetric: "duration" | "distance";
@@ -31,7 +41,7 @@ interface CardioExerciseCardProps {
   distanceUnit?: "km" | "mi";
   defaultMinutes?: number;
   note?: string;
-  loggedData?: CardioLogData;
+  loggedData?: PersistedCardioLogData;
   onLog: (data: CardioLogData) => Promise<void>;
   onNoteChange?: (note: string) => void;
   onSelect?: () => void;
@@ -205,10 +215,12 @@ export function CardioExerciseCard({
   const totalSeconds = minutes * 60 + seconds;
   const canLog = primaryMetric === "duration" ? totalSeconds > 0 : distance > 0;
   const isLogged = loggedData !== undefined || hasAcknowledgedLog;
-  const loggedDurationSeconds = loggedData?.durationSeconds ?? totalSeconds;
-  const loggedDistance = loggedData?.distance ?? distance;
-  const loggedDistanceUnit = loggedData?.distanceUnit ?? distanceUnit;
-  const loggedRpe = loggedData?.rpe ?? rpe;
+  const loggedSummary = getCardioDisplaySummary(loggedData, {
+    durationSeconds: totalSeconds,
+    distance,
+    distanceUnit,
+    rpe,
+  });
   const loggedVestWeight = loggedData?.vestWeight ?? vestWeight;
   const loggedVestWeightUnit = loggedData?.vestWeightUnit ?? unit;
   const hasLoggedVest = loggedData
@@ -355,11 +367,13 @@ export function CardioExerciseCard({
 
             {displayStatus === "completed" && isLogged && (
               <span className="font-mono text-xs text-muted-foreground tabular-nums">
-                {formatDuration(loggedDurationSeconds)}
+                {formatDuration(loggedSummary.durationSeconds)}
                 {primaryMetric === "distance" &&
-                  loggedDistance > 0 &&
-                  ` · ${loggedDistance} ${loggedDistanceUnit}`}
-                {` · RPE ${loggedRpe}`}
+                  loggedSummary.distance !== undefined &&
+                  loggedSummary.distance > 0 &&
+                  ` · ${loggedSummary.distance} ${loggedSummary.distanceUnit}`}
+                {loggedSummary.rpe !== undefined &&
+                  ` · RPE ${loggedSummary.rpe}`}
               </span>
             )}
           </div>
@@ -390,20 +404,24 @@ export function CardioExerciseCard({
                 <div className="flex items-center justify-between">
                   <div className="space-y-1">
                     <div className="font-mono text-2xl tabular-nums">
-                      {formatDuration(loggedDurationSeconds)}
+                      {formatDuration(loggedSummary.durationSeconds)}
                     </div>
-                    {primaryMetric === "distance" && loggedDistance > 0 && (
-                      <div className="font-mono text-lg tabular-nums text-muted-foreground">
-                        {loggedDistance} {loggedDistanceUnit}
+                    {primaryMetric === "distance" &&
+                      loggedSummary.distance !== undefined &&
+                      loggedSummary.distance > 0 && (
+                        <div className="font-mono text-lg tabular-nums text-muted-foreground">
+                          {loggedSummary.distance} {loggedSummary.distanceUnit}
+                        </div>
+                      )}
+                  </div>
+                  {loggedSummary.rpe !== undefined && (
+                    <div className="text-right">
+                      <div className="text-sm text-muted-foreground">RPE</div>
+                      <div className="font-mono text-2xl tabular-nums">
+                        {loggedSummary.rpe}
                       </div>
-                    )}
-                  </div>
-                  <div className="text-right">
-                    <div className="text-sm text-muted-foreground">RPE</div>
-                    <div className="font-mono text-2xl tabular-nums">
-                      {loggedRpe}
                     </div>
-                  </div>
+                  )}
                 </div>
                 {hasLoggedVest && (
                   <div className="mt-3 flex items-center gap-2 text-sm text-muted-foreground border-t pt-3">

--- a/src/components/workout/cardio-exercise-card.tsx
+++ b/src/components/workout/cardio-exercise-card.tsx
@@ -371,6 +371,7 @@ export function CardioExerciseCard({
                 {primaryMetric === "distance" &&
                   loggedSummary.distance !== undefined &&
                   loggedSummary.distance > 0 &&
+                  loggedSummary.distanceUnit !== undefined &&
                   ` · ${loggedSummary.distance} ${loggedSummary.distanceUnit}`}
                 {loggedSummary.rpe !== undefined &&
                   ` · RPE ${loggedSummary.rpe}`}
@@ -408,7 +409,8 @@ export function CardioExerciseCard({
                     </div>
                     {primaryMetric === "distance" &&
                       loggedSummary.distance !== undefined &&
-                      loggedSummary.distance > 0 && (
+                      loggedSummary.distance > 0 &&
+                      loggedSummary.distanceUnit !== undefined && (
                         <div className="font-mono text-lg tabular-nums text-muted-foreground">
                           {loggedSummary.distance} {loggedSummary.distanceUnit}
                         </div>

--- a/src/components/workout/cardio-exercise-card.tsx
+++ b/src/components/workout/cardio-exercise-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useRef, useEffect, useCallback } from "react";
+import { useState, useRef, useEffect, useCallback, useId } from "react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { RpeSlider } from "./rpe-slider";
@@ -8,9 +8,20 @@ import { NoteSheet } from "./note-sheet";
 import { SetStepper } from "./set-stepper";
 import { useHaptic } from "@/hooks/use-haptic";
 import { Check, ChevronDown, ChevronUp, Dumbbell, MessageSquare } from "lucide-react";
+import { CardioSaveBlockedError } from "@/lib/cardio-persistence";
 import { cn } from "@/lib/utils";
 
 type ExerciseStatus = "completed" | "current" | "upcoming";
+
+export type CardioLogData = {
+  durationSeconds: number;
+  distance?: number;
+  distanceUnit?: "km" | "mi";
+  rpe?: number;
+  vestWeight?: number;
+  vestWeightUnit?: "kg" | "lb";
+  intensity?: number;
+};
 
 interface CardioExerciseCardProps {
   exerciseName: string;
@@ -20,15 +31,8 @@ interface CardioExerciseCardProps {
   distanceUnit?: "km" | "mi";
   defaultMinutes?: number;
   note?: string;
-  onLog: (data: {
-    durationSeconds: number;
-    distance?: number;
-    distanceUnit?: "km" | "mi";
-    rpe?: number;
-    vestWeight?: number;
-    vestWeightUnit?: "kg" | "lb";
-    intensity?: number;
-  }) => void;
+  loggedData?: CardioLogData;
+  onLog: (data: CardioLogData) => Promise<void>;
   onNoteChange?: (note: string) => void;
   onSelect?: () => void;
 }
@@ -177,6 +181,7 @@ export function CardioExerciseCard({
   distanceUnit = "mi",
   defaultMinutes = 20,
   note,
+  loggedData,
   onLog,
   onNoteChange,
   onSelect,
@@ -190,11 +195,25 @@ export function CardioExerciseCard({
   const [showEquipment, setShowEquipment] = useState(false);
   const [useVest, setUseVest] = useState(false);
   const [vestWeight, setVestWeight] = useState(unit === "kg" ? 10 : 20);
-  const [isLogged, setIsLogged] = useState(false);
+  const [hasAcknowledgedLog, setHasAcknowledgedLog] = useState(false);
+  const [isSaving, setIsSaving] = useState(false);
+  const [logError, setLogError] = useState<string | null>(null);
   const [showNoteSheet, setShowNoteSheet] = useState(false);
+  const isSavingRef = useRef(false);
+  const logErrorId = useId();
 
   const totalSeconds = minutes * 60 + seconds;
   const canLog = primaryMetric === "duration" ? totalSeconds > 0 : distance > 0;
+  const isLogged = loggedData !== undefined || hasAcknowledgedLog;
+  const loggedDurationSeconds = loggedData?.durationSeconds ?? totalSeconds;
+  const loggedDistance = loggedData?.distance ?? distance;
+  const loggedDistanceUnit = loggedData?.distanceUnit ?? distanceUnit;
+  const loggedRpe = loggedData?.rpe ?? rpe;
+  const loggedVestWeight = loggedData?.vestWeight ?? vestWeight;
+  const loggedVestWeightUnit = loggedData?.vestWeightUnit ?? unit;
+  const hasLoggedVest = loggedData
+    ? loggedData.vestWeight !== undefined
+    : useVest;
 
   const isExpanded = status === "current";
   const displayStatus = isLogged && status !== "current" ? "completed" : status;
@@ -207,21 +226,37 @@ export function CardioExerciseCard({
     }
   };
 
-  const handleLog = () => {
-    if (!canLog) return;
-    vibrate("success");
+  const handleLog = async () => {
+    if (!canLog || isSavingRef.current) return;
 
-    onLog({
-      durationSeconds: totalSeconds,
-      distance: primaryMetric === "distance" ? distance : undefined,
-      distanceUnit: primaryMetric === "distance" ? distanceUnit : undefined,
-      rpe,
-      vestWeight: useVest ? vestWeight : undefined,
-      vestWeightUnit: useVest ? unit : undefined,
-      intensity: rpe,
-    });
+    isSavingRef.current = true;
+    setIsSaving(true);
+    setLogError(null);
 
-    setIsLogged(true);
+    try {
+      await onLog({
+        durationSeconds: totalSeconds,
+        distance: primaryMetric === "distance" ? distance : undefined,
+        distanceUnit: primaryMetric === "distance" ? distanceUnit : undefined,
+        rpe,
+        vestWeight: useVest ? vestWeight : undefined,
+        vestWeightUnit: useVest ? unit : undefined,
+        intensity: rpe,
+      });
+
+      setHasAcknowledgedLog(true);
+      vibrate("success");
+    } catch (error) {
+      setLogError(
+        error instanceof CardioSaveBlockedError
+          ? "The workout is already finishing, so this cardio wasn't saved."
+          : "Cardio wasn't saved. Check your connection and try again."
+      );
+      vibrate("warning");
+    } finally {
+      isSavingRef.current = false;
+      setIsSaving(false);
+    }
   };
 
   const handleSecondsChange = (newSeconds: number) => {
@@ -320,9 +355,11 @@ export function CardioExerciseCard({
 
             {displayStatus === "completed" && isLogged && (
               <span className="font-mono text-xs text-muted-foreground tabular-nums">
-                {formatDuration(totalSeconds)}
-                {distance > 0 && ` · ${distance} ${distanceUnit}`}
-                {` · RPE ${rpe}`}
+                {formatDuration(loggedDurationSeconds)}
+                {primaryMetric === "distance" &&
+                  loggedDistance > 0 &&
+                  ` · ${loggedDistance} ${loggedDistanceUnit}`}
+                {` · RPE ${loggedRpe}`}
               </span>
             )}
           </div>
@@ -353,23 +390,27 @@ export function CardioExerciseCard({
                 <div className="flex items-center justify-between">
                   <div className="space-y-1">
                     <div className="font-mono text-2xl tabular-nums">
-                      {formatDuration(totalSeconds)}
+                      {formatDuration(loggedDurationSeconds)}
                     </div>
-                    {distance > 0 && (
+                    {primaryMetric === "distance" && loggedDistance > 0 && (
                       <div className="font-mono text-lg tabular-nums text-muted-foreground">
-                        {distance} {distanceUnit}
+                        {loggedDistance} {loggedDistanceUnit}
                       </div>
                     )}
                   </div>
                   <div className="text-right">
                     <div className="text-sm text-muted-foreground">RPE</div>
-                    <div className="font-mono text-2xl tabular-nums">{rpe}</div>
+                    <div className="font-mono text-2xl tabular-nums">
+                      {loggedRpe}
+                    </div>
                   </div>
                 </div>
-                {useVest && (
+                {hasLoggedVest && (
                   <div className="mt-3 flex items-center gap-2 text-sm text-muted-foreground border-t pt-3">
                     <Dumbbell className="h-4 w-4" />
-                    <span>Vest: {vestWeight} {unit}</span>
+                    <span>
+                      Vest: {loggedVestWeight} {loggedVestWeightUnit}
+                    </span>
                   </div>
                 )}
               </div>
@@ -381,11 +422,21 @@ export function CardioExerciseCard({
               )}
               <div className="flex items-center justify-center pt-2">
                 <Check className="h-5 w-5 text-primary mr-2" />
-                <span className="text-sm font-medium text-muted-foreground">Logged</span>
+                <span
+                  className="text-sm font-medium text-muted-foreground"
+                  role="status"
+                >
+                  Logged
+                </span>
               </div>
             </div>
           ) : (
-          <div className="space-y-4 px-4 pb-4 pt-2">
+          <fieldset
+            className="space-y-4 px-4 pb-4 pt-2"
+            disabled={isSaving}
+            aria-describedby={logError ? logErrorId : undefined}
+          >
+            <legend className="sr-only">Log cardio for {exerciseName}</legend>
             {primaryMetric === "duration" ? (
               <div>
                 <label className="mb-2 block text-xs font-medium text-muted-foreground uppercase tracking-wide">
@@ -509,17 +560,24 @@ export function CardioExerciseCard({
             )}
 
             <Button
+              type="button"
               size="lg"
               className={cn(
                 "mt-2 h-14 w-full text-base font-semibold tracking-wide",
                 "transition-all duration-200"
               )}
               onClick={handleLog}
-              disabled={!canLog}
+              disabled={!canLog || isSaving}
+              aria-busy={isSaving}
             >
-              LOG CARDIO
+              {isSaving ? "SAVING CARDIO..." : "LOG CARDIO"}
             </Button>
-          </div>
+            {logError && (
+              <p id={logErrorId} className="text-sm text-destructive" role="alert">
+                {logError}
+              </p>
+            )}
+          </fieldset>
           )}
         </div>
       </div>

--- a/src/components/workout/edit-exercise-sheet.tsx
+++ b/src/components/workout/edit-exercise-sheet.tsx
@@ -28,6 +28,7 @@ export type RoutineExercise = {
 	kind: "lifting" | "cardio" | "mobility";
 	targetSets: number;
 	targetReps: string;
+	measurementType?: "reps" | "duration";
 	targetDuration?: number;
 	targetHoldSeconds?: number;
 	perSide?: boolean;
@@ -81,6 +82,9 @@ function EditExerciseForm({
 	);
 	const [sets, setSets] = useState(exercise.targetSets);
 	const [reps, setReps] = useState(exercise.targetReps);
+	const [measurementType, setMeasurementType] = useState<"reps" | "duration">(
+		exercise.measurementType ?? "reps"
+	);
 	const [duration, setDuration] = useState(exercise.targetDuration ?? 20);
 	const [holdSeconds, setHoldSeconds] = useState(
 		exercise.targetHoldSeconds ?? 30
@@ -130,6 +134,7 @@ function EditExerciseForm({
 						id: exerciseId,
 						muscleGroups,
 						name,
+						measurementType,
 					});
 				} catch (error) {
 					toast.error("Failed to update exercise");
@@ -142,6 +147,7 @@ function EditExerciseForm({
 						name,
 						category: kind,
 						muscleGroups,
+						measurementType,
 					});
 				} catch (error) {
 					toast.error("Failed to create exercise");
@@ -158,6 +164,7 @@ function EditExerciseForm({
 			kind,
 			targetSets: sets,
 			targetReps: reps,
+			measurementType: kind === "lifting" ? measurementType : undefined,
 			targetDuration: duration,
 			targetHoldSeconds: holdSeconds,
 			perSide,
@@ -185,7 +192,7 @@ function EditExerciseForm({
 			<DrawerHeader>
 				<DrawerTitle>Edit Exercise</DrawerTitle>
 				<DrawerDescription>
-					Configure sets, reps, and rest time
+					Configure how this exercise is measured and logged
 				</DrawerDescription>
 			</DrawerHeader>
 
@@ -228,6 +235,18 @@ function EditExerciseForm({
 
 				{kind === "lifting" ? (
 					<>
+						<div className="space-y-3">
+							<Label>Measure By</Label>
+							<Tabs
+								value={measurementType}
+								onValueChange={(value) => setMeasurementType(value as "reps" | "duration")}
+							>
+								<TabsList className="grid h-12 w-full grid-cols-2">
+									<TabsTrigger value="reps" className="h-10">Reps</TabsTrigger>
+									<TabsTrigger value="duration" className="h-10">Time</TabsTrigger>
+								</TabsList>
+							</Tabs>
+						</div>
 						<div className="space-y-3">
 							<Label>
 								Muscle Groups
@@ -305,6 +324,7 @@ function EditExerciseForm({
 							</div>
 						</div>
 
+						{measurementType === "reps" ? (
 						<div className="space-y-3">
 							<Label>Reps</Label>
 							<div className="grid grid-cols-4 gap-2">
@@ -338,6 +358,35 @@ function EditExerciseForm({
 								className="h-12 text-center font-mono"
 							/>
 						</div>
+						) : (
+							<div className="space-y-4">
+								<div className="flex items-center justify-between">
+									<Label>Hold Duration</Label>
+									<span className="text-2xl font-mono font-bold tabular-nums">
+										{holdSeconds}s
+									</span>
+								</div>
+								<div className="grid grid-cols-4 gap-2">
+									{[15, 30, 45, 60].map((preset) => (
+										<Button
+											key={preset}
+											variant={holdSeconds === preset ? "default" : "outline"}
+											className="h-12 font-mono"
+											onClick={() => setHoldSeconds(preset)}
+										>
+											{preset}s
+										</Button>
+									))}
+								</div>
+								<Slider
+									value={[holdSeconds]}
+									onValueChange={([value]) => setHoldSeconds(value)}
+									min={5}
+									max={300}
+									step={5}
+								/>
+							</div>
+						)}
 
 						<div className="space-y-4">
 							<div className="flex items-center justify-between">

--- a/src/components/workout/edit-set-sheet.tsx
+++ b/src/components/workout/edit-set-sheet.tsx
@@ -20,6 +20,7 @@ export interface EditableSet {
   setNumber: number;
   reps: number;
   weight: number;
+  durationSeconds?: number;
   unit: "lb" | "kg";
   isBodyweight?: boolean;
   rpe?: number | null;
@@ -28,7 +29,7 @@ export interface EditableSet {
 interface EditSetSheetProps {
   set: EditableSet | null;
   onOpenChange: (open: boolean) => void;
-  onSave: (entryId: string, data: { reps: number; weight: number; rpe?: number | null }) => void;
+  onSave: (entryId: string, data: { reps?: number; weight?: number; durationSeconds?: number; rpe?: number | null }) => void;
   onDelete: (entryId: string) => void;
 }
 
@@ -40,15 +41,21 @@ function EditSetContent({
 }: {
   set: EditableSet;
   onOpenChange: (open: boolean) => void;
-  onSave: (entryId: string, data: { reps: number; weight: number; rpe?: number | null }) => void;
+  onSave: (entryId: string, data: { reps?: number; weight?: number; durationSeconds?: number; rpe?: number | null }) => void;
   onDelete: (entryId: string) => void;
 }) {
   const [weight, setWeight] = useState(set.weight);
   const [reps, setReps] = useState(set.reps);
+  const [durationSeconds, setDurationSeconds] = useState(set.durationSeconds ?? 30);
   const [rpe, setRpe] = useState<number | null>(set.rpe ?? null);
 
   const handleSave = () => {
-    onSave(set.entryId, { reps, weight, rpe });
+    onSave(
+      set.entryId,
+      set.durationSeconds !== undefined
+        ? { durationSeconds, rpe }
+        : { reps, weight, rpe }
+    );
     onOpenChange(false);
   };
 
@@ -58,6 +65,9 @@ function EditSetContent({
   };
 
   const formatSetDisplay = () => {
+    if (set.durationSeconds !== undefined) {
+      return `${durationSeconds} seconds`;
+    }
     if (set.isBodyweight && weight === 0) {
       return `BW × ${reps}`;
     }
@@ -78,6 +88,18 @@ function EditSetContent({
 
       <div className="flex-1 px-4 py-6">
         <div className="flex flex-wrap items-end justify-center gap-6">
+          {set.durationSeconds !== undefined ? (
+            <SetStepper
+              label="Duration"
+              value={durationSeconds}
+              onChange={setDurationSeconds}
+              step={5}
+              min={1}
+              max={3600}
+              unit="seconds"
+            />
+          ) : (
+            <>
           {(!set.isBodyweight || weight > 0) && (
             <SetStepper
               label={set.isBodyweight ? "Added Weight" : "Weight"}
@@ -96,6 +118,8 @@ function EditSetContent({
             min={1}
             max={100}
           />
+            </>
+          )}
         </div>
 
         <div className="mt-6">

--- a/src/components/workout/edit-set-sheet.tsx
+++ b/src/components/workout/edit-set-sheet.tsx
@@ -22,6 +22,8 @@ export interface EditableSet {
   weight: number;
   durationSeconds?: number;
   unit: "lb" | "kg";
+  storedWeight?: number;
+  storedUnit?: "lb" | "kg";
   isBodyweight?: boolean;
   rpe?: number | null;
 }
@@ -105,7 +107,7 @@ function EditSetContent({
               label={set.isBodyweight ? "Added Weight" : "Weight"}
               value={weight}
               onChange={setWeight}
-              step={5}
+              step={set.unit === "kg" ? 2.5 : 5}
               min={0}
               unit={set.unit}
             />

--- a/src/components/workout/exercise-accordion.tsx
+++ b/src/components/workout/exercise-accordion.tsx
@@ -348,7 +348,7 @@ export function ExerciseAccordion({
 	sets,
 	status,
 	equipment,
-	defaultWeight = 45,
+	defaultWeight,
 	defaultReps = 8,
 	unit = "lb",
 	targetSets,
@@ -366,11 +366,15 @@ export function ExerciseAccordion({
 	const resolvedUnit =
 		sets.length > 0 ? sets[sets.length - 1].unit : lastSession?.unit ?? unit;
 	const resolvedWeightStep = resolvedUnit === "kg" ? 2.5 : 5;
+	const resolvedDefaultWeight =
+		defaultWeight ?? (resolvedUnit === "kg" ? 20 : 45);
 
 	const initialWeight =
 		sets.length > 0
 			? sets[sets.length - 1].weight
-			: progressionSuggestion?.targetWeight ?? lastSession?.weight ?? defaultWeight;
+			: progressionSuggestion?.targetWeight ??
+				lastSession?.weight ??
+				resolvedDefaultWeight;
 	const initialReps =
 		sets.length > 0
 			? sets[sets.length - 1].reps

--- a/src/components/workout/routine-detail-sheet.tsx
+++ b/src/components/workout/routine-detail-sheet.tsx
@@ -37,6 +37,8 @@ export type RoutineForDetail = {
       exerciseName: string;
       targetSets?: number;
       targetReps?: string;
+      measurementType?: "reps" | "duration";
+      targetHoldSeconds?: number;
     }>;
   }>;
 };
@@ -151,7 +153,9 @@ export function RoutineDetailSheet({ routine, onOpenChange }: RoutineDetailSheet
                           </span>
                           {ex.targetSets && (
                             <span className="text-xs text-muted-foreground font-mono tabular-nums ml-2">
-                              {ex.targetSets}×{ex.targetReps || "?"}
+                              {ex.targetSets}×{ex.measurementType === "duration"
+                                ? `${ex.targetHoldSeconds ?? 30}s`
+                                : ex.targetReps || "?"}
                             </span>
                           )}
                         </div>

--- a/src/components/workout/smart-swap-sheet.tsx
+++ b/src/components/workout/smart-swap-sheet.tsx
@@ -38,7 +38,11 @@ interface SmartSwapSheetProps {
 	onOpenChange: (open: boolean) => void;
 	workoutId: Id<"workouts">;
 	exerciseName: string;
-	onSwapComplete: (newExerciseName: string) => void;
+	onSwapComplete: (selection: {
+		name: string;
+		measurementType: "reps" | "duration";
+		targetHoldSeconds?: number;
+	}) => void;
 }
 
 const SWAP_REASONS: Array<{
@@ -93,6 +97,8 @@ export function SmartSwapSheet({
 			equipmentNeeded: string[];
 			muscleEmphasis: string;
 			difficultyAdjustment?: "easier" | "similar" | "harder";
+			measurementType?: "reps" | "duration";
+			targetHoldSeconds?: number;
 		}>
 	>([]);
 	const [swapId, setSwapId] = useState<Id<"exerciseSwaps"> | null>(null);
@@ -123,17 +129,21 @@ export function SmartSwapSheet({
 		}
 	};
 
-	const handleSelectAlternative = async (alternativeExercise: string) => {
+	const handleSelectAlternative = async (alternative: (typeof alternatives)[number]) => {
 		if (swapId) {
 			try {
-				await confirmSwap({ swapId, selectedExercise: alternativeExercise });
+				await confirmSwap({ swapId, selectedExercise: alternative.exercise });
 			} catch (error) {
 				console.error("Failed to confirm swap:", error);
 			}
 		}
 
-		toast.success(`Swapped to ${alternativeExercise}`);
-		onSwapComplete(alternativeExercise);
+		toast.success(`Swapped to ${alternative.exercise}`);
+		onSwapComplete({
+			name: alternative.exercise,
+			measurementType: alternative.measurementType ?? "reps",
+			targetHoldSeconds: alternative.targetHoldSeconds,
+		});
 		handleClose();
 	};
 
@@ -275,7 +285,7 @@ export function SmartSwapSheet({
 										</div>
 										<Button
 											size="sm"
-											onClick={() => handleSelectAlternative(alt.exercise)}
+											onClick={() => handleSelectAlternative(alt)}
 										>
 											<Check className="h-4 w-4 mr-1.5" />
 											Use

--- a/src/components/workout/timed-exercise-accordion.tsx
+++ b/src/components/workout/timed-exercise-accordion.tsx
@@ -1,0 +1,230 @@
+"use client";
+
+import { useState } from "react";
+import { Check, MessageSquare, Shuffle } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
+import { NoteSheet } from "./note-sheet";
+import { RpeSelector } from "./rpe-selector";
+import { useHaptic } from "@/hooks/use-haptic";
+import { cn } from "@/lib/utils";
+
+type ExerciseStatus = "completed" | "current" | "upcoming";
+
+export interface TimedSetData {
+	entryId?: string;
+	setNumber: number;
+	durationSeconds: number;
+	rpe?: number | null;
+}
+
+interface TimedExerciseAccordionProps {
+	exerciseName: string;
+	sets: TimedSetData[];
+	status: ExerciseStatus;
+	targetSets?: number;
+	targetDurationSeconds?: number;
+	lastSession?: {
+		date: string;
+		sets: Array<{ durationSeconds: number }>;
+	};
+	note?: string;
+	onAddSet: (set: { durationSeconds: number; rpe?: number | null }) => Promise<void>;
+	onEditSet?: (set: TimedSetData) => void;
+	onSwap?: () => void;
+	onNoteChange?: (note: string) => void;
+	onSelect?: () => void;
+}
+
+function formatDuration(seconds: number): string {
+	if (seconds < 60) return `${seconds}s`;
+	const minutes = Math.floor(seconds / 60);
+	const remainingSeconds = seconds % 60;
+	return remainingSeconds > 0 ? `${minutes}m ${remainingSeconds}s` : `${minutes}m`;
+}
+
+function formatHistoryDate(dateString: string): string {
+	return new Date(dateString).toLocaleDateString(undefined, {
+		month: "short",
+		day: "numeric",
+	});
+}
+
+export function TimedExerciseAccordion({
+	exerciseName,
+	sets,
+	status,
+	targetSets,
+	targetDurationSeconds = 30,
+	lastSession,
+	note,
+	onAddSet,
+	onEditSet,
+	onSwap,
+	onNoteChange,
+	onSelect,
+}: TimedExerciseAccordionProps) {
+	const { vibrate } = useHaptic();
+	const [durationSeconds, setDurationSeconds] = useState(
+		sets.at(-1)?.durationSeconds ?? targetDurationSeconds
+	);
+	const [rpe, setRpe] = useState<number | null>(null);
+	const [isSubmitting, setIsSubmitting] = useState(false);
+	const [error, setError] = useState<string | null>(null);
+	const [showNoteSheet, setShowNoteSheet] = useState(false);
+
+	const loggedCount = sets.length;
+	const isComplete = targetSets !== undefined && loggedCount >= targetSets;
+	const isExpanded = status === "current";
+
+	const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+		event.preventDefault();
+		if (!Number.isFinite(durationSeconds) || durationSeconds < 1) {
+			setError("Enter a duration of at least 1 second.");
+			return;
+		}
+
+		setError(null);
+		setIsSubmitting(true);
+		try {
+			await onAddSet({ durationSeconds, rpe });
+			setRpe(null);
+			vibrate("success");
+		} catch {
+			setError("This set could not be saved. Try again.");
+		} finally {
+			setIsSubmitting(false);
+		}
+	};
+
+	return (
+		<div
+			className={cn(
+				"rounded-lg border transition-all duration-300 ease-out",
+				status === "current" && "border-primary/30 bg-card shadow-lg ring-1 ring-primary/10",
+				status === "completed" && "border-transparent bg-muted/20",
+				status === "upcoming" && "border-muted/50 bg-card/50 opacity-70"
+			)}
+		>
+			<div className="flex items-center gap-3 p-4">
+				<button
+					type="button"
+					onClick={status === "current" ? undefined : onSelect}
+					disabled={status === "current" || !onSelect}
+					className="flex min-h-12 min-w-0 flex-1 items-center gap-3 rounded-md text-left focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+				>
+					<span
+						className={cn(
+							"flex h-6 w-6 shrink-0 items-center justify-center rounded font-mono text-xs font-bold",
+							status === "current" && "bg-primary text-primary-foreground",
+							status === "completed" && "bg-primary/20 text-primary",
+							status === "upcoming" && "bg-muted text-muted-foreground"
+						)}
+					>
+						{status === "completed" ? <Check className="h-3.5 w-3.5" /> : loggedCount}
+					</span>
+					<span className="min-w-0 flex-1">
+						<span className="block truncate font-semibold">{exerciseName}</span>
+						<span className="block text-xs text-muted-foreground">
+							Timed hold · {formatDuration(targetDurationSeconds)} target
+						</span>
+					</span>
+					<span className="shrink-0 font-mono text-sm tabular-nums text-muted-foreground">
+						{targetSets === undefined ? loggedCount : `${loggedCount}/${targetSets}`}
+					</span>
+				</button>
+
+				{isExpanded && onSwap && (
+					<Button variant="ghost" size="icon" className="h-10 w-10" onClick={onSwap}>
+						<Shuffle className="h-4 w-4" />
+						<span className="sr-only">Swap exercise</span>
+					</Button>
+				)}
+				{isExpanded && onNoteChange && (
+					<Button variant="ghost" size="icon" className="h-10 w-10" onClick={() => setShowNoteSheet(true)}>
+						<MessageSquare className={cn("h-4 w-4", note && "fill-primary text-primary")} />
+						<span className="sr-only">Add note</span>
+					</Button>
+				)}
+			</div>
+
+			{isExpanded && (
+				<form onSubmit={handleSubmit} className="space-y-4 px-4 pb-4">
+					{lastSession && (
+						<p className="rounded border border-dashed border-muted-foreground/30 bg-muted/20 px-3 py-2 text-xs text-muted-foreground">
+							Last {formatHistoryDate(lastSession.date)}: {lastSession.sets.map((set) => formatDuration(set.durationSeconds)).join(", ")}
+						</p>
+					)}
+
+					{sets.length > 0 && (
+						<div className="space-y-1" aria-label="Logged timed sets">
+							{sets.map((set) => (
+								<button
+									key={set.setNumber}
+									type="button"
+									onClick={() => onEditSet?.(set)}
+									disabled={!onEditSet || !set.entryId}
+									className="flex min-h-11 w-full items-center justify-between rounded border border-transparent bg-muted/40 px-3 text-sm enabled:hover:border-border enabled:hover:bg-muted"
+								>
+									<span className="text-muted-foreground">Set {set.setNumber}</span>
+									<span className="font-mono font-medium tabular-nums">{formatDuration(set.durationSeconds)}</span>
+									<Check className="h-4 w-4 text-primary" />
+								</button>
+							))}
+						</div>
+					)}
+
+					<div className="space-y-2">
+						<Label htmlFor={`duration-${exerciseName}`}>Duration (seconds)</Label>
+						<Input
+							id={`duration-${exerciseName}`}
+							name="durationSeconds"
+							type="number"
+							inputMode="numeric"
+							enterKeyHint="done"
+							min={1}
+							max={3600}
+							required
+							value={durationSeconds}
+							onChange={(event) => {
+								setError(null);
+								setDurationSeconds(Number(event.target.value));
+							}}
+							aria-describedby={error ? `duration-error-${exerciseName}` : undefined}
+							className="h-12 text-center font-mono text-lg"
+						/>
+					</div>
+
+					<RpeSelector value={rpe} onChange={setRpe} />
+
+					{error && (
+						<p id={`duration-error-${exerciseName}`} role="alert" className="text-sm text-destructive">
+							{error}
+						</p>
+					)}
+
+					<Button type="submit" size="lg" className="h-12 w-full" disabled={isComplete || isSubmitting}>
+						{isComplete
+							? "COMPLETE"
+							: isSubmitting
+								? "SAVING…"
+								: targetSets === undefined
+									? `LOG SET ${loggedCount + 1}`
+									: `LOG SET ${loggedCount + 1}/${targetSets}`}
+					</Button>
+				</form>
+			)}
+
+			{onNoteChange && (
+				<NoteSheet
+					open={showNoteSheet}
+					onOpenChange={setShowNoteSheet}
+					exerciseName={exerciseName}
+					note={note ?? ""}
+					onSave={onNoteChange}
+				/>
+			)}
+		</div>
+	);
+}

--- a/src/lib/cardio-display.test.ts
+++ b/src/lib/cardio-display.test.ts
@@ -35,7 +35,23 @@ describe("getCardioDisplaySummary", () => {
       getCardioDisplaySummary({ durationSeconds: 600 }, draft),
       {
         durationSeconds: 600,
+        distance: undefined,
         distanceUnit: undefined,
+      }
+    );
+  });
+
+  test("omits persisted distances whose unit is unknown", () => {
+    assert.deepEqual(
+      getCardioDisplaySummary(
+        { durationSeconds: 600, distance: 5, rpe: 6 },
+        draft
+      ),
+      {
+        durationSeconds: 600,
+        distance: undefined,
+        distanceUnit: undefined,
+        rpe: 6,
       }
     );
   });

--- a/src/lib/cardio-display.test.ts
+++ b/src/lib/cardio-display.test.ts
@@ -1,0 +1,46 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { getCardioDisplaySummary } from "./cardio-display";
+
+const draft = {
+  durationSeconds: 1_200,
+  distance: 1,
+  distanceUnit: "mi" as const,
+  rpe: 5,
+};
+
+describe("getCardioDisplaySummary", () => {
+  test("normalizes persisted meter distances to kilometers", () => {
+    assert.deepEqual(
+      getCardioDisplaySummary(
+        {
+          durationSeconds: 120,
+          distance: 400,
+          distanceUnit: "m",
+          rpe: 7,
+        },
+        draft
+      ),
+      {
+        durationSeconds: 120,
+        distance: 0.4,
+        distanceUnit: "km",
+        rpe: 7,
+      }
+    );
+  });
+
+  test("does not invent missing persisted distance or RPE values", () => {
+    assert.deepEqual(
+      getCardioDisplaySummary({ durationSeconds: 600 }, draft),
+      {
+        durationSeconds: 600,
+        distanceUnit: undefined,
+      }
+    );
+  });
+
+  test("uses draft values only for a newly acknowledged log", () => {
+    assert.deepEqual(getCardioDisplaySummary(undefined, draft), draft);
+  });
+});

--- a/src/lib/cardio-display.ts
+++ b/src/lib/cardio-display.ts
@@ -31,6 +31,14 @@ export function getCardioDisplaySummary(
     };
   }
 
+  if (distanceUnit === undefined) {
+    return {
+      ...summary,
+      distance: undefined,
+      distanceUnit: undefined,
+    };
+  }
+
   return {
     ...summary,
     distanceUnit,

--- a/src/lib/cardio-display.ts
+++ b/src/lib/cardio-display.ts
@@ -1,0 +1,38 @@
+export type CardioDistanceUnit = "m" | "km" | "mi";
+export type DisplayCardioDistanceUnit = Exclude<CardioDistanceUnit, "m">;
+
+export type PersistedCardioSummary = {
+  durationSeconds: number;
+  distance?: number;
+  distanceUnit?: CardioDistanceUnit;
+  rpe?: number;
+};
+
+export type DraftCardioSummary = {
+  durationSeconds: number;
+  distance: number;
+  distanceUnit: DisplayCardioDistanceUnit;
+  rpe: number;
+};
+
+export function getCardioDisplaySummary(
+  persisted: PersistedCardioSummary | undefined,
+  draft: DraftCardioSummary
+) {
+  const summary = persisted ?? draft;
+  const distanceUnit = summary.distanceUnit;
+
+  if (distanceUnit === "m") {
+    return {
+      ...summary,
+      distance:
+        summary.distance === undefined ? undefined : summary.distance / 1_000,
+      distanceUnit: "km" as const,
+    };
+  }
+
+  return {
+    ...summary,
+    distanceUnit,
+  };
+}

--- a/src/lib/cardio-persistence.test.ts
+++ b/src/lib/cardio-persistence.test.ts
@@ -1,0 +1,65 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import {
+  CardioSaveBlockedError,
+  createCardioPersistenceGate,
+} from "./cardio-persistence";
+
+function deferred<T>() {
+  let resolve!: (value: T) => void;
+  let reject!: (error: unknown) => void;
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise;
+    reject = rejectPromise;
+  });
+
+  return { promise, resolve, reject };
+}
+
+describe("cardio persistence gate", () => {
+  test("tracks concurrent saves until each one is acknowledged", async () => {
+    const pendingCounts: number[] = [];
+    const gate = createCardioPersistenceGate((count) => pendingCounts.push(count));
+    const first = deferred<string>();
+    const second = deferred<string>();
+
+    const firstSave = gate.runSave(() => first.promise);
+    const secondSave = gate.runSave(() => second.promise);
+
+    assert.equal(gate.pendingCount, 2);
+    assert.equal(gate.tryStartCompletion(), "cardio_save_pending");
+
+    first.resolve("first");
+    assert.equal(await firstSave, "first");
+    assert.equal(gate.pendingCount, 1);
+    assert.equal(gate.tryStartCompletion(), "cardio_save_pending");
+
+    second.resolve("second");
+    assert.equal(await secondSave, "second");
+    assert.equal(gate.pendingCount, 0);
+    assert.deepEqual(pendingCounts, [1, 2, 1, 0]);
+  });
+
+  test("releases a failed save so it can be retried", async () => {
+    const gate = createCardioPersistenceGate();
+    const failure = new Error("offline");
+
+    await assert.rejects(gate.runSave(() => Promise.reject(failure)), failure);
+    assert.equal(gate.pendingCount, 0);
+    assert.equal(await gate.runSave(() => Promise.resolve("saved")), "saved");
+  });
+
+  test("prevents a new save once completion starts", async () => {
+    const gate = createCardioPersistenceGate();
+
+    assert.equal(gate.tryStartCompletion(), "started");
+    assert.equal(gate.tryStartCompletion(), "already_completing");
+    await assert.rejects(
+      gate.runSave(() => Promise.resolve()),
+      CardioSaveBlockedError
+    );
+
+    gate.finishCompletion();
+    assert.equal(await gate.runSave(() => Promise.resolve("saved")), "saved");
+  });
+});

--- a/src/lib/cardio-persistence.ts
+++ b/src/lib/cardio-persistence.ts
@@ -1,0 +1,64 @@
+export class CardioSaveBlockedError extends Error {
+  constructor() {
+    super("The workout is already finishing");
+    this.name = "CardioSaveBlockedError";
+  }
+}
+
+export type CompletionStartResult =
+  | "started"
+  | "cardio_save_pending"
+  | "already_completing";
+
+export function createCardioPersistenceGate(
+  onPendingCountChange?: (pendingCount: number) => void
+) {
+  let pendingCount = 0;
+  let completionInProgress = false;
+
+  const publishPendingCount = () => {
+    onPendingCountChange?.(pendingCount);
+  };
+
+  return {
+    async runSave<T>(save: () => Promise<T>): Promise<T> {
+      if (completionInProgress) {
+        throw new CardioSaveBlockedError();
+      }
+
+      pendingCount += 1;
+      publishPendingCount();
+
+      try {
+        return await save();
+      } finally {
+        pendingCount -= 1;
+        publishPendingCount();
+      }
+    },
+
+    tryStartCompletion(): CompletionStartResult {
+      if (completionInProgress) return "already_completing";
+      if (pendingCount > 0) return "cardio_save_pending";
+
+      completionInProgress = true;
+      return "started";
+    },
+
+    finishCompletion() {
+      completionInProgress = false;
+    },
+
+    get pendingCount() {
+      return pendingCount;
+    },
+
+    get completionInProgress() {
+      return completionInProgress;
+    },
+  };
+}
+
+export type CardioPersistenceGate = ReturnType<
+  typeof createCardioPersistenceGate
+>;

--- a/src/lib/progression.test.ts
+++ b/src/lib/progression.test.ts
@@ -18,9 +18,20 @@ describe("progression unit normalization", () => {
           workoutId: "previous",
           date: "2026-07-07T00:00:00.000Z",
           sets: [
-            { setNumber: 1, weight: 220.5, reps: 8, rpe: null, unit: "lb" },
+            {
+              setNumber: 1,
+              weight: 100 / 0.453592,
+              reps: 8,
+              rpe: null,
+              unit: "lb",
+            },
           ],
-          bestSet: { weight: 220.5, reps: 8, rpe: null, unit: "lb" },
+          bestSet: {
+            weight: 100 / 0.453592,
+            reps: 8,
+            rpe: null,
+            unit: "lb",
+          },
         },
       ],
       "8",
@@ -65,6 +76,39 @@ describe("progression unit normalization", () => {
       rpe: 8,
       date: "2026-07-14T00:00:00.000Z",
       unit: "kg",
+    });
+  });
+
+  test("does not collapse distinct canonical weights that display the same", () => {
+    const result = calculateProgressionSuggestion(
+      [
+        {
+          workoutId: "latest",
+          date: "2026-07-14T00:00:00.000Z",
+          sets: [
+            { setNumber: 1, weight: 100, reps: 8, rpe: null, unit: "kg" },
+          ],
+          bestSet: { weight: 100, reps: 8, rpe: null, unit: "kg" },
+        },
+        {
+          workoutId: "previous",
+          date: "2026-07-07T00:00:00.000Z",
+          sets: [
+            { setNumber: 1, weight: 220.4, reps: 8, rpe: null, unit: "lb" },
+          ],
+          bestSet: { weight: 220.4, reps: 8, rpe: null, unit: "lb" },
+        },
+      ],
+      "8",
+      "kg"
+    );
+
+    assert.equal(result?.lastSession.weight, 100);
+    assert.deepEqual(result?.suggestion, {
+      type: "hold",
+      targetWeight: 100,
+      targetReps: 8,
+      reasoning: "Build consistency at this weight.",
     });
   });
 });

--- a/src/lib/progression.test.ts
+++ b/src/lib/progression.test.ts
@@ -1,0 +1,70 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { calculateProgressionSuggestion } from "./progression";
+
+describe("progression unit normalization", () => {
+  test("normalizes mixed history before comparing sessions and suggesting weight", () => {
+    const result = calculateProgressionSuggestion(
+      [
+        {
+          workoutId: "latest",
+          date: "2026-07-14T00:00:00.000Z",
+          sets: [
+            { setNumber: 1, weight: 100, reps: 8, rpe: null, unit: "kg" },
+          ],
+          bestSet: { weight: 100, reps: 8, rpe: null, unit: "kg" },
+        },
+        {
+          workoutId: "previous",
+          date: "2026-07-07T00:00:00.000Z",
+          sets: [
+            { setNumber: 1, weight: 220.5, reps: 8, rpe: null, unit: "lb" },
+          ],
+          bestSet: { weight: 220.5, reps: 8, rpe: null, unit: "lb" },
+        },
+      ],
+      "8",
+      "kg"
+    );
+
+    assert.deepEqual(result?.lastSession, {
+      weight: 100,
+      reps: 8,
+      rpe: null,
+      date: "2026-07-14T00:00:00.000Z",
+      unit: "kg",
+    });
+    assert.deepEqual(result?.suggestion, {
+      type: "increase_weight",
+      targetWeight: 102.5,
+      targetReps: 8,
+      reasoning: "Hit 8 reps for 2 sessions. Ready to add weight.",
+    });
+  });
+
+  test("reselects the heaviest set after converting a mixed-unit session", () => {
+    const result = calculateProgressionSuggestion(
+      [
+        {
+          workoutId: "mixed",
+          date: "2026-07-14T00:00:00.000Z",
+          sets: [
+            { setNumber: 1, weight: 100, reps: 8, rpe: 8, unit: "lb" },
+            { setNumber: 2, weight: 60, reps: 6, rpe: 8, unit: "kg" },
+          ],
+          bestSet: { weight: 100, reps: 8, rpe: 8, unit: "lb" },
+        },
+      ],
+      undefined,
+      "kg"
+    );
+
+    assert.deepEqual(result?.lastSession, {
+      weight: 60,
+      reps: 6,
+      rpe: 8,
+      date: "2026-07-14T00:00:00.000Z",
+      unit: "kg",
+    });
+  });
+});

--- a/src/lib/progression.ts
+++ b/src/lib/progression.ts
@@ -1,3 +1,5 @@
+import { displayWeight, type WeightUnit } from "./units";
+
 type ExerciseSession = {
   workoutId: string;
   date: string;
@@ -15,6 +17,32 @@ type ExerciseSession = {
     unit: "kg" | "lb";
   };
 };
+
+function convertSessionToUnit(
+  session: ExerciseSession,
+  unit: WeightUnit
+): ExerciseSession {
+  const sets = session.sets.map((set) => ({
+    ...set,
+    weight: displayWeight(set.weight, set.unit, unit),
+    unit,
+  }));
+  const workingSets = sets.filter((set) => set.reps > 0);
+  const bestSet = (workingSets.length > 0 ? workingSets : sets).reduce(
+    (best, current) => (current.weight > best.weight ? current : best),
+    {
+      ...session.bestSet,
+      weight: displayWeight(
+        session.bestSet.weight,
+        session.bestSet.unit,
+        unit
+      ),
+      unit,
+    }
+  );
+
+  return { ...session, sets, bestSet };
+}
 
 export type ProgressionSuggestion = {
   type: "increase_weight" | "increase_reps" | "hold" | "deload";
@@ -99,15 +127,20 @@ function getAvgRpe(sessions: ExerciseSession[]): number | null {
 
 export function calculateProgressionSuggestion(
   sessions: ExerciseSession[],
-  targetRepRange?: string
+  targetRepRange?: string,
+  preferredUnit?: WeightUnit
 ): { lastSession: GhostSetData; suggestion: ProgressionSuggestion } | null {
   if (sessions.length === 0) return null;
 
-  const lastSession = sessions[0];
+  const normalizedSessions = preferredUnit
+    ? sessions.map((session) => convertSessionToUnit(session, preferredUnit))
+    : sessions;
+
+  const lastSession = normalizedSessions[0];
   const { bestSet } = lastSession;
   const repRange = parseRepRange(targetRepRange);
 
-  const sessionsAtWeight = sessionsAtSameWeight(sessions);
+  const sessionsAtWeight = sessionsAtSameWeight(normalizedSessions);
   const consecutiveSessionsAtWeight = sessionsAtWeight.length;
 
   const sessionsHittingTarget = repRange
@@ -115,14 +148,14 @@ export function calculateProgressionSuggestion(
     : [];
   const consecutiveTargetHits = sessionsHittingTarget.length;
 
-  const sessionsAtWeightAndReps = sessionsAtSameWeightAndReps(sessions);
+  const sessionsAtWeightAndReps = sessionsAtSameWeightAndReps(normalizedSessions);
   const consecutiveAtWeightAndReps = sessionsAtWeightAndReps.length;
 
   const avgRpe = getAvgRpe(sessionsAtWeight.slice(0, 3));
   const lastRpe = bestSet.rpe;
   const hasAnyRpeData = avgRpe !== null || lastRpe !== null;
 
-  const recentRpes = sessions
+  const recentRpes = normalizedSessions
     .slice(0, 3)
     .map((s) => s.bestSet.rpe)
     .filter((rpe): rpe is number => rpe !== null);

--- a/src/lib/progression.ts
+++ b/src/lib/progression.ts
@@ -1,4 +1,4 @@
-import { displayWeight, type WeightUnit } from "./units";
+import { convertWeight, displayWeight, type WeightUnit } from "./units";
 
 type ExerciseSession = {
   workoutId: string;
@@ -24,7 +24,7 @@ function convertSessionToUnit(
 ): ExerciseSession {
   const sets = session.sets.map((set) => ({
     ...set,
-    weight: displayWeight(set.weight, set.unit, unit),
+    weight: convertWeight(set.weight, set.unit, unit),
     unit,
   }));
   const workingSets = sets.filter((set) => set.reps > 0);
@@ -32,7 +32,7 @@ function convertSessionToUnit(
     (best, current) => (current.weight > best.weight ? current : best),
     {
       ...session.bestSet,
-      weight: displayWeight(
+      weight: convertWeight(
         session.bestSet.weight,
         session.bestSet.unit,
         unit
@@ -217,7 +217,7 @@ export function calculateProgressionSuggestion(
 
   return {
     lastSession: {
-      weight: bestSet.weight,
+      weight: displayWeight(bestSet.weight, bestSet.unit, bestSet.unit),
       reps: bestSet.reps,
       rpe: bestSet.rpe,
       date: lastSession.date,
@@ -225,7 +225,10 @@ export function calculateProgressionSuggestion(
     },
     suggestion: {
       type: suggestionType,
-      targetWeight,
+      targetWeight:
+        targetWeight === null
+          ? null
+          : displayWeight(targetWeight, bestSet.unit, bestSet.unit),
       targetReps,
       reasoning,
     },

--- a/src/lib/units.test.ts
+++ b/src/lib/units.test.ts
@@ -1,0 +1,54 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import {
+  calculateVolumeInUnit,
+  convertWeight,
+  displayWeight,
+  editedWeightForStorage,
+} from "./units";
+
+describe("weight units", () => {
+  test("converts pounds and kilograms for display", () => {
+    assert.equal(displayWeight(225, "lb", "kg"), 102.1);
+    assert.equal(displayWeight(100, "kg", "lb"), 220.5);
+  });
+
+  test("leaves same-unit source values unchanged before display rounding", () => {
+    assert.equal(convertWeight(42.25, "lb", "lb"), 42.25);
+    assert.equal(convertWeight(42.25, "kg", "kg"), 42.25);
+  });
+
+  test("sums mixed-unit volume in the requested unit without per-set rounding", () => {
+    const sets = [
+      { weight: 100, reps: 10, unit: "lb" as const },
+      { weight: 100, reps: 10, unit: "kg" as const },
+      { reps: 8, unit: "lb" as const },
+    ];
+
+    assert.ok(Math.abs(calculateVolumeInUnit(sets, "kg") - 1453.592) < 1e-6);
+    assert.ok(Math.abs(calculateVolumeInUnit(sets, "lb") - 3204.62) < 1e-6);
+  });
+
+  test("preserves a legacy source value unless its displayed weight changes", () => {
+    assert.equal(
+      editedWeightForStorage({
+        displayedWeight: 102.1,
+        displayUnit: "kg",
+        storedUnit: "lb",
+        originalDisplayedWeight: 102.1,
+        originalStoredWeight: 225,
+      }),
+      225
+    );
+    assert.equal(
+      editedWeightForStorage({
+        displayedWeight: 102.6,
+        displayUnit: "kg",
+        storedUnit: "lb",
+        originalDisplayedWeight: 102.1,
+        originalStoredWeight: 225,
+      }),
+      226
+    );
+  });
+});

--- a/src/lib/units.ts
+++ b/src/lib/units.ts
@@ -1,5 +1,11 @@
 export type WeightUnit = "lb" | "kg";
 
+export type WeightedReps = {
+  weight?: number;
+  reps?: number;
+  unit?: WeightUnit;
+};
+
 const LB_TO_KG = 0.453592;
 const KG_TO_LB = 2.20462;
 
@@ -27,4 +33,35 @@ export function displayWeight(
 ): number {
   const converted = convertWeight(weight, fromUnit, toUnit);
   return roundWeight(converted, toUnit);
+}
+
+export function calculateVolumeInUnit(
+  sets: WeightedReps[],
+  toUnit: WeightUnit
+): number {
+  return sets.reduce((total, set) => {
+    const weight = set.weight ?? 0;
+    const reps = set.reps ?? 0;
+    const sourceUnit = set.unit ?? toUnit;
+    return total + convertWeight(weight, sourceUnit, toUnit) * reps;
+  }, 0);
+}
+
+export function editedWeightForStorage({
+  displayedWeight,
+  displayUnit,
+  storedUnit,
+  originalDisplayedWeight,
+  originalStoredWeight,
+}: {
+  displayedWeight: number;
+  displayUnit: WeightUnit;
+  storedUnit: WeightUnit;
+  originalDisplayedWeight: number;
+  originalStoredWeight?: number;
+}): number | undefined {
+  if (displayedWeight === originalDisplayedWeight) {
+    return originalStoredWeight;
+  }
+  return displayWeight(displayedWeight, displayUnit, storedUnit);
 }

--- a/src/lib/workout-exercise-group.test.ts
+++ b/src/lib/workout-exercise-group.test.ts
@@ -1,0 +1,31 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { getExerciseGroupKey } from "./workout-exercise-group";
+
+describe("getExerciseGroupKey", () => {
+	test("separates rep and timed lifting rows with the same name", () => {
+		const repKey = getExerciseGroupKey({
+			name: "Plank",
+			category: "lifting",
+			measurementType: "reps",
+		});
+		const durationKey = getExerciseGroupKey({
+			name: "Plank",
+			category: "lifting",
+			measurementType: "duration",
+		});
+
+		assert.notEqual(repKey, durationKey);
+	});
+
+	test("keeps the missing measurement type backward compatible with reps", () => {
+		assert.equal(
+			getExerciseGroupKey({ name: "Squat", category: "lifting" }),
+			getExerciseGroupKey({
+				name: "Squat",
+				category: "lifting",
+				measurementType: "reps",
+			})
+		);
+	});
+});

--- a/src/lib/workout-exercise-group.ts
+++ b/src/lib/workout-exercise-group.ts
@@ -1,0 +1,14 @@
+export type ExerciseGroupDescriptor = {
+	name: string;
+	category: "lifting" | "cardio" | "mobility" | "other";
+	measurementType?: "reps" | "duration";
+};
+
+export function getExerciseGroupKey(exercise: ExerciseGroupDescriptor) {
+	const category = exercise.category === "cardio" ? "cardio" : "lifting";
+	const measurementType =
+		category === "lifting" && exercise.measurementType === "duration"
+			? "duration"
+			: "reps";
+	return JSON.stringify([exercise.name, category, measurementType]);
+}

--- a/tests/week.test.mjs
+++ b/tests/week.test.mjs
@@ -1,0 +1,25 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import { getMondayWeekKey, getMondayWeekStartUtc } from "../convex/lib/week.ts";
+
+test("keeps Monday and Sunday in the same Monday-starting week", () => {
+  const monday = Date.parse("2026-07-20T00:00:00.000Z");
+  const sunday = Date.parse("2026-07-26T23:59:59.999Z");
+
+  assert.equal(getMondayWeekStartUtc(monday), monday);
+  assert.equal(getMondayWeekStartUtc(sunday), monday);
+  assert.equal(getMondayWeekKey(sunday), "2026-07-20");
+});
+
+test("resets the week at Monday 00:00 UTC", () => {
+  const sunday = Date.parse("2026-07-19T23:59:59.999Z");
+  const monday = Date.parse("2026-07-20T00:00:00.000Z");
+
+  assert.equal(getMondayWeekKey(sunday), "2026-07-13");
+  assert.equal(getMondayWeekKey(monday), "2026-07-20");
+});
+
+test("handles a Monday-starting week across a year boundary", () => {
+  assert.equal(getMondayWeekKey(Date.parse("2027-01-03T12:00:00.000Z")), "2026-12-28");
+  assert.equal(getMondayWeekKey(Date.parse("2027-01-04T00:00:00.000Z")), "2027-01-04");
+});


### PR DESCRIPTION
> **Release hold:** Do not merge before **2026-07-22 20:45 UTC** unless explicitly approved. PR #47's version notifier was promoted to production at 2026-07-21 20:44 UTC; this window gives active users time to load the notifier before the next release.

## What does this PR do?

Bundles the four reviewed production-feedback fixes into one release merge and therefore one Vercel production deployment:

- #42 — Monday-starting Training Lab and dashboard week semantics
- #44 — timed strength sets and backward-compatible measurement metadata
- #45 — authoritative preferred workout units with mixed-unit normalization
- #46 — acknowledged cardio persistence and workout-finish gating

The branch starts from production commit `768149b`, which shipped the version update notice in #47. It merges the exact reviewed #42 head and the exact reviewed #46 tip; #46 contains the updated #44 → #45 stack.

## Why one release PR?

Merging #42, #44, #45, and #46 separately into `main` would normally trigger four production deployments. Merging this release PR once creates one `main` update and one user-visible version notification. Use a **merge commit**, not squash, when releasing so the reviewed component commits remain in history.

## Greptile review status

All Greptile inline findings on the component PRs were addressed with evidence and resolved before this release branch was assembled:

- #42: 0 findings
- #44: 3 findings fixed/resolved
- #45: 1 finding fixed/resolved; fresh Greptile 5/5 re-review
- #46: 3 findings fixed/resolved, including the rerun edge case

## Compatibility and deployment notes

- Schema additions are optional and existing workout/routine/entry records remain valid.
- No production data was mutated while preparing this release.
- After this code deploys, run `exercises:updateSystemExercises` against production to backfill `measurementType: "duration"` on the existing Plank catalog record.
- Weekly boundaries remain UTC until the proposed user-time-zone follow-up is implemented.

## How to test

Integration checks run from the release branch:

- `bun test` — 37 passed, 0 failed
- `bunx tsc --noEmit` — passed
- `bun run lint` — 0 errors, 7 pre-existing warnings
- `bun run build` — passed; all routes generated
- `git diff --check origin/main...HEAD` — passed

Manual release checks:

1. Confirm #47's production `/api/version` endpoint still returns a non-null deployment ID with `no-store` headers.
2. Merge this PR once using a merge commit after the hold window.
3. Confirm one Vercel production deployment completes for the resulting `main` commit.
4. Run the Plank catalog backfill mutation and verify a Plank routine opens the timed-hold logger.
5. Verify kg/lb entry, cardio save/finish gating, and Monday Training Lab totals in production.

## Related issues

Production feedback records; no GitHub issue numbers.

## Checklist

- [x] Component PR Greptile threads addressed
- [x] Focused and integration tests pass
- [x] TypeScript and production build pass
- [x] No production data mutation performed
- [x] 24-hour notifier adoption window elapsed or explicit release approval received

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/house-of-giants/codesmith/opentrainer/pr/48"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787258764&installation_model_id=19704&pr_number=48&repository=house-of-giants%2Fopentrainer&return_to=https%3A%2F%2Fgithub.com%2Fhouse-of-giants%2Fopentrainer%2Fpull%2F48&signature=d4ebc84fb13a7ce54ed53f0a5cefacac9544ae3e4e169af035b90c4ee823dc5b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->