### PR TITLE
fix(exercises): expose guarded cleanup runner

### DIFF
--- a/convex/migrations/exerciseDeduplication.test.ts
+++ b/convex/migrations/exerciseDeduplication.test.ts
@@ -53,7 +53,10 @@ const apply = makeFunctionReference<"mutation", ApplyArgs, ApplyResult>(
 );
 
 function createTest() {
-	return convexTest(schema, modules);
+	return convexTest(schema, modules).withIdentity({
+		issuer: "https://opentrainer.app/migrations",
+		subject: "exercise-deduplication",
+	});
 }
 
 async function insertUser(t: ReturnType<typeof createTest>) {
@@ -157,6 +160,23 @@ async function seedReferencedDuplicates(t: ReturnType<typeof createTest>) {
 }
 
 describe("exercise deduplication migration", () => {
+	test("requires the dedicated operator identity", async () => {
+		const t = convexTest(schema, modules);
+
+		await assert.rejects(
+			t.query(audit, {}),
+			/Exercise deduplication requires an operator identity/
+		);
+		await assert.rejects(
+			t.mutation(apply, {
+				confirmation: "deduplicate-exercises",
+				expectedExerciseCount: 0,
+				expectedRemovableExerciseCount: 0,
+			}),
+			/Exercise deduplication requires an operator identity/
+		);
+	});
+
 	test("audits duplicate references with per-exercise counts", async () => {
 		const t = createTest();
 		const seeded = await seedReferencedDuplicates(t);

--- a/convex/migrations/exerciseDeduplication.test.ts
+++ b/convex/migrations/exerciseDeduplication.test.ts
@@ -162,6 +162,10 @@ async function seedReferencedDuplicates(t: ReturnType<typeof createTest>) {
 describe("exercise deduplication migration", () => {
 	test("requires the dedicated operator identity", async () => {
 		const t = convexTest(schema, modules);
+		const nonOperator = t.withIdentity({
+			issuer: "https://clerk.opentrainer.app",
+			subject: "app-user",
+		});
 
 		await assert.rejects(
 			t.query(audit, {}),
@@ -169,6 +173,18 @@ describe("exercise deduplication migration", () => {
 		);
 		await assert.rejects(
 			t.mutation(apply, {
+				confirmation: "deduplicate-exercises",
+				expectedExerciseCount: 0,
+				expectedRemovableExerciseCount: 0,
+			}),
+			/Exercise deduplication requires an operator identity/
+		);
+		await assert.rejects(
+			nonOperator.query(audit, {}),
+			/Exercise deduplication requires an operator identity/
+		);
+		await assert.rejects(
+			nonOperator.mutation(apply, {
 				confirmation: "deduplicate-exercises",
 				expectedExerciseCount: 0,
 				expectedRemovableExerciseCount: 0,

--- a/convex/migrations/exerciseDeduplication.ts
+++ b/convex/migrations/exerciseDeduplication.ts
@@ -1,16 +1,29 @@
 import { v } from "convex/values";
 import type { Doc, Id } from "../_generated/dataModel";
 import {
-	internalMutation,
-	internalQuery,
+	mutation,
+	query,
 	type MutationCtx,
 	type QueryCtx,
 } from "../_generated/server";
 import { getExerciseCleanupPlan } from "../../src/lib/exercise-deduplication";
 
+const MIGRATION_OPERATOR_ISSUER = "https://opentrainer.app/migrations";
+const MIGRATION_OPERATOR_SUBJECT = "exercise-deduplication";
+
 type ExerciseCleanupGroup = ReturnType<
 	typeof getExerciseCleanupPlan<Doc<"exercises">>
 >[number];
+
+async function requireMigrationOperator(ctx: QueryCtx | MutationCtx) {
+	const identity = await ctx.auth.getUserIdentity();
+	if (
+		identity?.issuer !== MIGRATION_OPERATOR_ISSUER ||
+		identity.subject !== MIGRATION_OPERATOR_SUBJECT
+	) {
+		throw new Error("Exercise deduplication requires an operator identity");
+	}
+}
 
 async function loadCleanupState(ctx: QueryCtx | MutationCtx) {
 	const [exercises, routines, entries] = await Promise.all([
@@ -100,9 +113,10 @@ function serializeGroup(
 	};
 }
 
-export const audit = internalQuery({
+export const audit = query({
 	args: {},
 	handler: async (ctx) => {
+		await requireMigrationOperator(ctx);
 		const state = await loadCleanupState(ctx);
 		return {
 			...state.summary,
@@ -117,13 +131,14 @@ export const audit = internalQuery({
 	},
 });
 
-export const apply = internalMutation({
+export const apply = mutation({
 	args: {
 		confirmation: v.literal("deduplicate-exercises"),
 		expectedExerciseCount: v.number(),
 		expectedRemovableExerciseCount: v.number(),
 	},
 	handler: async (ctx, args) => {
+		await requireMigrationOperator(ctx);
 		const state = await loadCleanupState(ctx);
 		if (state.summary.exerciseCount !== args.expectedExerciseCount) {
 			throw new Error(


### PR DESCRIPTION
## What does this PR do?

Makes the one-time exercise deduplication audit and apply functions callable by `convex run`. They were previously internal functions, which the CLI cannot invoke.

Both entrypoints now require a dedicated operator identity injected by the authenticated Convex CLI. Ordinary application identities and unauthenticated requests are rejected before any data read or write. Existing confirmation, count-drift, and system-row deletion guards remain unchanged.

## Related issue

N/A

## How to test

1. Run `bun test` (49 pass, 0 fail).
2. Run `bunx tsc --noEmit` (passes).
3. Run `bun run lint` (passes with 7 pre-existing warnings).
4. Run `bun run build` (passes).
5. Run `git diff --check` (passes).
6. Confirm focused tests reject missing operator identity and retain all destructive-operation coverage.

## Checklist

- [x] I have tested this locally
- [x] `bun run lint` passes
- [x] Documentation updates are not needed

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/house-of-giants/codesmith/opentrainer/pr/53"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1787355539&installation_model_id=19704&pr_number=53&repository=house-of-giants%2Fopentrainer&return_to=https%3A%2F%2Fgithub.com%2Fhouse-of-giants%2Fopentrainer%2Fpull%2F53&signature=3981f1a783a21b859bb24293ef45af7c6256ed7f6e5cb0a1a8e10fbe309b29a8"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with Codesmith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>/codesmith</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security**
  - Restricted exercise deduplication audit and apply operations to authorized migration operators.
  - Unauthorized requests are now rejected before any migration work is performed.

- **Tests**
  - Added coverage confirming both operations reject requests without the required operator identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->