### PR TITLE
chore(release): ship exercise and workout fixes

### DIFF
--- a/convex/ai/aggregators.ts
+++ b/convex/ai/aggregators.ts
@@ -949,10 +949,13 @@ export const getExerciseContext = internalQuery({
     exerciseName: v.string(),
   },
   handler: async (ctx, args) => {
-    const exercise = await ctx.db
+    const exercises = await ctx.db
       .query("exercises")
       .withIndex("by_name", (q) => q.eq("name", args.exerciseName))
-      .first();
+      .collect();
+    const exercise =
+      exercises.find((candidate) => candidate.isSystemExercise) ??
+      exercises.find((candidate) => candidate.userId === args.userId);
 
     const recentEntries = await ctx.db
       .query("entries")

--- a/convex/exercises.ts
+++ b/convex/exercises.ts
@@ -2,14 +2,10 @@ import { v } from "convex/values";
 import type { Doc } from "./_generated/dataModel";
 import { mutation, query, type MutationCtx, type QueryCtx } from "./_generated/server";
 import { getCurrentUser } from "./auth";
-
-function cleanExerciseName(name: string) {
-  return name.normalize("NFKC").trim().replace(/\s+/g, " ");
-}
-
-function normalizeExerciseName(name: string) {
-  return cleanExerciseName(name).toLowerCase();
-}
+import {
+  cleanExerciseName,
+  normalizeExerciseName,
+} from "../src/lib/exercise-names";
 
 function hasExerciseName(exercise: Doc<"exercises">, normalizedName: string) {
   return (
@@ -67,7 +63,16 @@ function deduplicateExercises(exercises: Doc<"exercises">[]) {
 
   for (const exercise of preferredExercises) {
     const normalizedName = normalizeExerciseName(exercise.name);
-    if (!uniqueExercises.has(normalizedName)) {
+    const matchesExistingExercise = Array.from(uniqueExercises.values()).some(
+      (existingExercise) =>
+        hasExerciseName(existingExercise, normalizedName) ||
+        hasExerciseName(
+          exercise,
+          normalizeExerciseName(existingExercise.name)
+        )
+    );
+
+    if (!matchesExistingExercise) {
       uniqueExercises.set(normalizedName, exercise);
     }
   }

--- a/convex/exercises.ts
+++ b/convex/exercises.ts
@@ -1,6 +1,79 @@
 import { v } from "convex/values";
-import { mutation, query } from "./_generated/server";
+import type { Doc } from "./_generated/dataModel";
+import { mutation, query, type MutationCtx, type QueryCtx } from "./_generated/server";
 import { getCurrentUser } from "./auth";
+
+function cleanExerciseName(name: string) {
+  return name.normalize("NFKC").trim().replace(/\s+/g, " ");
+}
+
+function normalizeExerciseName(name: string) {
+  return cleanExerciseName(name).toLowerCase();
+}
+
+function hasExerciseName(exercise: Doc<"exercises">, normalizedName: string) {
+  return (
+    normalizeExerciseName(exercise.name) === normalizedName ||
+    exercise.aliases?.some(
+      (alias) => normalizeExerciseName(alias) === normalizedName
+    ) === true
+  );
+}
+
+function findMatchingExercise(
+  systemExercises: Doc<"exercises">[],
+  userExercises: Doc<"exercises">[],
+  normalizedName: string
+) {
+  return (
+    systemExercises.find(
+      (exercise) => normalizeExerciseName(exercise.name) === normalizedName
+    ) ??
+    userExercises.find(
+      (exercise) => normalizeExerciseName(exercise.name) === normalizedName
+    ) ??
+    systemExercises.find((exercise) => hasExerciseName(exercise, normalizedName)) ??
+    userExercises.find((exercise) => hasExerciseName(exercise, normalizedName))
+  );
+}
+
+async function getVisibleExercises(ctx: QueryCtx | MutationCtx) {
+  const user = await getCurrentUser(ctx, {
+    requireAuth: false,
+    requireUser: false,
+  });
+  const systemExercises = await ctx.db
+    .query("exercises")
+    .withIndex("by_system", (q) => q.eq("isSystemExercise", true))
+    .collect();
+  const userExercises = user
+    ? await ctx.db
+        .query("exercises")
+        .withIndex("by_user", (q) => q.eq("userId", user._id))
+        .collect()
+    : [];
+
+  return [...systemExercises, ...userExercises];
+}
+
+function deduplicateExercises(exercises: Doc<"exercises">[]) {
+  const preferredExercises = [...exercises].sort((a, b) => {
+    if (a.isSystemExercise !== b.isSystemExercise) {
+      return a.isSystemExercise ? -1 : 1;
+    }
+    return a.createdAt - b.createdAt;
+  });
+  const uniqueExercises = new Map<string, Doc<"exercises">>();
+
+  for (const exercise of preferredExercises) {
+    const normalizedName = normalizeExerciseName(exercise.name);
+    if (!uniqueExercises.has(normalizedName)) {
+      uniqueExercises.set(normalizedName, exercise);
+    }
+  }
+
+  return Array.from(uniqueExercises.values());
+}
 
 // ============================================================================
 // System Exercises Data
@@ -150,7 +223,7 @@ export const getExercises = query({
     search: v.optional(v.string()),
   },
   handler: async (ctx, args) => {
-    let exercises = await ctx.db.query("exercises").collect();
+    let exercises = await getVisibleExercises(ctx);
 
     if (args.category) {
       exercises = exercises.filter(e => e.category === args.category);
@@ -170,7 +243,7 @@ export const getExercises = query({
       );
     }
 
-    return exercises.sort((a, b) => {
+    return deduplicateExercises(exercises).sort((a, b) => {
       if (a.isSystemExercise !== b.isSystemExercise) {
         return a.isSystemExercise ? -1 : 1;
       }
@@ -185,7 +258,15 @@ export const getExercises = query({
 export const getExercise = query({
   args: { id: v.id("exercises") },
   handler: async (ctx, args) => {
-    return await ctx.db.get(args.id);
+    const exercise = await ctx.db.get(args.id);
+    if (!exercise) return null;
+    if (exercise.isSystemExercise) return exercise;
+
+    const user = await getCurrentUser(ctx, {
+      requireAuth: false,
+      requireUser: false,
+    });
+    return exercise.userId === user?._id ? exercise : null;
   },
 });
 
@@ -195,7 +276,7 @@ export const getExercise = query({
 export const getMuscleGroups = query({
   args: {},
   handler: async (ctx) => {
-    const exercises = await ctx.db.query("exercises").collect();
+    const exercises = await getVisibleExercises(ctx);
     const muscleGroups = new Set<string>();
     
     for (const exercise of exercises) {
@@ -318,9 +399,33 @@ export const createExercise = mutation({
     const user = await getCurrentUser(ctx);
     if (!user) throw new Error("User not found");
 
+    const name = cleanExerciseName(args.name);
+    const normalizedName = normalizeExerciseName(name);
+    if (!normalizedName) {
+      throw new Error("Exercise name is required");
+    }
+
+    const systemExercises = await ctx.db
+      .query("exercises")
+      .withIndex("by_system", (q) => q.eq("isSystemExercise", true))
+      .collect();
+    const userExercises = await ctx.db
+      .query("exercises")
+      .withIndex("by_user", (q) => q.eq("userId", user._id))
+      .collect();
+    const existingExercise = findMatchingExercise(
+      systemExercises,
+      userExercises,
+      normalizedName
+    );
+
+    if (existingExercise) {
+      return existingExercise._id;
+    }
+
     const id = await ctx.db.insert("exercises", {
       userId: user._id,
-      name: args.name,
+      name,
       aliases: args.aliases,
       category: args.category,
       muscleGroups: args.muscleGroups,
@@ -371,7 +476,25 @@ export const updateExercise = mutation({
     }
 
     if (args.name !== undefined) {
-      updates.name = args.name;
+      const name = cleanExerciseName(args.name);
+      const normalizedName = normalizeExerciseName(name);
+      if (!normalizedName) {
+        throw new Error("Exercise name is required");
+      }
+
+      if (normalizedName !== normalizeExerciseName(exercise.name)) {
+        const visibleExercises = await getVisibleExercises(ctx);
+        const duplicate = visibleExercises.find(
+          (candidate) =>
+            candidate._id !== exercise._id &&
+            hasExerciseName(candidate, normalizedName)
+        );
+        if (duplicate) {
+          throw new Error("An exercise with this name already exists");
+        }
+      }
+
+      updates.name = name;
     }
 
     await ctx.db.patch(args.id, updates);

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -98,6 +98,7 @@ export default defineSchema({
     createdAt: v.number(),
   })
     .index("by_user", ["userId"])
+    .index("by_system", ["isSystemExercise"])
     .index("by_category", ["category"])
     .index("by_name", ["name"]),
 

--- a/src/app/routines/[id]/edit/page.tsx
+++ b/src/app/routines/[id]/edit/page.tsx
@@ -64,6 +64,7 @@ import {
 	type RoutineExercise,
 } from "@/components/workout/edit-exercise-sheet";
 import { ImportDayDialog } from "@/components/workout/import-day-dialog";
+import { normalizeExerciseName } from "@/lib/exercise-names";
 
 type RoutineDay = {
 	id: string;
@@ -423,6 +424,15 @@ export default function EditRoutinePage() {
 		return true;
 	});
 
+	const normalizedSearchQuery = normalizeExerciseName(searchQuery);
+	const hasExactExerciseMatch = exercises?.some(
+		(exercise) =>
+			normalizeExerciseName(exercise.name) === normalizedSearchQuery ||
+			exercise.aliases?.some(
+				(alias) => normalizeExerciseName(alias) === normalizedSearchQuery
+			)
+	);
+
 	const needsSeeding = exercises && exercises.length === 0;
 
 	if (routine === undefined) {
@@ -740,7 +750,7 @@ export default function EditRoutinePage() {
 						)}
 
 						<div className="flex-1 overflow-y-auto -mx-4 px-4 space-y-1">
-							{searchQuery.trim() && (
+							{searchQuery.trim() && !hasExactExerciseMatch && (
 								<button
 									className="w-full flex items-center justify-between p-3 rounded-lg text-left bg-primary/5 border border-primary/20 hover:bg-primary/10 active:bg-primary/15 transition-colors mb-2"
 									onClick={() => {

--- a/src/app/routines/new/page.tsx
+++ b/src/app/routines/new/page.tsx
@@ -57,6 +57,7 @@ import {
   verticalListSortingStrategy,
 } from "@dnd-kit/sortable";
 import { CSS } from "@dnd-kit/utilities";
+import { normalizeExerciseName } from "@/lib/exercise-names";
 
 type RoutineExercise = {
   id: string;
@@ -444,6 +445,15 @@ export default function NewRoutinePage() {
     return true;
   });
 
+  const normalizedSearchQuery = normalizeExerciseName(searchQuery);
+  const hasExactExerciseMatch = exercises?.some(
+    (exercise) =>
+      normalizeExerciseName(exercise.name) === normalizedSearchQuery ||
+      exercise.aliases?.some(
+        (alias) => normalizeExerciseName(alias) === normalizedSearchQuery
+      )
+  );
+
   const needsSeeding = exercises && exercises.length === 0;
 
   return (
@@ -664,7 +674,7 @@ export default function NewRoutinePage() {
             )}
 
             <div className="flex-1 overflow-y-auto space-y-2">
-              {searchQuery.trim() && (
+              {searchQuery.trim() && !hasExactExerciseMatch && (
                 <Button
                   variant="outline"
                   className="w-full justify-start h-auto py-3 mb-2 bg-primary/5 border-primary/20 hover:bg-primary/10 text-primary hover:text-primary"

--- a/src/app/workout/active/page.tsx
+++ b/src/app/workout/active/page.tsx
@@ -45,7 +45,10 @@ import {
 	CardioSaveBlockedError,
 	createCardioPersistenceGate,
 } from "@/lib/cardio-persistence";
-import { getExerciseGroupKey } from "@/lib/workout-exercise-group";
+import {
+	getExerciseGroup,
+	getExerciseGroupKey,
+} from "@/lib/workout-exercise-group";
 import posthog from "posthog-js";
 
 type EntryData = {
@@ -771,8 +774,11 @@ export default function ActiveWorkoutPage() {
 		}
 	) => {
 		if (!set.entryId) return;
-		const storedSet = exerciseGroups
-			.get(exerciseName)
+		const storedSet = getExerciseGroup(exerciseGroups, {
+			name: exerciseName,
+			category: "lifting",
+			measurementType: "reps",
+		})
 			?.entries.find((entry) => entry._id === set.entryId)?.lifting;
 		setEditingSet({
 			entryId: set.entryId,

--- a/src/app/workout/active/page.tsx
+++ b/src/app/workout/active/page.tsx
@@ -38,17 +38,17 @@ import { calculateProgressionSuggestion } from "@/lib/progression";
 import {
 	calculateVolumeInUnit,
 	displayWeight,
-	editedWeightForStorage,
 	type WeightUnit,
 } from "@/lib/units";
 import {
 	CardioSaveBlockedError,
 	createCardioPersistenceGate,
 } from "@/lib/cardio-persistence";
+import { getExerciseGroupKey } from "@/lib/workout-exercise-group";
 import {
-	getExerciseGroup,
-	getExerciseGroupKey,
-} from "@/lib/workout-exercise-group";
+	buildRepLiftingUpdate,
+	createEditableLiftingSet,
+} from "@/lib/workout-set-edit";
 import posthog from "posthog-js";
 
 type EntryData = {
@@ -773,25 +773,12 @@ export default function ActiveWorkoutPage() {
 			rpe?: number | null;
 		}
 	) => {
-		if (!set.entryId) return;
-		const storedSet = getExerciseGroup(exerciseGroups, {
-			name: exerciseName,
-			category: "lifting",
-			measurementType: "reps",
-		})
-			?.entries.find((entry) => entry._id === set.entryId)?.lifting;
-		setEditingSet({
-			entryId: set.entryId,
+		const editableSet = createEditableLiftingSet(
+			exerciseGroups,
 			exerciseName,
-			setNumber: set.setNumber,
-			reps: set.reps,
-			weight: set.weight,
-			unit: set.unit,
-			storedWeight: storedSet?.weight,
-			storedUnit: storedSet?.unit,
-			isBodyweight: set.isBodyweight,
-			rpe: set.rpe,
-		});
+			set
+		);
+		if (editableSet) setEditingSet(editableSet);
 	};
 
 	const handleEditTimedSet = (exerciseName: string, set: TimedSetData) => {
@@ -825,24 +812,7 @@ export default function ActiveWorkoutPage() {
 								unit: editingSet.unit,
 								rpe: data.rpe ?? undefined,
 							}
-						: {
-								setNumber: editingSet.setNumber,
-								reps: data.reps,
-								weight:
-									data.weight === undefined
-										? undefined
-										: editedWeightForStorage({
-												displayedWeight: data.weight,
-												displayUnit: editingSet.unit,
-												storedUnit:
-													editingSet.storedUnit ?? editingSet.unit,
-												originalDisplayedWeight: editingSet.weight,
-												originalStoredWeight: editingSet.storedWeight,
-											}),
-								unit: editingSet.storedUnit ?? editingSet.unit,
-								isBodyweight: editingSet.isBodyweight,
-								rpe: data.rpe ?? undefined,
-							},
+						: buildRepLiftingUpdate(editingSet, data),
 			});
 			vibrate("success");
 			toast.success("Set updated");

--- a/src/lib/exercise-names.ts
+++ b/src/lib/exercise-names.ts
@@ -1,3 +1,7 @@
+export function cleanExerciseName(name: string) {
+  return name.normalize("NFKC").trim().replace(/\s+/g, " ");
+}
+
 export function normalizeExerciseName(name: string) {
-  return name.normalize("NFKC").trim().replace(/\s+/g, " ").toLowerCase();
+  return cleanExerciseName(name).toLowerCase();
 }

--- a/src/lib/exercise-names.ts
+++ b/src/lib/exercise-names.ts
@@ -1,0 +1,3 @@
+export function normalizeExerciseName(name: string) {
+  return name.normalize("NFKC").trim().replace(/\s+/g, " ").toLowerCase();
+}

--- a/src/lib/workout-exercise-group.test.ts
+++ b/src/lib/workout-exercise-group.test.ts
@@ -1,6 +1,9 @@
 import assert from "node:assert/strict";
 import { describe, test } from "node:test";
-import { getExerciseGroupKey } from "./workout-exercise-group";
+import {
+	getExerciseGroup,
+	getExerciseGroupKey,
+} from "./workout-exercise-group";
 
 describe("getExerciseGroupKey", () => {
 	test("separates rep and timed lifting rows with the same name", () => {
@@ -26,6 +29,25 @@ describe("getExerciseGroupKey", () => {
 				category: "lifting",
 				measurementType: "reps",
 			})
+		);
+	});
+
+	test("retrieves a rep-based lifting group from its structured key", () => {
+		const descriptor = {
+			name: "Bench Press",
+			category: "lifting" as const,
+			measurementType: "reps" as const,
+		};
+		const group = { storedWeight: 225 };
+		const groups = new Map([[getExerciseGroupKey(descriptor), group]]);
+
+		assert.equal(getExerciseGroup(groups, descriptor), group);
+		assert.equal(
+			getExerciseGroup(groups, {
+				...descriptor,
+				measurementType: "duration",
+			}),
+			undefined
 		);
 	});
 });

--- a/src/lib/workout-exercise-group.ts
+++ b/src/lib/workout-exercise-group.ts
@@ -12,3 +12,10 @@ export function getExerciseGroupKey(exercise: ExerciseGroupDescriptor) {
 			: "reps";
 	return JSON.stringify([exercise.name, category, measurementType]);
 }
+
+export function getExerciseGroup<T>(
+	groups: ReadonlyMap<string, T>,
+	exercise: ExerciseGroupDescriptor
+): T | undefined {
+	return groups.get(getExerciseGroupKey(exercise));
+}

--- a/src/lib/workout-set-edit.test.ts
+++ b/src/lib/workout-set-edit.test.ts
@@ -1,0 +1,69 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import { getExerciseGroupKey } from "./workout-exercise-group";
+import {
+	buildRepLiftingUpdate,
+	createEditableLiftingSet,
+} from "./workout-set-edit";
+
+test("editing only RPE preserves the original stored weight and unit", async () => {
+	const entryId = "entry-1";
+	const exerciseName = "Bench Press";
+	const exerciseGroups = new Map([
+		[
+			getExerciseGroupKey({
+				name: exerciseName,
+				category: "lifting",
+				measurementType: "reps",
+			}),
+			{
+				entries: [
+					{
+						_id: entryId,
+						lifting: { weight: 225, unit: "lb" as const },
+					},
+				],
+			},
+		],
+	]);
+	const editingSet = createEditableLiftingSet(exerciseGroups, exerciseName, {
+		entryId,
+		setNumber: 1,
+		reps: 8,
+		weight: 102.1,
+		unit: "kg",
+		rpe: 7,
+	});
+	assert.ok(editingSet);
+
+	let received:
+		| {
+				entryId: string;
+				lifting: ReturnType<typeof buildRepLiftingUpdate>;
+		  }
+		| undefined;
+	const updateLiftingEntry = async (args: NonNullable<typeof received>) => {
+		received = args;
+	};
+
+	await updateLiftingEntry({
+		entryId,
+		lifting: buildRepLiftingUpdate(editingSet, {
+			reps: 8,
+			weight: 102.1,
+			rpe: 8,
+		}),
+	});
+
+	assert.deepEqual(received, {
+		entryId,
+		lifting: {
+			setNumber: 1,
+			reps: 8,
+			weight: 225,
+			unit: "lb",
+			isBodyweight: undefined,
+			rpe: 8,
+		},
+	});
+});

--- a/src/lib/workout-set-edit.ts
+++ b/src/lib/workout-set-edit.ts
@@ -1,0 +1,75 @@
+import { getExerciseGroup } from "./workout-exercise-group";
+import { editedWeightForStorage, type WeightUnit } from "./units";
+
+type StoredLiftingEntry = {
+	_id: string;
+	lifting?: {
+		weight?: number;
+		unit: WeightUnit;
+	};
+};
+
+type DisplayedLiftingSet = {
+	entryId?: string;
+	setNumber: number;
+	reps: number;
+	weight: number;
+	unit: WeightUnit;
+	isBodyweight?: boolean;
+	rpe?: number | null;
+};
+
+export type EditableLiftingSet = DisplayedLiftingSet & {
+	entryId: string;
+	exerciseName: string;
+	storedWeight?: number;
+	storedUnit?: WeightUnit;
+};
+
+export function createEditableLiftingSet(
+	exerciseGroups: ReadonlyMap<
+		string,
+		{ entries: readonly StoredLiftingEntry[] }
+	>,
+	exerciseName: string,
+	set: DisplayedLiftingSet
+): EditableLiftingSet | undefined {
+	if (!set.entryId) return undefined;
+
+	const storedSet = getExerciseGroup(exerciseGroups, {
+		name: exerciseName,
+		category: "lifting",
+		measurementType: "reps",
+	})?.entries.find((entry) => entry._id === set.entryId)?.lifting;
+
+	return {
+		...set,
+		entryId: set.entryId,
+		exerciseName,
+		storedWeight: storedSet?.weight,
+		storedUnit: storedSet?.unit,
+	};
+}
+
+export function buildRepLiftingUpdate(
+	editingSet: EditableLiftingSet,
+	data: { reps?: number; weight?: number; rpe?: number | null }
+) {
+	return {
+		setNumber: editingSet.setNumber,
+		reps: data.reps,
+		weight:
+			data.weight === undefined
+				? undefined
+				: editedWeightForStorage({
+						displayedWeight: data.weight,
+						displayUnit: editingSet.unit,
+						storedUnit: editingSet.storedUnit ?? editingSet.unit,
+						originalDisplayedWeight: editingSet.weight,
+						originalStoredWeight: editingSet.storedWeight,
+					}),
+		unit: editingSet.storedUnit ?? editingSet.unit,
+		isBodyweight: editingSet.isBodyweight,
+		rpe: data.rpe ?? undefined,
+	};
+}


### PR DESCRIPTION
## What does this PR do?

Bundles two reviewed fixes into one release merge and therefore one eventual production deployment:

- #49 — canonical, owner-scoped exercise search and legacy custom-exercise deduplication
- #50 — preserve the original stored weight and unit when editing set reps or RPE

The i18n research PR #43 is intentionally excluded. The release branch starts at current production commit f9317c3 and merges the exact reviewed heads afaffa0 (#49) and 3d0f4fe (#50).

## Why one release PR?

Merging #49 and #50 separately would create two main updates and normally two production deployments. Merging this release PR once creates one production update and one user-visible release notification. Use a merge commit, not squash, so both component heads and their review history remain reachable.

## Release identity and SemVer

This operational release intentionally leaves package.json at 0.1.0 and does not create a new semver tag. The in-app update notifier uses the production Vercel deployment ID from /api/version, so every deploy already has a unique release identity without inventing a package-version bump for each ad-hoc feedback batch. SemVer can remain reserved for meaningful product or API milestones.

## Review status

- #49: both initial review findings are addressed in afaffa0 (alias-aware deduplication and one shared normalization implementation); component checks pass. The follow-up automated review was rate-limited.
- #50: the edit-path regression finding is addressed in 3d0f4fe; component checks pass. The follow-up automated review was rate-limited.
- Both exact PR heads are ancestors of this release branch and merged without conflicts.

## Compatibility and deployment notes

- The new system-exercise index is additive and existing exercise records remain valid.
- Legacy duplicate documents are retained so existing routine and workout references remain intact.
- No production data was mutated while preparing this release.
- Timed strength and cardio edit paths are unchanged.

## How to test

Integration checks run from the combined release branch:

- bun test — 39 passed, 0 failed
- bunx tsc --noEmit — passed
- bun run lint — 0 errors, 7 pre-existing warnings
- bun run build — passed; all routes generated
- git diff --check origin/main...HEAD — passed

Manual release checks:

1. Merge this PR once using a merge commit.
2. Confirm one production deployment completes for the resulting main commit.
3. Confirm production /api/version returns the new deployment ID with no-store headers.
4. Search for Plank and Side Plank and confirm canonical/owned results appear only once.
5. Log a weighted set, edit only its RPE, and confirm the weight remains unchanged, including when the preferred display unit differs from the stored unit.

## Related issues

Production feedback records; no GitHub issue numbers.

## Checklist

- [x] #49 and #50 exact reviewed heads included
- [x] Integration tests, TypeScript, lint, and production build pass
- [x] No production data mutation performed
- [x] i18n research PR excluded
- [x] No artificial semver bump or tag

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/house-of-giants/codesmith/opentrainer/pr/51"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787267180&installation_model_id=19704&pr_number=51&repository=house-of-giants%2Fopentrainer&return_to=https%3A%2F%2Fgithub.com%2Fhouse-of-giants%2Fopentrainer%2Fpull%2F51&signature=15e99ea59719aeb7f26c429cacd7c383ea9cc12b1c53876427f8f1606d7182d1"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->