### PR TITLE
fix(workouts): preserve weight when editing RPE

### DIFF
--- a/src/app/workout/active/page.tsx
+++ b/src/app/workout/active/page.tsx
@@ -45,7 +45,10 @@ import {
 	CardioSaveBlockedError,
 	createCardioPersistenceGate,
 } from "@/lib/cardio-persistence";
-import { getExerciseGroupKey } from "@/lib/workout-exercise-group";
+import {
+	getExerciseGroup,
+	getExerciseGroupKey,
+} from "@/lib/workout-exercise-group";
 import posthog from "posthog-js";
 
 type EntryData = {
@@ -771,8 +774,11 @@ export default function ActiveWorkoutPage() {
 		}
 	) => {
 		if (!set.entryId) return;
-		const storedSet = exerciseGroups
-			.get(exerciseName)
+		const storedSet = getExerciseGroup(exerciseGroups, {
+			name: exerciseName,
+			category: "lifting",
+			measurementType: "reps",
+		})
 			?.entries.find((entry) => entry._id === set.entryId)?.lifting;
 		setEditingSet({
 			entryId: set.entryId,

--- a/src/app/workout/active/page.tsx
+++ b/src/app/workout/active/page.tsx
@@ -38,17 +38,17 @@ import { calculateProgressionSuggestion } from "@/lib/progression";
 import {
 	calculateVolumeInUnit,
 	displayWeight,
-	editedWeightForStorage,
 	type WeightUnit,
 } from "@/lib/units";
 import {
 	CardioSaveBlockedError,
 	createCardioPersistenceGate,
 } from "@/lib/cardio-persistence";
+import { getExerciseGroupKey } from "@/lib/workout-exercise-group";
 import {
-	getExerciseGroup,
-	getExerciseGroupKey,
-} from "@/lib/workout-exercise-group";
+	buildRepLiftingUpdate,
+	createEditableLiftingSet,
+} from "@/lib/workout-set-edit";
 import posthog from "posthog-js";
 
 type EntryData = {
@@ -773,25 +773,12 @@ export default function ActiveWorkoutPage() {
 			rpe?: number | null;
 		}
 	) => {
-		if (!set.entryId) return;
-		const storedSet = getExerciseGroup(exerciseGroups, {
-			name: exerciseName,
-			category: "lifting",
-			measurementType: "reps",
-		})
-			?.entries.find((entry) => entry._id === set.entryId)?.lifting;
-		setEditingSet({
-			entryId: set.entryId,
+		const editableSet = createEditableLiftingSet(
+			exerciseGroups,
 			exerciseName,
-			setNumber: set.setNumber,
-			reps: set.reps,
-			weight: set.weight,
-			unit: set.unit,
-			storedWeight: storedSet?.weight,
-			storedUnit: storedSet?.unit,
-			isBodyweight: set.isBodyweight,
-			rpe: set.rpe,
-		});
+			set
+		);
+		if (editableSet) setEditingSet(editableSet);
 	};
 
 	const handleEditTimedSet = (exerciseName: string, set: TimedSetData) => {
@@ -825,24 +812,7 @@ export default function ActiveWorkoutPage() {
 								unit: editingSet.unit,
 								rpe: data.rpe ?? undefined,
 							}
-						: {
-								setNumber: editingSet.setNumber,
-								reps: data.reps,
-								weight:
-									data.weight === undefined
-										? undefined
-										: editedWeightForStorage({
-												displayedWeight: data.weight,
-												displayUnit: editingSet.unit,
-												storedUnit:
-													editingSet.storedUnit ?? editingSet.unit,
-												originalDisplayedWeight: editingSet.weight,
-												originalStoredWeight: editingSet.storedWeight,
-											}),
-								unit: editingSet.storedUnit ?? editingSet.unit,
-								isBodyweight: editingSet.isBodyweight,
-								rpe: data.rpe ?? undefined,
-							},
+						: buildRepLiftingUpdate(editingSet, data),
 			});
 			vibrate("success");
 			toast.success("Set updated");

--- a/src/lib/workout-exercise-group.test.ts
+++ b/src/lib/workout-exercise-group.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { describe, test } from "node:test";
-import { getExerciseGroupKey } from "./workout-exercise-group";
+import {
+	getExerciseGroup,
+	getExerciseGroupKey,
+} from "./workout-exercise-group";
 
 describe("getExerciseGroupKey", () => {
 	test("separates rep and timed lifting rows with the same name", () => {
@@ -26,6 +29,25 @@ describe("getExerciseGroupKey", () => {
 				category: "lifting",
 				measurementType: "reps",
 			})
+		);
+	});
+
+	test("retrieves a rep-based lifting group from its structured key", () => {
+		const descriptor = {
+			name: "Bench Press",
+			category: "lifting" as const,
+			measurementType: "reps" as const,
+		};
+		const group = { storedWeight: 225 };
+		const groups = new Map([[getExerciseGroupKey(descriptor), group]]);
+
+		assert.equal(getExerciseGroup(groups, descriptor), group);
+		assert.equal(
+			getExerciseGroup(groups, {
+				...descriptor,
+				measurementType: "duration",
+			}),
+			undefined
 		);
 	});
 });

