### PR TITLE
feat: edit historical workout dates

### DIFF
--- a/src/app/workout/[id]/page.tsx
+++ b/src/app/workout/[id]/page.tsx
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/dialog";
 import {
   ArrowLeft,
+  CalendarClock,
   Clock,
   Download,
   Dumbbell,
@@ -220,7 +221,7 @@ export default function WorkoutDetailsPage() {
         from_completed_at: workout.completedAt ?? editableCompletedAt,
         to_completed_at: completedAt,
       });
-      toast.success("Workout times updated");
+      toast.success("Workout date/time updated");
     } catch (error) {
       console.error(error);
       throw error;
@@ -295,7 +296,8 @@ export default function WorkoutDetailsPage() {
                   size="sm"
                   onClick={() => setShowTimeEditor(true)}
                 >
-                  Edit times
+                  <CalendarClock data-icon="inline-start" />
+                  Edit date/time
                 </Button>
               )}
             </div>

--- a/src/components/workout/workout-time-editor-dialog.tsx
+++ b/src/components/workout/workout-time-editor-dialog.tsx
@@ -12,6 +12,12 @@ import {
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
+import {
+  buildWorkoutTimeEditRange,
+  getLocalDateInputValue,
+  getLocalTimeInputValue,
+  validateWorkoutTimeEditRange,
+} from "@/lib/workout-time-edit";
 
 interface WorkoutTimeEditorDialogProps {
   open: boolean;
@@ -21,37 +27,6 @@ interface WorkoutTimeEditorDialogProps {
   mode: "finish" | "edit";
   onSubmit: (startedAt: number, completedAt: number) => Promise<void>;
   isSubmitting: boolean;
-}
-
-function toTimeValue(timestamp: number) {
-  return new Date(timestamp).toLocaleTimeString("en-GB", {
-    hour: "2-digit",
-    minute: "2-digit",
-    hour12: false,
-  });
-}
-
-function buildTimestampForWorkoutDate(baseTimestamp: number, timeValue: string) {
-  if (!timeValue) return null;
-
-  const [hoursString, minutesString] = timeValue.split(":");
-  const hours = Number(hoursString);
-  const minutes = Number(minutesString);
-
-  if (
-    Number.isNaN(hours) ||
-    Number.isNaN(minutes) ||
-    hours < 0 ||
-    hours > 23 ||
-    minutes < 0 ||
-    minutes > 59
-  ) {
-    return null;
-  }
-
-  const date = new Date(baseTimestamp);
-  date.setHours(hours, minutes, 0, 0);
-  return date.getTime();
 }
 
 function formatDuration(startedAt: number, completedAt: number) {
@@ -74,40 +49,6 @@ function formatWorkoutDate(timestamp: number) {
   });
 }
 
-type ValidationState = {
-  message: string | null;
-  startInvalid?: boolean;
-  endInvalid?: boolean;
-};
-
-function validateValues(
-  startedAt: number | null,
-  completedAt: number | null
-): ValidationState {
-  if (startedAt === null) {
-    return { message: "Choose a start time", startInvalid: true };
-  }
-
-  if (completedAt === null) {
-    return { message: "Choose an end time", endInvalid: true };
-  }
-
-  if (startedAt >= completedAt) {
-    return { message: "End time must be after start time", endInvalid: true };
-  }
-
-  const now = Date.now();
-  if (startedAt > now || completedAt > now) {
-    return {
-      message: "Times can't be in the future",
-      startInvalid: startedAt > now,
-      endInvalid: completedAt > now,
-    };
-  }
-
-  return { message: null };
-}
-
 export function WorkoutTimeEditorDialog({
   open,
   onOpenChange,
@@ -117,23 +58,30 @@ export function WorkoutTimeEditorDialog({
   onSubmit,
   isSubmitting,
 }: WorkoutTimeEditorDialogProps) {
+  const [openedAt] = useState(() => Date.now());
+  const [workoutDateValue, setWorkoutDateValue] = useState(() =>
+    getLocalDateInputValue(initialStartedAt)
+  );
   const [startedAtValue, setStartedAtValue] = useState(() =>
-    toTimeValue(initialStartedAt)
+    getLocalTimeInputValue(initialStartedAt)
   );
   const [completedAtValue, setCompletedAtValue] = useState(() =>
-    toTimeValue(initialCompletedAt)
+    getLocalTimeInputValue(initialCompletedAt)
   );
   const [submitError, setSubmitError] = useState<string | null>(null);
   const workoutDateLabel = formatWorkoutDate(initialStartedAt);
-  const parsedStartedAt = buildTimestampForWorkoutDate(
+  const selectedWorkoutDateValue =
+    mode === "edit" ? workoutDateValue : getLocalDateInputValue(initialStartedAt);
+  const parsedRange = buildWorkoutTimeEditRange({
     initialStartedAt,
-    startedAtValue
-  );
-  const parsedCompletedAt = buildTimestampForWorkoutDate(
     initialCompletedAt,
-    completedAtValue
-  );
-  const validationState = validateValues(parsedStartedAt, parsedCompletedAt);
+    dateValue: selectedWorkoutDateValue,
+    startedAtTimeValue: startedAtValue,
+    completedAtTimeValue: completedAtValue,
+  });
+  const validationState = validateWorkoutTimeEditRange(parsedRange, openedAt);
+  const { startedAt: parsedStartedAt, completedAt: parsedCompletedAt } =
+    parsedRange;
 
   const durationPreview =
     parsedStartedAt !== null &&
@@ -142,21 +90,28 @@ export function WorkoutTimeEditorDialog({
       ? formatDuration(parsedStartedAt, parsedCompletedAt)
       : null;
 
-  const title = mode === "finish" ? "Edit workout time" : "Edit workout times";
+  const title =
+    mode === "finish" ? "Edit workout time" : "Edit workout date/time";
   const description =
     mode === "finish"
       ? "Fix the start and end time before finishing this workout."
-      : "Correct the workout start and end time.";
+      : "Correct the workout date, start time, and end time.";
   const submitLabel = mode === "finish" ? "Finish Workout" : "Save";
+  const todayDateValue = getLocalDateInputValue(openedAt);
 
   const handleSubmit = async () => {
-    if (validationState.message) {
-      setSubmitError(validationState.message);
+    const submissionValidationState = validateWorkoutTimeEditRange(
+      parsedRange,
+      Date.now()
+    );
+
+    if (submissionValidationState.message) {
+      setSubmitError(submissionValidationState.message);
       return;
     }
 
     if (parsedStartedAt === null || parsedCompletedAt === null) {
-      setSubmitError("Choose a valid start and end time");
+      setSubmitError("Choose a valid workout date and times");
       return;
     }
 
@@ -167,12 +122,13 @@ export function WorkoutTimeEditorDialog({
       onOpenChange(false);
     } catch (error) {
       setSubmitError(
-        error instanceof Error ? error.message : "Failed to update workout times"
+        error instanceof Error ? error.message : "Failed to update workout"
       );
     }
   };
 
   const errorMessage = submitError ?? validationState.message;
+  const dateInputInvalid = validationState.dateInvalid ? true : undefined;
   const startInputInvalid = validationState.startInvalid ? true : undefined;
   const endInputInvalid = validationState.endInvalid ? true : undefined;
 
@@ -185,12 +141,32 @@ export function WorkoutTimeEditorDialog({
         </DialogHeader>
 
         <div className="space-y-4">
-          <div className="rounded-md border bg-muted/30 px-3 py-2 text-sm">
-            <div className="flex items-center justify-between gap-2">
-              <span className="text-muted-foreground">Date</span>
-              <span className="font-medium font-mono">{workoutDateLabel}</span>
+          {mode === "edit" ? (
+            <div className="space-y-2">
+              <Label htmlFor="workout-date">Date</Label>
+              <Input
+                id="workout-date"
+                type="date"
+                value={workoutDateValue}
+                max={todayDateValue}
+                onChange={(event) => {
+                  setWorkoutDateValue(event.target.value);
+                  setSubmitError(null);
+                }}
+                aria-invalid={dateInputInvalid}
+                disabled={isSubmitting}
+              />
             </div>
-          </div>
+          ) : (
+            <div className="rounded-md border bg-muted/30 px-3 py-2 text-sm">
+              <div className="flex items-center justify-between gap-2">
+                <span className="text-muted-foreground">Date</span>
+                <span className="font-medium font-mono">
+                  {workoutDateLabel}
+                </span>
+              </div>
+            </div>
+          )}
 
           <div className="space-y-2">
             <Label htmlFor="workout-start-time">Start</Label>

--- a/src/lib/workout-time-edit.test.ts
+++ b/src/lib/workout-time-edit.test.ts
@@ -1,0 +1,158 @@
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import { describe, test } from "node:test";
+import { fileURLToPath } from "node:url";
+import {
+  buildWorkoutTimeEditRange,
+  getLocalDateInputValue,
+  validateWorkoutTimeEditRange,
+} from "./workout-time-edit";
+
+const repoRoot = fileURLToPath(new URL("../..", import.meta.url));
+
+describe("workout time editing date math", () => {
+  test("moves same-day workouts to the selected local calendar date", () => {
+    const range = buildWorkoutTimeEditRange({
+      initialStartedAt: new Date(2026, 0, 12, 9, 15).getTime(),
+      initialCompletedAt: new Date(2026, 0, 12, 10, 45).getTime(),
+      dateValue: "2026-02-03",
+      startedAtTimeValue: "07:30",
+      completedAtTimeValue: "08:45",
+    });
+
+    assert.equal(range.startedAt, new Date(2026, 1, 3, 7, 30).getTime());
+    assert.equal(range.completedAt, new Date(2026, 1, 3, 8, 45).getTime());
+    assert.equal(getLocalDateInputValue(range.startedAt!), "2026-02-03");
+    assert.deepEqual(
+      validateWorkoutTimeEditRange(
+        range,
+        new Date(2026, 1, 3, 9, 0).getTime()
+      ),
+      { message: null }
+    );
+  });
+
+  test("preserves the existing end-day offset for overnight workouts", () => {
+    const range = buildWorkoutTimeEditRange({
+      initialStartedAt: new Date(2026, 0, 12, 23, 30).getTime(),
+      initialCompletedAt: new Date(2026, 0, 13, 1, 15).getTime(),
+      dateValue: "2026-02-03",
+      startedAtTimeValue: "22:45",
+      completedAtTimeValue: "00:30",
+    });
+
+    assert.equal(range.startedAt, new Date(2026, 1, 3, 22, 45).getTime());
+    assert.equal(range.completedAt, new Date(2026, 1, 4, 0, 30).getTime());
+    assert.deepEqual(
+      validateWorkoutTimeEditRange(
+        range,
+        new Date(2026, 1, 4, 1, 0).getTime()
+      ),
+      { message: null }
+    );
+  });
+
+  test("rejects nonexistent spring-forward local times instead of normalizing them", () => {
+    const child = spawnSync(
+      process.execPath,
+      [
+        "--eval",
+        `
+          import assert from "node:assert/strict";
+          import {
+            buildWorkoutTimeEditRange,
+            validateWorkoutTimeEditRange,
+          } from "./src/lib/workout-time-edit.ts";
+
+          assert.equal(new Date(2026, 2, 8, 2, 30).getHours(), 3);
+
+          const range = buildWorkoutTimeEditRange({
+            initialStartedAt: new Date(2026, 0, 12, 9, 15).getTime(),
+            initialCompletedAt: new Date(2026, 0, 12, 10, 45).getTime(),
+            dateValue: "2026-03-08",
+            startedAtTimeValue: "02:30",
+            completedAtTimeValue: "03:45",
+          });
+
+          assert.equal(range.startedAt, null);
+          assert.equal(range.completedAt, new Date(2026, 2, 8, 3, 45).getTime());
+          assert.deepEqual(validateWorkoutTimeEditRange(range), {
+            message: "Choose a start time",
+            startInvalid: true,
+          });
+        `,
+      ],
+      {
+        cwd: repoRoot,
+        encoding: "utf8",
+        env: { NODE_ENV: "test", TZ: "America/Los_Angeles" },
+      }
+    );
+
+    assert.ifError(child.error);
+    assert.equal(child.status, 0, child.stderr || child.stdout);
+  });
+
+  test("rejects invalid local dates before parsing them as timestamps", () => {
+    const range = buildWorkoutTimeEditRange({
+      initialStartedAt: new Date(2026, 0, 12, 9, 15).getTime(),
+      initialCompletedAt: new Date(2026, 0, 12, 10, 45).getTime(),
+      dateValue: "2026-02-31",
+      startedAtTimeValue: "07:30",
+      completedAtTimeValue: "08:45",
+    });
+
+    assert.equal(range.startedAt, null);
+    assert.equal(range.completedAt, null);
+    assert.deepEqual(validateWorkoutTimeEditRange(range), {
+      message: "Choose a workout date",
+      dateInvalid: true,
+    });
+  });
+
+  test("rejects end-before-start for same-day workouts", () => {
+    const range = buildWorkoutTimeEditRange({
+      initialStartedAt: new Date(2026, 0, 12, 9, 15).getTime(),
+      initialCompletedAt: new Date(2026, 0, 12, 10, 45).getTime(),
+      dateValue: "2026-02-03",
+      startedAtTimeValue: "10:00",
+      completedAtTimeValue: "09:59",
+    });
+
+    assert.deepEqual(
+      validateWorkoutTimeEditRange(
+        range,
+        new Date(2026, 1, 3, 12, 0).getTime()
+      ),
+      { message: "End time must be after start time", endInvalid: true }
+    );
+  });
+
+  test("allows timestamps at now and rejects future boundaries", () => {
+    const validRange = buildWorkoutTimeEditRange({
+      initialStartedAt: new Date(2026, 0, 12, 9, 15).getTime(),
+      initialCompletedAt: new Date(2026, 0, 12, 10, 45).getTime(),
+      dateValue: "2026-02-03",
+      startedAtTimeValue: "08:00",
+      completedAtTimeValue: "09:00",
+    });
+    const now = new Date(2026, 1, 3, 9, 0).getTime();
+
+    assert.deepEqual(validateWorkoutTimeEditRange(validRange, now), {
+      message: null,
+    });
+
+    const futureRange = buildWorkoutTimeEditRange({
+      initialStartedAt: new Date(2026, 0, 12, 9, 15).getTime(),
+      initialCompletedAt: new Date(2026, 0, 12, 10, 45).getTime(),
+      dateValue: "2026-02-03",
+      startedAtTimeValue: "08:00",
+      completedAtTimeValue: "09:01",
+    });
+
+    assert.deepEqual(validateWorkoutTimeEditRange(futureRange, now), {
+      message: "Workout timestamps can't be in the future",
+      endInvalid: true,
+    });
+  });
+});

--- a/src/lib/workout-time-edit.ts
+++ b/src/lib/workout-time-edit.ts
@@ -1,0 +1,255 @@
+const MS_PER_DAY = 24 * 60 * 60 * 1000;
+
+type LocalDateParts = {
+  year: number;
+  monthIndex: number;
+  day: number;
+};
+
+type LocalTimeParts = {
+  hours: number;
+  minutes: number;
+};
+
+export type WorkoutTimeEditRange = {
+  startedAt: number | null;
+  completedAt: number | null;
+  dateInvalid: boolean;
+  startTimeInvalid: boolean;
+  endTimeInvalid: boolean;
+};
+
+export type WorkoutTimeEditValidationState = {
+  message: string | null;
+  dateInvalid?: boolean;
+  startInvalid?: boolean;
+  endInvalid?: boolean;
+};
+
+function padDatePart(value: number) {
+  return String(value).padStart(2, "0");
+}
+
+function parseLocalDateInput(value: string): LocalDateParts | null {
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value);
+  if (!match) return null;
+
+  const year = Number(match[1]);
+  const month = Number(match[2]);
+  const day = Number(match[3]);
+
+  if (
+    !Number.isInteger(year) ||
+    !Number.isInteger(month) ||
+    !Number.isInteger(day) ||
+    month < 1 ||
+    month > 12 ||
+    day < 1 ||
+    day > 31
+  ) {
+    return null;
+  }
+
+  const monthIndex = month - 1;
+  const date = new Date(year, monthIndex, day);
+  if (
+    date.getFullYear() !== year ||
+    date.getMonth() !== monthIndex ||
+    date.getDate() !== day
+  ) {
+    return null;
+  }
+
+  return { year, monthIndex, day };
+}
+
+function parseLocalTimeInput(value: string): LocalTimeParts | null {
+  const match = /^(\d{1,2}):(\d{2})$/.exec(value);
+  if (!match) return null;
+
+  const hours = Number(match[1]);
+  const minutes = Number(match[2]);
+
+  if (
+    !Number.isInteger(hours) ||
+    !Number.isInteger(minutes) ||
+    hours < 0 ||
+    hours > 23 ||
+    minutes < 0 ||
+    minutes > 59
+  ) {
+    return null;
+  }
+
+  return { hours, minutes };
+}
+
+function getLocalCalendarDayIndex(timestamp: number) {
+  const date = new Date(timestamp);
+  return Math.floor(
+    Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()) / MS_PER_DAY
+  );
+}
+
+function addLocalCalendarDays(
+  dateParts: LocalDateParts,
+  dayOffset: number
+): LocalDateParts | null {
+  const timestamp = Date.UTC(
+    dateParts.year,
+    dateParts.monthIndex,
+    dateParts.day + dayOffset
+  );
+
+  if (Number.isNaN(timestamp)) return null;
+
+  const date = new Date(timestamp);
+  return {
+    year: date.getUTCFullYear(),
+    monthIndex: date.getUTCMonth(),
+    day: date.getUTCDate(),
+  };
+}
+
+export function getLocalDateInputValue(timestamp: number) {
+  const date = new Date(timestamp);
+  return [
+    date.getFullYear(),
+    padDatePart(date.getMonth() + 1),
+    padDatePart(date.getDate()),
+  ].join("-");
+}
+
+export function getLocalTimeInputValue(timestamp: number) {
+  const date = new Date(timestamp);
+  return [padDatePart(date.getHours()), padDatePart(date.getMinutes())].join(
+    ":"
+  );
+}
+
+export function getLocalCalendarDayOffset(
+  startedAt: number,
+  completedAt: number
+) {
+  return (
+    getLocalCalendarDayIndex(completedAt) -
+    getLocalCalendarDayIndex(startedAt)
+  );
+}
+
+export function buildLocalDateTimeTimestamp({
+  dateValue,
+  timeValue,
+  dayOffset = 0,
+}: {
+  dateValue: string;
+  timeValue: string;
+  dayOffset?: number;
+}) {
+  const dateParts = parseLocalDateInput(dateValue);
+  const timeParts = parseLocalTimeInput(timeValue);
+
+  if (!dateParts || !timeParts) return null;
+
+  const expectedDateParts = addLocalCalendarDays(dateParts, dayOffset);
+  if (!expectedDateParts) return null;
+
+  const date = new Date(
+    dateParts.year,
+    dateParts.monthIndex,
+    dateParts.day + dayOffset,
+    timeParts.hours,
+    timeParts.minutes,
+    0,
+    0
+  );
+  const timestamp = date.getTime();
+
+  if (Number.isNaN(timestamp)) return null;
+
+  if (
+    date.getFullYear() !== expectedDateParts.year ||
+    date.getMonth() !== expectedDateParts.monthIndex ||
+    date.getDate() !== expectedDateParts.day ||
+    date.getHours() !== timeParts.hours ||
+    date.getMinutes() !== timeParts.minutes
+  ) {
+    return null;
+  }
+
+  return timestamp;
+}
+
+export function buildWorkoutTimeEditRange({
+  initialStartedAt,
+  initialCompletedAt,
+  dateValue,
+  startedAtTimeValue,
+  completedAtTimeValue,
+}: {
+  initialStartedAt: number;
+  initialCompletedAt: number;
+  dateValue: string;
+  startedAtTimeValue: string;
+  completedAtTimeValue: string;
+}): WorkoutTimeEditRange {
+  const dateInvalid = parseLocalDateInput(dateValue) === null;
+  const startTimeInvalid = parseLocalTimeInput(startedAtTimeValue) === null;
+  const endTimeInvalid = parseLocalTimeInput(completedAtTimeValue) === null;
+  const completedDayOffset = getLocalCalendarDayOffset(
+    initialStartedAt,
+    initialCompletedAt
+  );
+
+  return {
+    startedAt:
+      dateInvalid || startTimeInvalid
+        ? null
+        : buildLocalDateTimeTimestamp({
+            dateValue,
+            timeValue: startedAtTimeValue,
+          }),
+    completedAt:
+      dateInvalid || endTimeInvalid
+        ? null
+        : buildLocalDateTimeTimestamp({
+            dateValue,
+            timeValue: completedAtTimeValue,
+            dayOffset: completedDayOffset,
+          }),
+    dateInvalid,
+    startTimeInvalid,
+    endTimeInvalid,
+  };
+}
+
+export function validateWorkoutTimeEditRange(
+  range: WorkoutTimeEditRange,
+  now = Date.now()
+): WorkoutTimeEditValidationState {
+  if (range.dateInvalid) {
+    return { message: "Choose a workout date", dateInvalid: true };
+  }
+
+  if (range.startedAt === null || range.startTimeInvalid) {
+    return { message: "Choose a start time", startInvalid: true };
+  }
+
+  if (range.completedAt === null || range.endTimeInvalid) {
+    return { message: "Choose an end time", endInvalid: true };
+  }
+
+  if (range.startedAt >= range.completedAt) {
+    return { message: "End time must be after start time", endInvalid: true };
+  }
+
+  if (range.startedAt > now || range.completedAt > now) {
+    return {
+      message: "Workout timestamps can't be in the future",
+      ...(range.startedAt > now ? { startInvalid: true } : {}),
+      ...(range.completedAt > now ? { endInvalid: true } : {}),
+    };
+  }
+
+  return { message: null };
+}


### PR DESCRIPTION
## Summary

- Addresses the production feedback request to edit the calendar day of a historical completed workout, not only its times.
- Extends the existing workout time editor with local-calendar date handling while keeping active workout completion date-fixed.
- Preserves overnight day offsets and rejects invalid, future, end-before-start, DST-gap, and skipped-calendar-day values.
- Keeps the existing authenticated Convex update path and introduces no schema or dependency changes.

## Verification

- `TZ=America/Los_Angeles bun test src/lib/workout-time-edit.test.ts` — 6 passed
- `bun test` — 55 passed
- `bun run lint` — 0 errors; 7 pre-existing warnings in generated/demo files
- `bunx tsc --noEmit`
- `bun run build`
- `git diff --check`
- Strict specification review: passed
- Independent code-quality review: approved

## Manual QA

Authenticated browser QA was not completed in this environment. Residual check: edit a completed workout from `/history`, including an overnight workout, and confirm the displayed date and times persist after reload.

## Deferred

Internationalization remains deferred and is not included in this PR.

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/house-of-giants/codesmith/opentrainer/pr/54"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789054506&installation_model_id=19704&pr_number=54&repository=house-of-giants%2Fopentrainer&return_to=https%3A%2F%2Fgithub.com%2Fhouse-of-giants%2Fopentrainer%2Fpull%2F54&signature=a35049f37c9cbf78089f5739aaab5ee15c2b185c5ef11f5a0fc30497b86269f4"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Workout time editing now includes the workout date, with date-aware controls and labels.
  - Dates are limited to today or earlier, while overnight workouts remain supported.
  - Improved validation prevents invalid dates, reversed time ranges, and future workout times.

- **Bug Fixes**
  - Added clearer feedback for date and time validation errors.
  - Improved handling of daylight-saving-time and calendar edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->