### PR TITLE
fix(exercises): add guarded duplicate cleanup

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -45,6 +45,7 @@
         "@types/node": "^20",
         "@types/react": "^19",
         "@types/react-dom": "^19",
+        "convex-test": "0.0.41",
         "eslint": "^9",
         "eslint-config-next": "16.1.1",
         "tailwindcss": "^4",
@@ -627,6 +628,8 @@
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
     "convex": ["convex@1.31.2", "", { "dependencies": { "esbuild": "0.25.4", "prettier": "^3.0.0" }, "peerDependencies": { "@auth0/auth0-react": "^2.0.1", "@clerk/clerk-react": "^4.12.8 || ^5.0.0", "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0" }, "optionalPeers": ["@auth0/auth0-react", "@clerk/clerk-react", "react"], "bin": { "convex": "bin/main.js" } }, "sha512-RFuJOwlL2bM5X63egvBI5ZZZH6wESREpAbHsLjODxzDeJuewTLKrEnbvHV/NWp1uJYpgEFJziuGHmZ0tnAmmJg=="],
+
+    "convex-test": ["convex-test@0.0.41", "", { "peerDependencies": { "convex": "^1.16.4" } }, "sha512-GPHeYFOi70n7UtW0eCEQFVhzl/+m8PvbWkDCbKpHLybI1MrScf4sVpGeM0cC2qmtxiduxa2nLPbehPalhh9oyQ=="],
 
     "cookie": ["cookie@1.0.2", "", {}, "sha512-9Kr/j4O16ISv8zBBhJoi4bXOYNTkFLOqSL3UDB0njXxCXNezjeyVrJyGOWtgfs/q2km1gwBcfH8q1yEGoMYunA=="],
 

--- a/convex/exercises.ts
+++ b/convex/exercises.ts
@@ -6,6 +6,7 @@ import {
   cleanExerciseName,
   normalizeExerciseName,
 } from "../src/lib/exercise-names";