--- a/src/lib/workout-exercise-group.ts
+++ b/src/lib/workout-exercise-group.ts
@@ -12,3 +12,10 @@ export function getExerciseGroupKey(exercise: ExerciseGroupDescriptor) {
 			: "reps";
 	return JSON.stringify([exercise.name, category, measurementType]);
 }
+
+export function getExerciseGroup<T>(
+	groups: ReadonlyMap<string, T>,
+	exercise: ExerciseGroupDescriptor
+): T | undefined {
+	return groups.get(getExerciseGroupKey(exercise));
+}

--- a/src/lib/workout-set-edit.test.ts
+++ b/src/lib/workout-set-edit.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { getExerciseGroupKey } from "./workout-exercise-group";
+import {
+	buildRepLiftingUpdate,
+	createEditableLiftingSet,
+} from "./workout-set-edit";
+
+test("editing only RPE preserves the original stored weight and unit", async () => {
+	const entryId = "entry-1";
+	const exerciseName = "Bench Press";
+	const exerciseGroups = new Map([
+		[
+			getExerciseGroupKey({
+				name: exerciseName,
+				category: "lifting",
+				measurementType: "reps",
+			}),
+			{
+				entries: [
+					{
+						_id: entryId,
+						lifting: { weight: 225, unit: "lb" as const },
+					},
+				],
+			},
+		],
+	]);
+	const editingSet = createEditableLiftingSet(exerciseGroups, exerciseName, {
+		entryId,
+		setNumber: 1,
+		reps: 8,
+		weight: 102.1,
+		unit: "kg",
+		rpe: 7,
+	});
+	assert.ok(editingSet);
+
+	let received:
+		| {
+				entryId: string;
+				lifting: ReturnType<typeof buildRepLiftingUpdate>;
+		  }
+		| undefined;
+	const updateLiftingEntry = async (args: NonNullable<typeof received>) => {
+		received = args;
+	};
+
+	await updateLiftingEntry({
+		entryId,
+		lifting: buildRepLiftingUpdate(editingSet, {
+			reps: 8,
+			weight: 102.1,
+			rpe: 8,
+		}),
+	});
+
+	assert.deepEqual(received, {
+		entryId,
+		lifting: {
+			setNumber: 1,
+			reps: 8,
+			weight: 225,
+			unit: "lb",
+			isBodyweight: undefined,
+			rpe: 8,
+		},
+	});
+});

