### PR TITLE
Fix duplicate custom exercises in search

### DIFF
--- a/convex/ai/aggregators.ts
+++ b/convex/ai/aggregators.ts
@@ -949,10 +949,13 @@ export const getExerciseContext = internalQuery({
     exerciseName: v.string(),
   },
   handler: async (ctx, args) => {
-    const exercise = await ctx.db
+    const exercises = await ctx.db
       .query("exercises")
       .withIndex("by_name", (q) => q.eq("name", args.exerciseName))
-      .first();
+      .collect();
+    const exercise =
+      exercises.find((candidate) => candidate.isSystemExercise) ??
+      exercises.find((candidate) => candidate.userId === args.userId);
 
     const recentEntries = await ctx.db
       .query("entries")

--- a/convex/exercises.ts
+++ b/convex/exercises.ts
@@ -2,14 +2,10 @@ import { v } from "convex/values";
 import type { Doc } from "./_generated/dataModel";
 import { mutation, query, type MutationCtx, type QueryCtx } from "./_generated/server";
 import { getCurrentUser } from "./auth";
-
-function cleanExerciseName(name: string) {
-  return name.normalize("NFKC").trim().replace(/\s+/g, " ");
-}
-
-function normalizeExerciseName(name: string) {
-  return cleanExerciseName(name).toLowerCase();
-}
+import {
+  cleanExerciseName,
+  normalizeExerciseName,
+} from "../src/lib/exercise-names";
 
 function hasExerciseName(exercise: Doc<"exercises">, normalizedName: string) {
   return (
@@ -67,7 +63,16 @@ function deduplicateExercises(exercises: Doc<"exercises">[]) {
 
   for (const exercise of preferredExercises) {
     const normalizedName = normalizeExerciseName(exercise.name);
-    if (!uniqueExercises.has(normalizedName)) {
+    const matchesExistingExercise = Array.from(uniqueExercises.values()).some(
+      (existingExercise) =>
+        hasExerciseName(existingExercise, normalizedName) ||
+        hasExerciseName(
+          exercise,
+          normalizeExerciseName(existingExercise.name)
+        )
+    );
+
+    if (!matchesExistingExercise) {
       uniqueExercises.set(normalizedName, exercise);
     }
   }

--- a/convex/exercises.ts
+++ b/convex/exercises.ts
@@ -1,6 +1,79 @@
 import { v } from "convex/values";
-import { mutation, query } from "./_generated/server";
+import type { Doc } from "./_generated/dataModel";
+import { mutation, query, type MutationCtx, type QueryCtx } from "./_generated/server";
 import { getCurrentUser } from "./auth";
+
+function cleanExerciseName(name: string) {
+  return name.normalize("NFKC").trim().replace(/\s+/g, " ");
+}
+
+function normalizeExerciseName(name: string) {
+  return cleanExerciseName(name).toLowerCase();
+}
+
+function hasExerciseName(exercise: Doc<"exercises">, normalizedName: string) {
+  return (
+    normalizeExerciseName(exercise.name) === normalizedName ||
+    exercise.aliases?.some(
+      (alias) => normalizeExerciseName(alias) === normalizedName
+    ) === true
+  );
+}
+
+function findMatchingExercise(
+  systemExercises: Doc<"exercises">[],
+  userExercises: Doc<"exercises">[],
+  normalizedName: string
+) {
+  return (
+    systemExercises.find(
+      (exercise) => normalizeExerciseName(exercise.name) === normalizedName
+    ) ??
+    userExercises.find(
+      (exercise) => normalizeExerciseName(exercise.name) === normalizedName
+    ) ??
+    systemExercises.find((exercise) => hasExerciseName(exercise, normalizedName)) ??
+    userExercises.find((exercise) => hasExerciseName(exercise, normalizedName))
+  );
+}
+
+async function getVisibleExercises(ctx: QueryCtx | MutationCtx) {
+  const user = await getCurrentUser(ctx, {
+    requireAuth: false,
+    requireUser: false,
+  });
+  const systemExercises = await ctx.db
+    .query("exercises")
+    .withIndex("by_system", (q) => q.eq("isSystemExercise", true))
+    .collect();
+  const userExercises = user
+    ? await ctx.db
+        .query("exercises")
+        .withIndex("by_user", (q) => q.eq("userId", user._id))
+        .collect()
+    : [];
+
+  return [...systemExercises, ...userExercises];
+}
+
+function deduplicateExercises(exercises: Doc<"exercises">[]) {
+  const preferredExercises = [...exercises].sort((a, b) => {
+    if (a.isSystemExercise !== b.isSystemExercise) {
+      return a.isSystemExercise ? -1 : 1;
+    }
+    return a.createdAt - b.createdAt;
+  });
+  const uniqueExercises = new Map<string, Doc<"exercises">>();
+
+  for (const exercise of preferredExercises) {
+    const normalizedName = normalizeExerciseName(exercise.name);
+    if (!uniqueExercises.has(normalizedName)) {
+      uniqueExercises.set(normalizedName, exercise);
+    }
+  }
+
+  return Array.from(uniqueExercises.values());
+}
 
 // ============================================================================
 // System Exercises Data
@@ -150,7 +223,7 @@ export const getExercises = query({
     search: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    let exercises = await ctx.db.query("exercises").collect();
+    let exercises = await getVisibleExercises(ctx);
 
     if (args.category) {
       exercises = exercises.filter(e => e.category === args.category);
@@ -170,7 +243,7 @@ export const getExercises = query({
       );
     }
 
-    return exercises.sort((a, b) => {
+    return deduplicateExercises(exercises).sort((a, b) => {
       if (a.isSystemExercise !== b.isSystemExercise) {
         return a.isSystemExercise ? -1 : 1;
       }
@@ -185,7 +258,15 @@ export const getExercises = query({
 export const getExercise = query({
   args: { id: v.id("exercises") },
   handler: async (ctx, args) => {
-    return await ctx.db.get(args.id);
+    const exercise = await ctx.db.get(args.id);
+    if (!exercise) return null;
+    if (exercise.isSystemExercise) return exercise;
+
+    const user = await getCurrentUser(ctx, {
+      requireAuth: false,
+      requireUser: false,
+    });
+    return exercise.userId === user?._id ? exercise : null;
   },
 });
 
@@ -195,7 +276,7 @@ export const getExercise = query({
 export const getMuscleGroups = query({
   args: {},
   handler: async (ctx) => {
-    const exercises = await ctx.db.query("exercises").collect();
+    const exercises = await getVisibleExercises(ctx);
     const muscleGroups = new Set<string>();
     
     for (const exercise of exercises) {
@@ -318,9 +399,33 @@ export const createExercise = mutation({
     const user = await getCurrentUser(ctx);
     if (!user) throw new Error("User not found");
 
+    const name = cleanExerciseName(args.name);
+    const normalizedName = normalizeExerciseName(name);
+    if (!normalizedName) {
+      throw new Error("Exercise name is required");
+    }
+
+    const systemExercises = await ctx.db
+      .query("exercises")
+      .withIndex("by_system", (q) => q.eq("isSystemExercise", true))
+      .collect();
+    const userExercises = await ctx.db
+      .query("exercises")
+      .withIndex("by_user", (q) => q.eq("userId", user._id))
+      .collect();
+    const existingExercise = findMatchingExercise(
+      systemExercises,
+      userExercises,
+      normalizedName
+    );
+
+    if (existingExercise) {
+      return existingExercise._id;
+    }
+
     const id = await ctx.db.insert("exercises", {
       userId: user._id,
-      name: args.name,
+      name,
       aliases: args.aliases,
       category: args.category,
       muscleGroups: args.muscleGroups,
@@ -371,7 +476,25 @@ export const updateExercise = mutation({
     }
 
     if (args.name !== undefined) {
-      updates.name = args.name;
+      const name = cleanExerciseName(args.name);
+      const normalizedName = normalizeExerciseName(name);
+      if (!normalizedName) {
+        throw new Error("Exercise name is required");
+      }
+
+      if (normalizedName !== normalizeExerciseName(exercise.name)) {
+        const visibleExercises = await getVisibleExercises(ctx);
+        const duplicate = visibleExercises.find(
+          (candidate) =>
+            candidate._id !== exercise._id &&
+            hasExerciseName(candidate, normalizedName)
+        );
+        if (duplicate) {
+          throw new Error("An exercise with this name already exists");
+        }
+      }
+
+      updates.name = name;
     }
 
     await ctx.db.patch(args.id, updates);

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -98,6 +98,7 @@ export default defineSchema({
     createdAt: v.number(),
   })
     .index("by_user", ["userId"])
+    .index("by_system", ["isSystemExercise"])
     .index("by_category", ["category"])
     .index("by_name", ["name"]),
 

--- a/src/app/routines/[id]/edit/page.tsx
+++ b/src/app/routines/[id]/edit/page.tsx
@@ -64,6 +64,7 @@ import {
 	type RoutineExercise,
 } from "@/components/workout/edit-exercise-sheet";
 import { ImportDayDialog } from "@/components/workout/import-day-dialog";
+import { normalizeExerciseName } from "@/lib/exercise-names";
 
 type RoutineDay = {
 	id: string;
@@ -423,6 +424,15 @@ export default function EditRoutinePage() {
 		return true;
 	});
 
+	const normalizedSearchQuery = normalizeExerciseName(searchQuery);
+	const hasExactExerciseMatch = exercises?.some(
+		(exercise) =>
+			normalizeExerciseName(exercise.name) === normalizedSearchQuery ||
+			exercise.aliases?.some(
+				(alias) => normalizeExerciseName(alias) === normalizedSearchQuery
+			)
+	);
+
 	const needsSeeding = exercises && exercises.length === 0;
 
 	if (routine === undefined) {
@@ -740,7 +750,7 @@ export default function EditRoutinePage() {
 						)}
 
 						<div className="flex-1 overflow-y-auto -mx-4 px-4 space-y-1">
-							{searchQuery.trim() && (
+							{searchQuery.trim() && !hasExactExerciseMatch && (
 								<button
 									className="w-full flex items-center justify-between p-3 rounded-lg text-left bg-primary/5 border border-primary/20 hover:bg-primary/10 active:bg-primary/15 transition-colors mb-2"
 									onClick={() => {

--- a/src/app/routines/new/page.tsx
+++ b/src/app/routines/new/page.tsx
@@ -57,6 +57,7 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import { normalizeExerciseName } from "@/lib/exercise-names";
 
 type RoutineExercise = {
   id: string;
@@ -444,6 +445,15 @@ export default function NewRoutinePage() {
     return true;
   });
 
+  const normalizedSearchQuery = normalizeExerciseName(searchQuery);
+  const hasExactExerciseMatch = exercises?.some(
+    (exercise) =>
+      normalizeExerciseName(exercise.name) === normalizedSearchQuery ||
+      exercise.aliases?.some(
+        (alias) => normalizeExerciseName(alias) === normalizedSearchQuery
+      )
+  );
+
   const needsSeeding = exercises && exercises.length === 0;
 
   return (
@@ -664,7 +674,7 @@ export default function NewRoutinePage() {
             )}
 
             <div className="flex-1 overflow-y-auto space-y-2">
-              {searchQuery.trim() && (
+              {searchQuery.trim() && !hasExactExerciseMatch && (
                 <Button
                   variant="outline"
                   className="w-full justify-start h-auto py-3 mb-2 bg-primary/5 border-primary/20 hover:bg-primary/10 text-primary hover:text-primary"

--- a/src/lib/exercise-names.ts
+++ b/src/lib/exercise-names.ts
@@ -1,3 +1,7 @@
+export function cleanExerciseName(name: string) {
+  return name.normalize("NFKC").trim().replace(/\s+/g, " ");
+}
+
 export function normalizeExerciseName(name: string) {
-  return name.normalize("NFKC").trim().replace(/\s+/g, " ").toLowerCase();
+  return cleanExerciseName(name).toLowerCase();
 }

--- a/src/lib/exercise-names.ts
+++ b/src/lib/exercise-names.ts
@@ -1,0 +1,3 @@
+export function normalizeExerciseName(name: string) {
+  return name.normalize("NFKC").trim().replace(/\s+/g, " ").toLowerCase();
+}


### PR DESCRIPTION
## What does this PR do?

- Limits the exercise library to system exercises plus custom exercises owned by the signed-in user.
- Normalizes exercise names and reuses an existing canonical exercise for exact name or alias matches.
- Collapses legacy duplicate rows to one visible result, preferring the system exercise and then the oldest custom entry.
- Hides the custom-exercise action when the search already exactly matches an exercise or alias.
- Prevents duplicate renames and applies the same ownership preference to AI exercise context.
- Adds a system-exercise index so scoped queries do not scan every custom exercise.

Legacy duplicate documents are intentionally retained so existing routine and workout references remain valid. The production audit found 12 `Plank` and 11 `Side Plank` rows in the newest 200 custom exercise documents; one owner had 11 of each.

## Related issue

N/A

## How to test

1. Open the exercise picker while creating or editing a routine.
2. Search for `plank`; verify the canonical `Plank` appears once and the custom-create action is hidden.
3. Search for `side plank`; verify only one owned custom entry appears and the custom-create action is hidden.
4. Attempt to create a case or whitespace variant of an existing exercise; verify the existing exercise ID is reused.
5. Verify another user custom exercises do not appear in search or muscle-group filters.

## Verification

- `bun run lint` — passes with seven pre-existing warnings
- `npx tsc --noEmit --pretty false`
- `npm run build`
- `npx convex codegen`
- Convex development query for `plank` returned one canonical system record

## Checklist

- [x] I have tested this locally
- [x] `bun run lint` passes
- [x] Documentation is not needed for this behavior fix

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/house-of-giants/codesmith/opentrainer/pr/49"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787264814&installation_model_id=19704&pr_number=49&repository=house-of-giants%2Fopentrainer&return_to=https%3A%2F%2Fgithub.com%2Fhouse-of-giants%2Fopentrainer%2Fpull%2F49&signature=5fdf9f3111afb726fdf4b6dbfff541b92cfc0211d877a645e878dff1873d8422"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved exercise search to recognize names consistently, including aliases and differences in capitalization or spacing.
  * Exercise lists now combine available library and custom exercises without duplicates.
  * AI exercise context now prioritizes library exercises when matching names.

* **Bug Fixes**
  * Prevented creation of duplicate custom exercises when an existing exercise matches the search.
  * Added validation to prevent duplicate exercise names when renaming.
  * Stored cleaned, consistent exercise names for new and updated exercises.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->