+import { deduplicateVisibleExercises } from "../src/lib/exercise-deduplication";
 
 function hasExerciseName(exercise: Doc<"exercises">, normalizedName: string) {
   return (
@@ -53,31 +54,7 @@ async function getVisibleExercises(ctx: QueryCtx | MutationCtx) {
 }
 
 function deduplicateExercises(exercises: Doc<"exercises">[]) {
-  const preferredExercises = [...exercises].sort((a, b) => {
-    if (a.isSystemExercise !== b.isSystemExercise) {
-      return a.isSystemExercise ? -1 : 1;
-    }
-    return a.createdAt - b.createdAt;
-  });
-  const uniqueExercises = new Map<string, Doc<"exercises">>();
-
-  for (const exercise of preferredExercises) {
-    const normalizedName = normalizeExerciseName(exercise.name);
-    const matchesExistingExercise = Array.from(uniqueExercises.values()).some(
-      (existingExercise) =>
-        hasExerciseName(existingExercise, normalizedName) ||
-        hasExerciseName(
-          exercise,
-          normalizeExerciseName(existingExercise.name)
-        )
-    );
-
-    if (!matchesExistingExercise) {
-      uniqueExercises.set(normalizedName, exercise);
-    }
-  }
-
-  return Array.from(uniqueExercises.values());
+  return deduplicateVisibleExercises(exercises);
 }
 
 // ============================================================================

--- a/convex/migrations/exerciseDeduplication.test.ts
+++ b/convex/migrations/exerciseDeduplication.test.ts
@@ -1,0 +1,295 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import { makeFunctionReference } from "convex/server";
+import { convexTest } from "convex-test";
+import type { Id } from "../_generated/dataModel";
+import schema from "../schema";
+
+const modules = {
+	"../_generated/server.ts": () => import("../_generated/server"),
+	"../migrations/exerciseDeduplication.ts": () =>
+		import("./exerciseDeduplication"),
+};
+
+type AuditResult = {
+	exerciseCount: number;
+	duplicateGroupCount: number;
+	removableExerciseCount: number;
+	routineReferenceCount: number;
+	entryReferenceCount: number;
+	groups: Array<{
+		ownerId: string;
+		canonical: {
+			id: Id<"exercises">;
+			name: string;
+			isSystemExercise: boolean;
+		};
+		duplicates: Array<{
+			id: Id<"exercises">;
+			name: string;
+			routineReferenceCount: number;
+			entryReferenceCount: number;
+		}>;
+	}>;
+};
+
+type ApplyArgs = {
+	confirmation: "deduplicate-exercises";
+	expectedExerciseCount: number;
+	expectedRemovableExerciseCount: number;
+};
+
+type ApplyResult = Omit<AuditResult, "groups"> & {
+	updatedRoutineCount: number;
+	updatedEntryCount: number;
+	deletedExerciseCount: number;
+};
+
+const audit = makeFunctionReference<"query", Record<string, never>, AuditResult>(
+	"migrations/exerciseDeduplication:audit"
+);
+const apply = makeFunctionReference<"mutation", ApplyArgs, ApplyResult>(
+	"migrations/exerciseDeduplication:apply"
+);
+
+function createTest() {
+	return convexTest(schema, modules);
+}
+
+async function insertUser(t: ReturnType<typeof createTest>) {
+	return t.run((ctx) =>
+		ctx.db.insert("users", {
+			clerkId: "test-user",
+			createdAt: 1,
+			updatedAt: 1,
+		})
+	);
+}
+
+async function insertExercise(
+	t: ReturnType<typeof createTest>,
+	value: {
+		name: string;
+		createdAt: number;
+		isSystemExercise: boolean;
+		userId?: Id<"users">;
+	}
+) {
+	return t.run((ctx) =>
+		ctx.db.insert("exercises", {
+			...value,
+			category: "lifting",
+		})
+	);
+}
+
+async function seedReferencedDuplicates(t: ReturnType<typeof createTest>) {
+	const userId = await insertUser(t);
+	const canonicalId = await insertExercise(t, {
+		name: "Plank",
+		createdAt: 1,
+		isSystemExercise: true,
+	});
+	const referencedDuplicateId = await insertExercise(t, {
+		name: "Plank",
+		createdAt: 2,
+		isSystemExercise: false,
+		userId,
+	});
+	const unreferencedDuplicateId = await insertExercise(t, {
+		name: " plank ",
+		createdAt: 3,
+		isSystemExercise: false,
+		userId,
+	});
+
+	const { routineId, entryId } = await t.run(async (ctx) => {
+		const routineId = await ctx.db.insert("routines", {
+			userId,
+			name: "Core",
+			source: "manual",
+			days: [
+				{
+					name: "Day 1",
+					exercises: [
+						{
+							exerciseId: referencedDuplicateId,
+							exerciseName: "Plank",
+							kind: "lifting",
+						},
+					],
+				},
+			],
+			isActive: true,
+			createdAt: 1,
+			updatedAt: 1,
+		});
+		const workoutId = await ctx.db.insert("workouts", {
+			userId,
+			status: "completed",
+			startedAt: 1,
+			completedAt: 2,
+		});
+		const entryId = await ctx.db.insert("entries", {
+			workoutId,
+			userId,
+			exerciseId: referencedDuplicateId,
+			exerciseName: "Plank",
+			kind: "lifting",
+			lifting: {
+				setNumber: 1,
+				durationSeconds: 60,
+				unit: "lb",
+			},
+			createdAt: 1,
+		});
+		return { routineId, entryId };
+	});
+
+	return {
+		userId,
+		canonicalId,
+		referencedDuplicateId,
+		unreferencedDuplicateId,
+		routineId,
+		entryId,
+	};
+}
+
+describe("exercise deduplication migration", () => {
+	test("audits duplicate references with per-exercise counts", async () => {
+		const t = createTest();
+		const seeded = await seedReferencedDuplicates(t);
+
+		const result = await t.query(audit, {});
+
+		assert.deepEqual(result, {
+			exerciseCount: 3,
+			duplicateGroupCount: 1,
+			removableExerciseCount: 2,
+			routineReferenceCount: 1,
+			entryReferenceCount: 1,
+			groups: [
+				{
+					ownerId: seeded.userId,
+					canonical: {
+						id: seeded.canonicalId,
+						name: "Plank",
+						isSystemExercise: true,
+					},
+					duplicates: [
+						{
+							id: seeded.referencedDuplicateId,
+							name: "Plank",
+							routineReferenceCount: 1,
+							entryReferenceCount: 1,
+						},
+						{
+							id: seeded.unreferencedDuplicateId,
+							name: " plank ",
+							routineReferenceCount: 0,
+							entryReferenceCount: 0,
+						},
+					],
+				},
+			],
+		});
+	});
+
+	test("rejects apply when either audited count changed", async () => {
+		const t = createTest();
+		await seedReferencedDuplicates(t);
+
+		await assert.rejects(
+			t.mutation(apply, {
+				confirmation: "deduplicate-exercises",
+				expectedExerciseCount: 4,
+				expectedRemovableExerciseCount: 2,
+			}),
+			/Exercise count changed: expected 4, found 3/
+		);
+		await assert.rejects(
+			t.mutation(apply, {
+				confirmation: "deduplicate-exercises",
+				expectedExerciseCount: 3,
+				expectedRemovableExerciseCount: 1,
+			}),
+			/Duplicate count changed: expected 1, found 2/
+		);
+	});
+
+	test("refuses to delete an exercise marked as system-owned", async () => {
+		const t = createTest();
+		const userId = await insertUser(t);
+		await insertExercise(t, {
+			name: "Plank",
+			createdAt: 1,
+			isSystemExercise: true,
+		});
+		await insertExercise(t, {
+			name: "Plank",
+			createdAt: 2,
+			isSystemExercise: true,
+			userId,
+		});
+		await insertExercise(t, {
+			name: "Plank",
+			createdAt: 3,
+			isSystemExercise: false,
+			userId,
+		});
+
+		await assert.rejects(
+			t.mutation(apply, {
+				confirmation: "deduplicate-exercises",
+				expectedExerciseCount: 3,
+				expectedRemovableExerciseCount: 2,
+			}),
+			/Refusing to delete non-custom exercise/
+		);
+		assert.equal(
+			await t.run(async (ctx) =>
+				(await ctx.db.query("exercises").collect()).length
+			),
+			3
+		);
+	});
+
+	test("remaps routine and entry references before deleting duplicates", async () => {
+		const t = createTest();
+		const seeded = await seedReferencedDuplicates(t);
+
+		const result = await t.mutation(apply, {
+			confirmation: "deduplicate-exercises",
+			expectedExerciseCount: 3,
+			expectedRemovableExerciseCount: 2,
+		});
+
+		assert.deepEqual(result, {
+			exerciseCount: 3,
+			duplicateGroupCount: 1,
+			removableExerciseCount: 2,
+			routineReferenceCount: 1,
+			entryReferenceCount: 1,
+			updatedRoutineCount: 1,
+			updatedEntryCount: 1,
+			deletedExerciseCount: 2,
+		});
+		await t.run(async (ctx) => {
+			const exercises = await ctx.db.query("exercises").collect();
+			assert.deepEqual(
+				exercises.map((exercise) => exercise._id),
+				[seeded.canonicalId]
+			);
+			assert.equal(
+				(await ctx.db.get(seeded.routineId))?.days[0].exercises[0]
+					.exerciseId,
+				seeded.canonicalId
+			);
+			assert.equal(
+				(await ctx.db.get(seeded.entryId))?.exerciseId,
+				seeded.canonicalId
+			);
+		});
+	});
+});

--- a/convex/migrations/exerciseDeduplication.ts
+++ b/convex/migrations/exerciseDeduplication.ts
@@ -1,0 +1,187 @@
+import { v } from "convex/values";
+import type { Doc, Id } from "../_generated/dataModel";
+import {
+	internalMutation,
+	internalQuery,
+	type MutationCtx,
+	type QueryCtx,
+} from "../_generated/server";
+import { getExerciseCleanupPlan } from "../../src/lib/exercise-deduplication";
+
+type ExerciseCleanupGroup = ReturnType<
+	typeof getExerciseCleanupPlan<Doc<"exercises">>
+>[number];
+
+async function loadCleanupState(ctx: QueryCtx | MutationCtx) {
+	const [exercises, routines, entries] = await Promise.all([
+		ctx.db.query("exercises").collect(),
+		ctx.db.query("routines").collect(),
+		ctx.db.query("entries").collect(),
+	]);
+	const groups = getExerciseCleanupPlan(exercises);
+	const duplicateToCanonical = new Map<string, Id<"exercises">>();
+
+	for (const group of groups) {
+		for (const duplicate of group.duplicates) {
+			duplicateToCanonical.set(duplicate._id, group.canonical._id);
+		}
+	}
+
+	let routineReferenceCount = 0;
+	for (const routine of routines) {
+		for (const day of routine.days) {
+			for (const exercise of day.exercises) {
+				if (
+					exercise.exerciseId &&
+					duplicateToCanonical.has(exercise.exerciseId)
+				) {
+					routineReferenceCount += 1;
+				}
+			}
+		}
+	}
+
+	let entryReferenceCount = 0;
+	for (const entry of entries) {
+		if (entry.exerciseId && duplicateToCanonical.has(entry.exerciseId)) {
+			entryReferenceCount += 1;
+		}
+	}
+
+	return {
+		exercises,
+		routines,
+		entries,
+		groups,
+		duplicateToCanonical,
+		summary: {
+			exerciseCount: exercises.length,
+			duplicateGroupCount: groups.length,
+			removableExerciseCount: groups.reduce(
+				(total, group) => total + group.duplicates.length,
+				0
+			),
+			routineReferenceCount,
+			entryReferenceCount,
+		},
+	};
+}
+
+function serializeGroup(
+	group: ExerciseCleanupGroup,
+	routines: Doc<"routines">[],
+	entries: Doc<"entries">[]
+) {
+	return {
+		ownerId: group.ownerId,
+		canonical: {
+			id: group.canonical._id,
+			name: group.canonical.name,
+			isSystemExercise: group.canonical.isSystemExercise ?? false,
+		},
+		duplicates: group.duplicates.map((duplicate) => ({
+			id: duplicate._id,
+			name: duplicate.name,
+			routineReferenceCount: routines.reduce(
+				(count, routine) =>
+					count +
+					routine.days.reduce(
+						(dayCount, day) =>
+							dayCount +
+							day.exercises.filter(
+								(exercise) => exercise.exerciseId === duplicate._id
+							).length,
+						0
+					),
+				0
+			),
+			entryReferenceCount: entries.filter(
+				(entry) => entry.exerciseId === duplicate._id
+			).length,
+		})),
+	};
+}
+
+export const audit = internalQuery({
+	args: {},
+	handler: async (ctx) => {
+		const state = await loadCleanupState(ctx);
+		return {
+			...state.summary,
+			groups: state.groups.map((group) =>
+				serializeGroup(group, state.routines, state.entries)
+			),
+		};
+	},
+});
+
+export const apply = internalMutation({
+	args: {
+		confirmation: v.literal("deduplicate-exercises"),
+		expectedExerciseCount: v.number(),
+		expectedRemovableExerciseCount: v.number(),
+	},
+	handler: async (ctx, args) => {
+		const state = await loadCleanupState(ctx);
+		if (state.summary.exerciseCount !== args.expectedExerciseCount) {
+			throw new Error(
+				`Exercise count changed: expected ${args.expectedExerciseCount}, found ${state.summary.exerciseCount}`
+			);
+		}
+		if (
+			state.summary.removableExerciseCount !==
+			args.expectedRemovableExerciseCount
+		) {
+			throw new Error(
+				`Duplicate count changed: expected ${args.expectedRemovableExerciseCount}, found ${state.summary.removableExerciseCount}`
+			);
+		}
+
+		let updatedRoutineCount = 0;
+		for (const routine of state.routines) {
+			let changed = false;
+			const days = routine.days.map((day) => ({
+				...day,
+				exercises: day.exercises.map((exercise) => {
+					const canonicalId = exercise.exerciseId
+						? state.duplicateToCanonical.get(exercise.exerciseId)
+						: undefined;
+					if (!canonicalId) return exercise;
+					changed = true;
+					return { ...exercise, exerciseId: canonicalId };
+				}),
+			}));
+
+			if (changed) {
+				await ctx.db.patch(routine._id, { days });
+				updatedRoutineCount += 1;
+			}
+		}
+
+		let updatedEntryCount = 0;
+		for (const entry of state.entries) {
+			const canonicalId = entry.exerciseId
+				? state.duplicateToCanonical.get(entry.exerciseId)
+				: undefined;
+			if (!canonicalId) continue;
+			await ctx.db.patch(entry._id, { exerciseId: canonicalId });
+			updatedEntryCount += 1;
+		}
+
+		for (const group of state.groups) {
+			for (const duplicate of group.duplicates) {
+				if (duplicate.isSystemExercise || !duplicate.userId) {
+					throw new Error(`Refusing to delete non-custom exercise ${duplicate._id}`);
+				}
+				await ctx.db.delete(duplicate._id);
+			}
+		}
+
+		return {
+			...state.summary,
+			updatedRoutineCount,
+			updatedEntryCount,
+			deletedExerciseCount: state.summary.removableExerciseCount,
+		};
+	},
+});

--- a/convex/migrations/exerciseDeduplication.ts
+++ b/convex/migrations/exerciseDeduplication.ts
@@ -27,23 +27,32 @@ async function loadCleanupState(ctx: QueryCtx | MutationCtx) {
 		}
 	}
 
+	const routineReferenceCounts = new Map<Id<"exercises">, number>();
 	let routineReferenceCount = 0;
 	for (const routine of routines) {
 		for (const day of routine.days) {
 			for (const exercise of day.exercises) {
-				if (
-					exercise.exerciseId &&
-					duplicateToCanonical.has(exercise.exerciseId)
-				) {
+				if (!exercise.exerciseId) continue;
+				routineReferenceCounts.set(
+					exercise.exerciseId,
+					(routineReferenceCounts.get(exercise.exerciseId) ?? 0) + 1
+				);
+				if (duplicateToCanonical.has(exercise.exerciseId)) {
 					routineReferenceCount += 1;
 				}
 			}
 		}
 	}
 
+	const entryReferenceCounts = new Map<Id<"exercises">, number>();
 	let entryReferenceCount = 0;
 	for (const entry of entries) {
-		if (entry.exerciseId && duplicateToCanonical.has(entry.exerciseId)) {
+		if (!entry.exerciseId) continue;
+		entryReferenceCounts.set(
+			entry.exerciseId,
+			(entryReferenceCounts.get(entry.exerciseId) ?? 0) + 1
+		);
+		if (duplicateToCanonical.has(entry.exerciseId)) {
 			entryReferenceCount += 1;
 		}
 	}
@@ -54,6 +63,8 @@ async function loadCleanupState(ctx: QueryCtx | MutationCtx) {
 		entries,
 		groups,
 		duplicateToCanonical,
+		routineReferenceCounts,
+		entryReferenceCounts,
 		summary: {
 			exerciseCount: exercises.length,
 			duplicateGroupCount: groups.length,
@@ -69,8 +80,8 @@ async function loadCleanupState(ctx: QueryCtx | MutationCtx) {
 
 function serializeGroup(
 	group: ExerciseCleanupGroup,
-	routines: Doc<"routines">[],
-	entries: Doc<"entries">[]
+	routineReferenceCounts: Map<Id<"exercises">, number>,
+	entryReferenceCounts: Map<Id<"exercises">, number>
 ) {
 	return {
 		ownerId: group.ownerId,
@@ -82,22 +93,9 @@ function serializeGroup(
 		duplicates: group.duplicates.map((duplicate) => ({
 			id: duplicate._id,
 			name: duplicate.name,
-			routineReferenceCount: routines.reduce(
-				(count, routine) =>
-					count +
-					routine.days.reduce(
-						(dayCount, day) =>
-							dayCount +
-							day.exercises.filter(
-								(exercise) => exercise.exerciseId === duplicate._id
-							).length,
-						0
-					),
-				0
-			),
-			entryReferenceCount: entries.filter(
-				(entry) => entry.exerciseId === duplicate._id
-			).length,
+			routineReferenceCount:
+				routineReferenceCounts.get(duplicate._id) ?? 0,
+			entryReferenceCount: entryReferenceCounts.get(duplicate._id) ?? 0,
 		})),
 	};
 }
@@ -109,7 +107,11 @@ export const audit = internalQuery({
 		return {
 			...state.summary,
 			groups: state.groups.map((group) =>
-				serializeGroup(group, state.routines, state.entries)
+				serializeGroup(
+					group,
+					state.routineReferenceCounts,
+					state.entryReferenceCounts
+				)
 			),
 		};
 	},

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
     "@types/node": "^20",
     "@types/react": "^19",
     "@types/react-dom": "^19",
+    "convex-test": "0.0.41",
     "eslint": "^9",
     "eslint-config-next": "16.1.1",
     "tailwindcss": "^4",

--- a/src/lib/exercise-deduplication.test.ts
+++ b/src/lib/exercise-deduplication.test.ts
@@ -1,0 +1,129 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import {
+	deduplicateVisibleExercises,
+	getExerciseCleanupPlan,
+} from "./exercise-deduplication";
+
+type Exercise = {
+	id: string;
+	name: string;
+	aliases?: string[];
+	userId?: string;
+	isSystemExercise?: boolean;
+	createdAt: number;
+};
+
+describe("exercise deduplication", () => {
+	test("prefers a system exercise over owned name and alias duplicates", () => {
+		const systemExercise: Exercise = {
+			id: "system-bench",
+			name: "Bench Press",
+			aliases: ["Barbell Bench Press"],
+			isSystemExercise: true,
+			createdAt: 1,
+		};
+		const exercises: Exercise[] = [
+			{
+				id: "custom-alias",
+				name: "Barbell Bench Press",
+				userId: "user-1",
+				createdAt: 3,
+			},
+			systemExercise,
+			{
+				id: "custom-name",
+				name: " bench   press ",
+				userId: "user-1",
+				createdAt: 2,
+			},
+		];
+
+		assert.deepEqual(deduplicateVisibleExercises(exercises), [systemExercise]);
+	});
+
+	test("keeps the oldest owned exercise when no system exercise matches", () => {
+		const oldest: Exercise = {
+			id: "side-plank-1",
+			name: "Side Plank",
+			userId: "user-1",
+			createdAt: 1,
+		};
+		const newest: Exercise = {
+			id: "side-plank-2",
+			name: "side plank",
+			userId: "user-1",
+			createdAt: 2,
+		};
+
+		assert.deepEqual(deduplicateVisibleExercises([newest, oldest]), [oldest]);
+	});
+
+	test("builds owner-scoped cleanup mappings without merging custom exercises across users", () => {
+		const systemPlank: Exercise = {
+			id: "system-plank",
+			name: "Plank",
+			isSystemExercise: true,
+			createdAt: 1,
+		};
+		const ownerOneSidePlank: Exercise = {
+			id: "owner-1-side-plank-1",
+			name: "Side Plank",
+			userId: "user-1",
+			createdAt: 2,
+		};
+		const plan = getExerciseCleanupPlan([
+			systemPlank,
+			{
+				id: "owner-1-plank",
+				name: "Plank",
+				userId: "user-1",
+				createdAt: 2,
+			},
+			{
+				id: "owner-2-plank",
+				name: "Plank",
+				userId: "user-2",
+				createdAt: 2,
+			},
+			ownerOneSidePlank,
+			{
+				id: "owner-1-side-plank-2",
+				name: "Side Plank",
+				userId: "user-1",
+				createdAt: 3,
+			},
+			{
+				id: "owner-2-side-plank",
+				name: "Side Plank",
+				userId: "user-2",
+				createdAt: 2,
+			},
+		]);
+
+		assert.deepEqual(
+			plan.map(({ ownerId, canonical, duplicates }) => ({
+				ownerId,
+				canonicalId: canonical.id,
+				duplicateIds: duplicates.map(({ id }) => id),
+			})),
+			[
+				{
+					ownerId: "user-1",
+					canonicalId: "system-plank",
+					duplicateIds: ["owner-1-plank"],
+				},
+				{
+					ownerId: "user-1",
+					canonicalId: "owner-1-side-plank-1",
+					duplicateIds: ["owner-1-side-plank-2"],
+				},
+				{
+					ownerId: "user-2",
+					canonicalId: "system-plank",
+					duplicateIds: ["owner-2-plank"],
+				},
+			]
+		);
+	});
+});

--- a/src/lib/exercise-deduplication.test.ts
+++ b/src/lib/exercise-deduplication.test.ts
@@ -59,6 +59,52 @@ describe("exercise deduplication", () => {
 		assert.deepEqual(deduplicateVisibleExercises([newest, oldest]), [oldest]);
 	});
 
+	test("treats an unset system flag as false when choosing the oldest custom exercise", () => {
+		const oldest: Exercise = {
+			id: "plank-1",
+			name: "Plank",
+			userId: "user-1",
+			isSystemExercise: false,
+			createdAt: 1,
+		};
+		const newest: Exercise = {
+			id: "plank-2",
+			name: "Plank",
+			userId: "user-1",
+			createdAt: 2,
+		};
+
+		assert.deepEqual(deduplicateVisibleExercises([newest, oldest]), [oldest]);
+	});
+
+	test("joins chained aliases through an existing duplicate", () => {
+		const canonical: Exercise = {
+			id: "bench-press",
+			name: "Bench Press",
+			userId: "user-1",
+			createdAt: 1,
+		};
+		const bridge: Exercise = {
+			id: "flat-bench",
+			name: "Flat Bench",
+			aliases: ["Bench Press"],
+			userId: "user-1",
+			createdAt: 2,
+		};
+		const chainedAlias: Exercise = {
+			id: "chest-press",
+			name: "Chest Press",
+			aliases: ["Flat Bench"],
+			userId: "user-1",
+			createdAt: 3,
+		};
+
+		assert.deepEqual(
+			deduplicateVisibleExercises([chainedAlias, bridge, canonical]),
+			[canonical]
+		);
+	});
+
 	test("builds owner-scoped cleanup mappings without merging custom exercises across users", () => {
 		const systemPlank: Exercise = {
 			id: "system-plank",

--- a/src/lib/exercise-deduplication.ts
+++ b/src/lib/exercise-deduplication.ts
@@ -1,0 +1,99 @@
+import { normalizeExerciseName } from "./exercise-names";
+
+export type DeduplicableExercise = {
+	name: string;
+	aliases?: string[];
+	userId?: string;
+	isSystemExercise?: boolean;
+	createdAt: number;
+};
+
+export type ExerciseDeduplicationGroup<T extends DeduplicableExercise> = {
+	canonical: T;
+	duplicates: T[];
+};
+
+function hasExerciseName(
+	exercise: DeduplicableExercise,
+	normalizedName: string
+) {
+	return (
+		normalizeExerciseName(exercise.name) === normalizedName ||
+		exercise.aliases?.some(
+			(alias) => normalizeExerciseName(alias) === normalizedName
+		) === true
+	);
+}
+
+function exerciseNamesOverlap(
+	left: DeduplicableExercise,
+	right: DeduplicableExercise
+) {
+	return (
+		hasExerciseName(left, normalizeExerciseName(right.name)) ||
+		hasExerciseName(right, normalizeExerciseName(left.name))
+	);
+}
+
+export function getExerciseDeduplicationGroups<
+	T extends DeduplicableExercise,
+>(exercises: readonly T[]): Array<ExerciseDeduplicationGroup<T>> {
+	const preferredExercises = [...exercises].sort((left, right) => {
+		if (left.isSystemExercise !== right.isSystemExercise) {
+			return left.isSystemExercise ? -1 : 1;
+		}
+		return left.createdAt - right.createdAt;
+	});
+	const groups: Array<ExerciseDeduplicationGroup<T>> = [];
+
+	for (const exercise of preferredExercises) {
+		const existingGroup = groups.find(({ canonical }) =>
+			exerciseNamesOverlap(canonical, exercise)
+		);
+		if (existingGroup) {
+			existingGroup.duplicates.push(exercise);
+		} else {
+			groups.push({ canonical: exercise, duplicates: [] });
+		}
+	}
+
+	return groups;
+}
+
+export function deduplicateVisibleExercises<T extends DeduplicableExercise>(
+	exercises: readonly T[]
+): T[] {
+	return getExerciseDeduplicationGroups(exercises).map(
+		({ canonical }) => canonical
+	);
+}
+
+export function getExerciseCleanupPlan<T extends DeduplicableExercise>(
+	exercises: readonly T[]
+) {
+	const systemExercises = exercises.filter(
+		(exercise) => exercise.isSystemExercise
+	);
+	const exercisesByOwner = new Map<string, T[]>();
+
+	for (const exercise of exercises) {
+		if (exercise.isSystemExercise || !exercise.userId) continue;
+		const ownerExercises = exercisesByOwner.get(exercise.userId) ?? [];
+		ownerExercises.push(exercise);
+		exercisesByOwner.set(exercise.userId, ownerExercises);
+	}
+
+	return Array.from(exercisesByOwner, ([ownerId, ownerExercises]) =>
+		getExerciseDeduplicationGroups([
+			...systemExercises,
+			...ownerExercises,
+		]).flatMap(({ canonical, duplicates }) => {
+			const ownedDuplicates = duplicates.filter(
+				(exercise) => exercise.userId === ownerId
+			);
+			return ownedDuplicates.length > 0
+				? [{ ownerId, canonical, duplicates: ownedDuplicates }]
+				: [];
+		})
+	).flat();
+}

--- a/src/lib/exercise-deduplication.ts
+++ b/src/lib/exercise-deduplication.ts
@@ -39,7 +39,7 @@ export function getExerciseDeduplicationGroups<
 	T extends DeduplicableExercise,
 >(exercises: readonly T[]): Array<ExerciseDeduplicationGroup<T>> {
 	const preferredExercises = [...exercises].sort((left, right) => {
-		if (left.isSystemExercise !== right.isSystemExercise) {
+		if (Boolean(left.isSystemExercise) !== Boolean(right.isSystemExercise)) {
 			return left.isSystemExercise ? -1 : 1;
 		}
 		return left.createdAt - right.createdAt;
@@ -47,8 +47,12 @@ export function getExerciseDeduplicationGroups<
 	const groups: Array<ExerciseDeduplicationGroup<T>> = [];
 
 	for (const exercise of preferredExercises) {
-		const existingGroup = groups.find(({ canonical }) =>
-			exerciseNamesOverlap(canonical, exercise)
+		const existingGroup = groups.find(
+			({ canonical, duplicates }) =>
+				exerciseNamesOverlap(canonical, exercise) ||
+				duplicates.some((duplicate) =>
+					exerciseNamesOverlap(duplicate, exercise)
+				)
 		);
 		if (existingGroup) {
 			existingGroup.duplicates.push(exercise);


### PR DESCRIPTION
## What does this PR do?

Production currently contains repeated custom exercise records, including 23 custom Plank/Side Plank records across two owners. A read-only snapshot found 289 exercises total, 60 owner-scoped duplicate groups, and 121 removable custom records.

This PR:
- extracts visible-exercise canonicalization into a shared helper with chained-alias and legacy system-flag coverage
- adds an internal audit query for physical duplicate cleanup
- precomputes per-exercise routine and entry reference counts in one traversal
- adds a confirmation- and count-guarded atomic mutation that remaps references before deleting only custom duplicates
- adds focused `convex-test` coverage for audit output, count mismatch rejection, system-row refusal, reference remapping, and deletion

Current snapshot impact: 19 routine exercise references require remapping; no workout-entry references require remapping. Production data has not been mutated.

Compatibility note: exercise names stored on routines and entries remain unchanged. Only their optional exercise IDs are remapped. `convex-test` is pinned to 0.0.41 because it supports the existing Convex 1.31 dependency without a runtime upgrade.

## Related issue

N/A

## How to test

1. Run `bun test` (48 pass, 0 fail).
2. Run `bunx tsc --noEmit` (passes).
3. Run `bun run lint` (passes with 7 pre-existing warnings).
4. Run `bun run build` (passes).
5. Run `git diff --check` (passes).
6. After deployment, run `bunx convex run migrations/exerciseDeduplication:audit --prod` and review every proposed mapping.
7. If production still reports 289 exercises and 121 removals, run `bunx convex run migrations/exerciseDeduplication:apply --prod {"confirmation":"deduplicate-exercises","expectedExerciseCount":289,"expectedRemovableExerciseCount":121}`.
8. Re-run the audit and confirm zero removable exercises.

## Checklist

- [x] I have tested this locally
- [x] `bun run lint` passes
- [x] Documentation updates are not needed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved exercise deduplication by matching names and aliases.
  * System exercises are preferred; otherwise the oldest custom exercise is retained.
  * Added a cleanup process that identifies duplicates, reports impacts, and updates references in routines and entries before removing duplicates.
* **Tests**
  * Added unit tests covering system-priority selection, oldest-exercise retention, and owner-scoped cleanup behavior.
  * Added migration tests validating audit/apply behavior and safe deletion rules.
* **Chores**
  * Added a development dependency for enhanced Convex test support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->