--- a/src/lib/workout-set-edit.ts
+++ b/src/lib/workout-set-edit.ts
@@ -1,0 +1,75 @@
+import { getExerciseGroup } from "./workout-exercise-group";
+import { editedWeightForStorage, type WeightUnit } from "./units";
+
+type StoredLiftingEntry = {
+	_id: string;
+	lifting?: {
+		weight?: number;
+		unit: WeightUnit;
+	};
+};
+
+type DisplayedLiftingSet = {
+	entryId?: string;
+	setNumber: number;
+	reps: number;
+	weight: number;
+	unit: WeightUnit;
+	isBodyweight?: boolean;
+	rpe?: number | null;
+};
+
+export type EditableLiftingSet = DisplayedLiftingSet & {
+	entryId: string;
+	exerciseName: string;
+	storedWeight?: number;
+	storedUnit?: WeightUnit;
+};
+
+export function createEditableLiftingSet(
+	exerciseGroups: ReadonlyMap<
+		string,
+		{ entries: readonly StoredLiftingEntry[] }
+	>,
+	exerciseName: string,
+	set: DisplayedLiftingSet
+): EditableLiftingSet | undefined {
+	if (!set.entryId) return undefined;
+
+	const storedSet = getExerciseGroup(exerciseGroups, {
+		name: exerciseName,
+		category: "lifting",
+		measurementType: "reps",
+	})?.entries.find((entry) => entry._id === set.entryId)?.lifting;
+
+	return {
+		...set,
+		entryId: set.entryId,
+		exerciseName,
+		storedWeight: storedSet?.weight,
+		storedUnit: storedSet?.unit,
+	};
+}
+
+export function buildRepLiftingUpdate(
+	editingSet: EditableLiftingSet,
+	data: { reps?: number; weight?: number; rpe?: number | null }
+) {
+	return {
+		setNumber: editingSet.setNumber,
+		reps: data.reps,
+		weight:
+			data.weight === undefined
+				? undefined
+				: editedWeightForStorage({
+						displayedWeight: data.weight,
+						displayUnit: editingSet.unit,
+						storedUnit: editingSet.storedUnit ?? editingSet.unit,
+						originalDisplayedWeight: editingSet.weight,
+						originalStoredWeight: editingSet.storedWeight,
+					}),
+		unit: editingSet.storedUnit ?? editingSet.unit,
+		isBodyweight: editingSet.isBodyweight,
+		rpe: data.rpe ?? undefined,
+	};
+}


### PR DESCRIPTION
## What does this PR do?

### Problem and evidence

Production feedback reported that editing only the RPE of a logged set on the active-workout page cleared its weight. Exercise groups are stored under structured keys containing the exercise name, category, and measurement type, but the edit path looked up the group with only the plain exercise name. The lookup therefore missed, and the full lifting-payload replacement omitted the original stored weight.

### Implementation

- Resolve the rep-based lifting group through the same structured-key helper used when groups are created.
- Reuse the original stored weight and unit when only RPE or reps change, preserving canonical values without conversion-rounding drift.
- Add focused coverage for structured rep-group retrieval and measurement-type separation.

### Compatibility notes

No schema, API, dependency, or production-data changes. Timed strength sets and cardio entries retain their existing edit paths.

## Related issue

N/A

## How to test

1. Start an active workout and log a weighted lifting set.
2. Open the logged set, change only its RPE, and save.
3. Confirm the displayed weight is unchanged and the new RPE persists.
4. Repeat with a preferred display unit different from the stored unit and confirm the canonical weight does not drift.

Automated verification:

- bun test — 39 passed, 0 failed
- bun run lint — passed with 7 pre-existing warnings and 0 errors
- bunx tsc --noEmit — passed
- bun run build — passed
- git diff --check — passed

## Checklist

- [x] I have tested this locally
- [x] bun run lint passes
- [x] Documentation is unchanged because this is a focused behavior fix

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/house-of-giants/codesmith/opentrainer/pr/50"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787264984&installation_model_id=19704&pr_number=50&repository=house-of-giants%2Fopentrainer&return_to=https%3A%2F%2Fgithub.com%2Fhouse-of-giants%2Fopentrainer%2Fpull%2F50&signature=eb10bacabc049fa7a91fa04d0655ee3beb90cd9793a5bc0ce2ffd53710c271f5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved set editing in active workouts to consistently select the correct lifting exercise group.
  - Prevented conflicts between exercises tracked by repetitions and those tracked by duration.

- **Tests**
  - Added coverage confirming exercise groups are matched using their name, category, and measurement type.
  - Verified that groups with mismatched measurement types are not selected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->
