### PR TITLE
feat: make logged workouts fully editable from the detail page

### DIFF
--- a/convex/_generated/api.d.ts
+++ b/convex/_generated/api.d.ts
@@ -27,11 +27,16 @@ import type * as feedback from "../feedback.js";
 import type * as http from "../http.js";
 import type * as lib_equipment from "../lib/equipment.js";
 import type * as lib_logger from "../lib/logger.js";
+import type * as lib_muscleAnalytics from "../lib/muscleAnalytics.js";
 import type * as lib_rateLimit from "../lib/rateLimit.js";
+import type * as lib_routineMeasurements from "../lib/routineMeasurements.js";
+import type * as lib_week from "../lib/week.js";
+import type * as migrations_exerciseDeduplication from "../migrations/exerciseDeduplication.js";
 import type * as routines from "../routines.js";
 import type * as seed from "../seed.js";
 import type * as users from "../users.js";
 import type * as webhooks from "../webhooks.js";
+import type * as workoutSummary from "../workoutSummary.js";
 import type * as workouts from "../workouts.js";
 
 import type {
@@ -60,11 +65,16 @@ declare const fullApi: ApiFromModules<{
   http: typeof http;
   "lib/equipment": typeof lib_equipment;
   "lib/logger": typeof lib_logger;
+  "lib/muscleAnalytics": typeof lib_muscleAnalytics;
   "lib/rateLimit": typeof lib_rateLimit;
+  "lib/routineMeasurements": typeof lib_routineMeasurements;
+  "lib/week": typeof lib_week;
+  "migrations/exerciseDeduplication": typeof migrations_exerciseDeduplication;
   routines: typeof routines;
   seed: typeof seed;
   users: typeof users;
   webhooks: typeof webhooks;
+  workoutSummary: typeof workoutSummary;
   workouts: typeof workouts;
 }>;
 

--- a/convex/entries.ts
+++ b/convex/entries.ts
@@ -3,6 +3,7 @@ import { mutation, query, internalQuery } from "./_generated/server";
 import { getCurrentUser } from "./auth";
 import type { Id } from "./_generated/dataModel";
 import { createConvexLogger, truncateId } from "./lib/logger";
+import { recomputeWorkoutSummary } from "./workoutSummary";
 
 const liftingDataValidator = v.object({
   setNumber: v.number(),
@@ -255,6 +256,43 @@ export const updateLiftingEntry = mutation({
       notes: args.notes ?? entry.notes,
     });
 
+    await recomputeWorkoutSummary(ctx, entry.workoutId);
+
+    return args.entryId;
+  },
+});
+
+export const updateCardioEntry = mutation({
+  args: {
+    entryId: v.id("entries"),
+    cardio: cardioDataValidator,
+    notes: v.optional(v.string()),
+  },
+  handler: async (ctx, args) => {
+    const user = await getCurrentUser(ctx);
+    if (!user) throw new Error("User not found");
+
+    const entry = await ctx.db.get(args.entryId);
+    if (!entry || entry.userId !== user._id) {
+      throw new Error("Entry not found or not authorized");
+    }
+
+    if (entry.kind !== "cardio") {
+      throw new Error("Entry is not a cardio entry");
+    }
+
+    const { durationSeconds } = args.cardio;
+    if (!Number.isFinite(durationSeconds) || durationSeconds <= 0) {
+      throw new Error("Duration must be greater than zero");
+    }
+
+    await ctx.db.patch(args.entryId, {
+      cardio: args.cardio,
+      notes: args.notes ?? entry.notes,
+    });
+
+    await recomputeWorkoutSummary(ctx, entry.workoutId);
+
     return args.entryId;
   },
 });
@@ -332,6 +370,8 @@ export const updateMobilityEntry = mutation({
       notes: args.notes ?? entry.notes,
     });
 
+    await recomputeWorkoutSummary(ctx, entry.workoutId);
+
     return args.entryId;
   },
 });
@@ -358,6 +398,8 @@ export const deleteEntry = mutation({
     }
 
     await ctx.db.delete(args.entryId);
+
+    await recomputeWorkoutSummary(ctx, entry.workoutId);
 
     logger.success({
       entry: { id: truncateId(args.entryId), kind: entry.kind, exercise: entry.exerciseName },

--- a/convex/workoutSummary.ts
+++ b/convex/workoutSummary.ts
@@ -1,0 +1,86 @@
+import type { Doc, Id } from "./_generated/dataModel";
+import type { MutationCtx } from "./_generated/server";
+
+type WorkoutSummary = NonNullable<Doc<"workouts">["summary"]>;
+
+export async function getWorkoutEntries(
+  ctx: MutationCtx,
+  workoutId: Id<"workouts">
+): Promise<Doc<"entries">[]> {
+  return ctx.db
+    .query("entries")
+    .withIndex("by_workout_created", (q) => q.eq("workoutId", workoutId))
+    .collect();
+}
+
+export function buildWorkoutSummary(
+  entries: Doc<"entries">[],
+  startedAt: number,
+  completedAt: number
+): WorkoutSummary {
+  let totalVolume = 0;
+  let totalSets = 0;
+  let totalCardioDurationSeconds = 0;
+  let totalDistanceKm = 0;
+  let hasCardio = false;
+  let hasMobility = false;
+  const exerciseNames = new Set<string>();
+
+  for (const entry of entries) {
+    exerciseNames.add(entry.exerciseName);
+
+    if (entry.kind === "lifting" && entry.lifting) {
+      totalSets++;
+      if (entry.lifting.weight && entry.lifting.reps) {
+        totalVolume += entry.lifting.weight * entry.lifting.reps;
+      }
+      continue;
+    }
+
+    if (entry.kind === "cardio" && entry.cardio) {
+      hasCardio = true;
+      totalCardioDurationSeconds += entry.cardio.durationSeconds;
+      if (entry.cardio.distance && entry.cardio.distanceUnit) {
+        const distanceKm =
+          entry.cardio.distanceUnit === "km"
+            ? entry.cardio.distance
+            : entry.cardio.distanceUnit === "mi"
+              ? entry.cardio.distance * 1.60934
+              : entry.cardio.distance / 1000;
+        totalDistanceKm += distanceKm;
+      }
+      continue;
+    }
+
+    if (entry.kind === "mobility") {
+      hasMobility = true;
+    }
+  }
+
+  const totalDurationMinutes = Math.round((completedAt - startedAt) / 60000);
+
+  return {
+    totalVolume,
+    totalSets,
+    totalDurationMinutes,
+    exerciseCount: exerciseNames.size,
+    totalCardioDurationSeconds: hasCardio ? totalCardioDurationSeconds : undefined,
+    totalDistanceKm: totalDistanceKm > 0 ? totalDistanceKm : undefined,
+    hasCardio: hasCardio || undefined,
+    hasMobility: hasMobility || undefined,
+  };
+}
+
+export async function recomputeWorkoutSummary(
+  ctx: MutationCtx,
+  workoutId: Id<"workouts">
+): Promise<void> {
+  const workout = await ctx.db.get(workoutId);
+  if (!workout || workout.status !== "completed" || workout.completedAt === undefined) {
+    return; // in_progress/cancelled workouts have no computed summary to keep fresh
+  }
+  const entries = await getWorkoutEntries(ctx, workoutId);
+  await ctx.db.patch(workoutId, {
+    summary: buildWorkoutSummary(entries, workout.startedAt, workout.completedAt),
+  });
+}

--- a/convex/workouts.ts
+++ b/convex/workouts.ts
@@ -1,80 +1,9 @@
 import { v } from "convex/values";
-import type { Doc, Id } from "./_generated/dataModel";
-import type { MutationCtx } from "./_generated/server";
 import { mutation, query } from "./_generated/server";
 import { getCurrentUser } from "./auth";
 import { createConvexLogger, truncateId } from "./lib/logger";
 import { getMondayWeekStartUtc, WEEK_IN_MS } from "./lib/week";
-
-type WorkoutSummary = NonNullable<Doc<"workouts">["summary"]>;
-
-async function getWorkoutEntries(
-  ctx: MutationCtx,
-  workoutId: Id<"workouts">
-): Promise<Doc<"entries">[]> {
-  return ctx.db
-    .query("entries")
-    .withIndex("by_workout_created", (q) => q.eq("workoutId", workoutId))
-    .collect();
-}
-
-function buildWorkoutSummary(
-  entries: Doc<"entries">[],
-  startedAt: number,
-  completedAt: number
-): WorkoutSummary {
-  let totalVolume = 0;
-  let totalSets = 0;
-  let totalCardioDurationSeconds = 0;
-  let totalDistanceKm = 0;
-  let hasCardio = false;
-  let hasMobility = false;
-  const exerciseNames = new Set<string>();
-
-  for (const entry of entries) {
-    exerciseNames.add(entry.exerciseName);
-
-    if (entry.kind === "lifting" && entry.lifting) {
-      totalSets++;
-      if (entry.lifting.weight && entry.lifting.reps) {
-        totalVolume += entry.lifting.weight * entry.lifting.reps;
-      }
-      continue;
-    }
-
-    if (entry.kind === "cardio" && entry.cardio) {
-      hasCardio = true;
-      totalCardioDurationSeconds += entry.cardio.durationSeconds;
-      if (entry.cardio.distance && entry.cardio.distanceUnit) {
-        const distanceKm =
-          entry.cardio.distanceUnit === "km"
-            ? entry.cardio.distance
-            : entry.cardio.distanceUnit === "mi"
-              ? entry.cardio.distance * 1.60934
-              : entry.cardio.distance / 1000;
-        totalDistanceKm += distanceKm;
-      }
-      continue;
-    }
-
-    if (entry.kind === "mobility") {
-      hasMobility = true;
-    }
-  }
-
-  const totalDurationMinutes = Math.round((completedAt - startedAt) / 60000);
-
-  return {
-    totalVolume,
-    totalSets,
-    totalDurationMinutes,
-    exerciseCount: exerciseNames.size,
-    totalCardioDurationSeconds: hasCardio ? totalCardioDurationSeconds : undefined,
-    totalDistanceKm: totalDistanceKm > 0 ? totalDistanceKm : undefined,
-    hasCardio: hasCardio || undefined,
-    hasMobility: hasMobility || undefined,
-  };
-}
+import { buildWorkoutSummary, getWorkoutEntries } from "./workoutSummary";
 
 function validateWorkoutTimeRange({
   startedAt,
@@ -649,6 +578,33 @@ export const updateWorkoutTitle = mutation({
 
     await ctx.db.patch(args.workoutId, {
       title: args.title,
+    });
+
+    return args.workoutId;
+  },
+});
+
+export const updateWorkoutNotes = mutation({
+  args: {
+    workoutId: v.id("workouts"),
+    notes: v.string(),
+  },
+  handler: async (ctx, args) => {
+    const user = await getCurrentUser(ctx);
+    if (!user) throw new Error("User not found");
+
+    const workout = await ctx.db.get(args.workoutId);
+    if (!workout) {
+      throw new Error("Workout not found");
+    }
+
+    if (workout.userId !== user._id) {
+      throw new Error("Not authorized");
+    }
+
+    const trimmed = args.notes.trim();
+    await ctx.db.patch(args.workoutId, {
+      notes: trimmed === "" ? undefined : trimmed,
     });
 
     return args.workoutId;

--- a/src/app/workout/[id]/page.tsx
+++ b/src/app/workout/[id]/page.tsx
@@ -495,6 +495,7 @@ export default function WorkoutDetailsPage() {
                   variant="ghost"
                   className="h-8 w-8 shrink-0"
                   onClick={commitTitle}
+                  aria-label="Save workout title"
                 >
                   <Check className="h-4 w-4" />
                 </Button>
@@ -570,7 +571,7 @@ export default function WorkoutDetailsPage() {
                   {workout.completedAt && ` - ${formatTime(workout.completedAt)}`}
                 </p>
               </div>
-              {workout.summary?.totalDurationMinutes && (
+              {!!workout.summary?.totalDurationMinutes && (
                 <div>
                   <p className="text-muted-foreground">Duration</p>
                   <p className="font-medium font-mono tabular-nums flex items-center gap-1">

--- a/src/app/workout/[id]/page.tsx
+++ b/src/app/workout/[id]/page.tsx
@@ -4,7 +4,7 @@ import { useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import { useMutation, useQuery } from "convex/react";
 import { api } from "../../../../convex/_generated/api";
-import { Id } from "../../../../convex/_generated/dataModel";
+import { Doc, Id } from "../../../../convex/_generated/dataModel";
 import { Card } from "@/components/ui/card";
 import { Skeleton } from "@/components/ui/skeleton";
 import { Button } from "@/components/ui/button";
@@ -20,10 +20,12 @@ import {
 import {
   ArrowLeft,
   CalendarClock,
+  Check,
   Clock,
   Download,
   Dumbbell,
   MessageSquare,
+  Pencil,
   Route,
   Timer,
   Trash2,
@@ -32,65 +34,62 @@ import {
 import Link from "next/link";
 import { ExportWorkoutDialog } from "@/components/workout/export-workout-dialog";
 import { WorkoutTimeEditorDialog } from "@/components/workout/workout-time-editor-dialog";
+import {
+  EditSetSheet,
+  type EditableSet,
+} from "@/components/workout/edit-set-sheet";
+import {
+  EditCardioSheet,
+  type EditableCardio,
+} from "@/components/workout/edit-cardio-sheet";
+import { NoteSheet } from "@/components/workout/note-sheet";
+import { WorkoutExerciseCard } from "@/components/workout/workout-exercise-card";
+import { useHaptic } from "@/hooks/use-haptic";
 import { toast } from "sonner";
 import posthog from "posthog-js";
 import {
   calculateVolumeInUnit,
   displayWeight,
+  editedWeightForStorage,
   type WeightUnit,
 } from "@/lib/units";
-
-type LiftingEntry = {
-  _id: string;
-  exerciseName: string;
-  kind: "lifting";
-  lifting: {
-    setNumber: number;
-    reps?: number;
-    weight?: number;
-    durationSeconds?: number;
-    unit: "kg" | "lb";
-    rpe?: number;
-    isWarmup?: boolean;
-  };
-  createdAt: number;
-};
-
-type CardioEntry = {
-  _id: string;
-  exerciseName: string;
-  kind: "cardio";
-  cardio: {
-    mode: "steady" | "intervals";
-    durationSeconds: number;
-    intensity?: number;
-    vestWeight?: number;
-    vestWeightUnit?: "kg" | "lb";
-  };
-  createdAt: number;
-};
-
-type Entry = LiftingEntry | CardioEntry;
+import {
+  buildRepLiftingUpdate,
+  buildTimedLiftingUpdate,
+} from "@/lib/workout-set-edit";
 
 type GroupedExercise = {
   name: string;
-  entries: Entry[];
+  entries: Doc<"entries">[];
 };
 
 export default function WorkoutDetailsPage() {
   const params = useParams();
   const router = useRouter();
+  const { vibrate } = useHaptic();
   const workoutId = params.id as Id<"workouts">;
   const [showExportDialog, setShowExportDialog] = useState(false);
   const [showTimeEditor, setShowTimeEditor] = useState(false);
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [isUpdatingTimes, setIsUpdatingTimes] = useState(false);
   const [isDeleting, setIsDeleting] = useState(false);
+  const [editingSet, setEditingSet] = useState<EditableSet | null>(null);
+  const [editingCardio, setEditingCardio] = useState<EditableCardio | null>(null);
+  const [noteExercise, setNoteExercise] = useState<string | null>(null);
+  const [showNotesSheet, setShowNotesSheet] = useState(false);
+  const [isEditingTitle, setIsEditingTitle] = useState(false);
+  const [titleDraft, setTitleDraft] = useState("");
 
   const workout = useQuery(api.workouts.getWorkoutWithEntries, { workoutId });
   const user = useQuery(api.users.getCurrentUser);
   const updateWorkoutTimes = useMutation(api.workouts.updateWorkoutTimes);
   const deleteWorkout = useMutation(api.workouts.deleteWorkout);
+  const updateWorkoutTitle = useMutation(api.workouts.updateWorkoutTitle);
+  const updateWorkoutNotes = useMutation(api.workouts.updateWorkoutNotes);
+  const updateExerciseNote = useMutation(api.workouts.updateExerciseNote);
+  const updateLiftingEntry = useMutation(api.entries.updateLiftingEntry);
+  const updateCardioEntry = useMutation(api.entries.updateCardioEntry);
+  const deleteEntry = useMutation(api.entries.deleteEntry);
   const isPro = user?.tier === "pro";
   const preferredUnit: WeightUnit = user?.preferredUnits ?? "lb";
 
@@ -117,12 +116,6 @@ export default function WorkoutDetailsPage() {
     return hours > 0 ? `${hours}h ${mins}m` : `${mins}m`;
   };
 
-  const formatCardioDuration = (seconds: number) => {
-    const mins = Math.floor(seconds / 60);
-    const secs = seconds % 60;
-    return secs > 0 ? `${mins}:${String(secs).padStart(2, "0")}` : `${mins}m`;
-  };
-
   const formatCardioSummaryDuration = (seconds: number) => {
     const hours = Math.floor(seconds / 3600);
     const mins = Math.floor((seconds % 3600) / 60);
@@ -139,8 +132,10 @@ export default function WorkoutDetailsPage() {
     return `${Math.round(km * 1000)} m`;
   };
 
-  const groupEntriesByExercise = (entries: Entry[]): GroupedExercise[] => {
-    const groups: Record<string, Entry[]> = {};
+  const groupEntriesByExercise = (
+    entries: Doc<"entries">[]
+  ): GroupedExercise[] => {
+    const groups: Record<string, Doc<"entries">[]> = {};
     const order: string[] = [];
 
     for (const entry of entries) {
@@ -161,17 +156,19 @@ export default function WorkoutDetailsPage() {
     return (
       <div className="flex min-h-screen flex-col">
         <header className="sticky top-0 z-40 border-b bg-background/95 backdrop-blur">
-          <div className="flex h-14 items-center gap-4 px-4">
+          <div className="mx-auto flex h-14 w-full max-w-lg items-center gap-4 px-4">
             <Skeleton className="h-8 w-8" />
             <Skeleton className="h-6 w-48" />
           </div>
         </header>
         <main className="flex-1 p-4">
-          <Skeleton className="mb-4 h-24 w-full" />
-          <div className="space-y-4">
-            {[...Array(3)].map((_, i) => (
-              <Skeleton key={i} className="h-32 w-full" />
-            ))}
+          <div className="mx-auto w-full max-w-lg">
+            <Skeleton className="mb-4 h-24 w-full" />
+            <div className="space-y-4">
+              {[...Array(3)].map((_, i) => (
+                <Skeleton key={i} className="h-32 w-full" />
+              ))}
+            </div>
           </div>
         </main>
       </div>
@@ -193,10 +190,14 @@ export default function WorkoutDetailsPage() {
     );
   }
 
-  const groupedExercises = groupEntriesByExercise(workout.entries as Entry[]);
+  const entries = workout.entries as Doc<"entries">[];
+  const groupedExercises = groupEntriesByExercise(entries);
+  const editable = workout.status !== "in_progress";
   const displayedVolume = calculateVolumeInUnit(
-    (workout.entries as Entry[]).flatMap((entry) =>
-      entry.kind === "lifting" && entry.lifting.durationSeconds === undefined
+    entries.flatMap((entry) =>
+      entry.kind === "lifting" &&
+      entry.lifting &&
+      entry.lifting.durationSeconds === undefined
         ? [entry.lifting]
         : []
     ),
@@ -249,19 +250,273 @@ export default function WorkoutDetailsPage() {
     }
   };
 
+  const startEditingTitle = () => {
+    setTitleDraft(workout.title ?? "Workout");
+    setIsEditingTitle(true);
+  };
+
+  const commitTitle = async () => {
+    setIsEditingTitle(false);
+    const trimmed = titleDraft.trim();
+    if (!trimmed || trimmed === (workout.title ?? "Workout")) return;
+    try {
+      await updateWorkoutTitle({ workoutId, title: trimmed });
+      posthog.capture("workout_title_edited", { workout_id: workoutId });
+      vibrate("success");
+      toast.success("Title updated");
+    } catch (error) {
+      toast.error("Failed to update title");
+      console.error(error);
+    }
+  };
+
+  const handleSaveWorkoutNotes = async (note: string) => {
+    try {
+      await updateWorkoutNotes({ workoutId, notes: note });
+      posthog.capture("workout_notes_edited", {
+        workout_id: workoutId,
+        cleared: note.trim() === "",
+      });
+      vibrate("success");
+      toast.success("Notes saved");
+    } catch (error) {
+      toast.error("Failed to save notes");
+      console.error(error);
+    }
+  };
+
+  const handleSaveExerciseNote = async (note: string) => {
+    if (!noteExercise) return;
+    try {
+      await updateExerciseNote({
+        workoutId,
+        exerciseName: noteExercise,
+        note,
+      });
+      posthog.capture("exercise_note_edited", {
+        workout_id: workoutId,
+        exercise_name: noteExercise,
+        cleared: note.trim() === "",
+      });
+      vibrate("success");
+      toast.success("Note saved");
+    } catch (error) {
+      toast.error("Failed to save note");
+      console.error(error);
+    }
+  };
+
+  const handleEditSet = (entry: Doc<"entries">) => {
+    if (!entry.lifting) return;
+    vibrate("light");
+    setEditingSet({
+      entryId: entry._id,
+      exerciseName: entry.exerciseName,
+      setNumber: entry.lifting.setNumber,
+      reps: entry.lifting.reps ?? 0,
+      weight: displayWeight(
+        entry.lifting.weight ?? 0,
+        entry.lifting.unit,
+        preferredUnit
+      ),
+      unit: preferredUnit,
+      storedWeight: entry.lifting.weight,
+      storedUnit: entry.lifting.unit,
+      isBodyweight: entry.lifting.isBodyweight,
+      isWarmup: entry.lifting.isWarmup,
+      rpe: entry.lifting.rpe ?? null,
+      durationSeconds: entry.lifting.durationSeconds,
+    });
+  };
+
+  const handleUpdateSet = async (
+    entryId: string,
+    data: {
+      reps?: number;
+      weight?: number;
+      durationSeconds?: number;
+      rpe?: number | null;
+      isWarmup?: boolean;
+    }
+  ) => {
+    if (!editingSet) return;
+    try {
+      await updateLiftingEntry({
+        entryId: entryId as Id<"entries">,
+        lifting:
+          data.durationSeconds !== undefined
+            ? buildTimedLiftingUpdate(editingSet, data)
+            : buildRepLiftingUpdate(editingSet, data),
+      });
+      posthog.capture("set_edited", {
+        workout_id: workoutId,
+        exercise_name: editingSet.exerciseName,
+        set_number: editingSet.setNumber,
+        reps: data.reps,
+        weight: data.weight,
+        unit: editingSet.unit,
+        duration_seconds: data.durationSeconds,
+        rpe: data.rpe,
+        is_warmup: data.isWarmup,
+      });
+      vibrate("success");
+      toast.success("Set updated");
+    } catch (error) {
+      toast.error("Failed to update set");
+      console.error(error);
+    }
+  };
+
+  const handleDeleteSet = async (entryId: string) => {
+    vibrate("warning");
+    try {
+      await deleteEntry({ entryId: entryId as Id<"entries"> });
+      posthog.capture("set_deleted", {
+        workout_id: workoutId,
+        exercise_name: editingSet?.exerciseName,
+        set_number: editingSet?.setNumber,
+      });
+      toast.success("Set deleted");
+    } catch (error) {
+      toast.error("Failed to delete set");
+      console.error(error);
+    }
+  };
+
+  const handleEditCardio = (entry: Doc<"entries">) => {
+    if (!entry.cardio) return;
+    vibrate("light");
+    setEditingCardio({
+      entryId: entry._id,
+      exerciseName: entry.exerciseName,
+      cardio: entry.cardio,
+      displayVestUnit: preferredUnit,
+    });
+  };
+
+  const handleUpdateCardio = async (
+    entryId: string,
+    data: { durationSeconds: number; intensity?: number; vestWeight?: number }
+  ) => {
+    if (!editingCardio) return;
+    const stored = editingCardio.cardio;
+    const storedVestUnit = stored.vestWeightUnit ?? "lb";
+    const vestWeight =
+      data.vestWeight === undefined || stored.vestWeight === undefined
+        ? stored.vestWeight
+        : editedWeightForStorage({
+            displayedWeight: data.vestWeight,
+            displayUnit: editingCardio.displayVestUnit,
+            storedUnit: storedVestUnit,
+            originalDisplayedWeight: displayWeight(
+              stored.vestWeight,
+              storedVestUnit,
+              editingCardio.displayVestUnit
+            ),
+            originalStoredWeight: stored.vestWeight,
+          });
+    const intensity = data.intensity ?? stored.intensity;
+    try {
+      await updateCardioEntry({
+        entryId: entryId as Id<"entries">,
+        cardio: {
+          ...stored,
+          durationSeconds: data.durationSeconds,
+          intensity,
+          vestWeight,
+        },
+      });
+      posthog.capture("cardio_edited", {
+        workout_id: workoutId,
+        exercise_name: editingCardio.exerciseName,
+        duration_seconds: data.durationSeconds,
+        intensity,
+        vest_weight: vestWeight,
+      });
+      vibrate("success");
+      toast.success("Cardio updated");
+    } catch (error) {
+      toast.error("Failed to update cardio");
+      console.error(error);
+    }
+  };
+
+  const handleDeleteCardio = async (entryId: string) => {
+    vibrate("warning");
+    try {
+      await deleteEntry({ entryId: entryId as Id<"entries"> });
+      posthog.capture("cardio_deleted", {
+        workout_id: workoutId,
+        exercise_name: editingCardio?.exerciseName,
+      });
+      toast.success("Cardio entry deleted");
+    } catch (error) {
+      toast.error("Failed to delete entry");
+      console.error(error);
+    }
+  };
+
+  const openWorkoutNotes = () => {
+    vibrate("light");
+    setShowNotesSheet(true);
+  };
+
+  const openExerciseNote = (exerciseName: string) => {
+    vibrate("light");
+    setNoteExercise(exerciseName);
+  };
+
   return (
     <div className="flex min-h-screen flex-col">
       <header className="sticky top-0 z-40 border-b bg-background/95 backdrop-blur">
-        <div className="flex h-14 items-center gap-4 px-4">
+        <div className="mx-auto flex h-14 w-full max-w-lg items-center gap-4 px-4">
           <Link href="/history">
             <Button variant="ghost" size="icon">
               <ArrowLeft className="h-5 w-5" />
             </Button>
           </Link>
-          <div className="flex-1">
-            <h1 className="font-semibold text-lg">
-              {workout.title ?? "Workout"}
-            </h1>
+          <div className="min-w-0 flex-1">
+            {isEditingTitle ? (
+              <div className="flex items-center gap-2">
+                <input
+                  type="text"
+                  value={titleDraft}
+                  onChange={(e) => setTitleDraft(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === "Enter") commitTitle();
+                    if (e.key === "Escape") setIsEditingTitle(false);
+                  }}
+                  className="h-8 min-w-0 flex-1 rounded border bg-background px-2 font-medium outline-none focus:ring-2 focus:ring-primary"
+                  placeholder="Workout title"
+                  autoFocus
+                />
+                <Button
+                  size="icon"
+                  variant="ghost"
+                  className="h-8 w-8 shrink-0"
+                  onClick={commitTitle}
+                >
+                  <Check className="h-4 w-4" />
+                </Button>
+              </div>
+            ) : (
+              <div className="flex min-w-0 items-center gap-2">
+                <h1 className="truncate font-semibold text-lg">
+                  {workout.title ?? "Workout"}
+                </h1>
+                {editable && (
+                  <Button
+                    size="icon"
+                    variant="ghost"
+                    className="h-8 w-8 shrink-0"
+                    onClick={startEditingTitle}
+                    aria-label="Edit workout title"
+                  >
+                    <Pencil className="h-4 w-4 text-muted-foreground" />
+                  </Button>
+                )}
+              </div>
+            )}
           </div>
           {isPro && (
             <Button
@@ -279,201 +534,141 @@ export default function WorkoutDetailsPage() {
       </header>
 
       <main className="flex-1 p-4">
-        <Card className="mb-6 p-4">
-          {workout.status !== "in_progress" && (
-            <div className="mb-4 flex justify-end gap-2">
-              <Button
-                variant="destructive"
-                size="sm"
-                onClick={() => setShowDeleteConfirm(true)}
-              >
-                <Trash2 data-icon="inline-start" />
-                Delete workout
-              </Button>
-              {workout.status === "completed" && (
+        <div className="mx-auto w-full max-w-lg">
+          <Card className="mb-6 p-4">
+            {editable && (
+              <div className="mb-4 flex justify-end gap-2">
                 <Button
-                  variant="outline"
+                  variant="destructive"
                   size="sm"
-                  onClick={() => setShowTimeEditor(true)}
+                  onClick={() => setShowDeleteConfirm(true)}
                 >
-                  <CalendarClock data-icon="inline-start" />
-                  Edit date/time
+                  <Trash2 data-icon="inline-start" />
+                  Delete workout
                 </Button>
-              )}
-            </div>
-          )}
-          <div className="grid grid-cols-2 gap-4 text-sm">
-            <div>
-              <p className="text-muted-foreground">Date</p>
-              <p className="font-medium font-mono">{formatDate(workout.startedAt)}</p>
-            </div>
-            <div>
-              <p className="text-muted-foreground">Time</p>
-              <p className="font-medium font-mono tabular-nums">
-                {formatTime(workout.startedAt)}
-                {workout.completedAt && ` - ${formatTime(workout.completedAt)}`}
-              </p>
-            </div>
-            {workout.summary?.totalDurationMinutes && (
-              <div>
-                <p className="text-muted-foreground">Duration</p>
-                <p className="font-medium font-mono tabular-nums flex items-center gap-1">
-                  <Clock className="h-4 w-4" />
-                  {formatDuration(workout.summary.totalDurationMinutes)}
-                </p>
+                {workout.status === "completed" && (
+                  <Button
+                    variant="outline"
+                    size="sm"
+                    onClick={() => setShowTimeEditor(true)}
+                  >
+                    <CalendarClock data-icon="inline-start" />
+                    Edit date/time
+                  </Button>
+                )}
               </div>
             )}
-            {(() => {
-              const volume = displayedVolume;
-              return volume && volume > 0 ? (
+            <div className="grid grid-cols-2 gap-4 text-sm">
+              <div>
+                <p className="text-muted-foreground">Date</p>
+                <p className="font-medium font-mono">{formatDate(workout.startedAt)}</p>
+              </div>
+              <div>
+                <p className="text-muted-foreground">Time</p>
+                <p className="font-medium font-mono tabular-nums">
+                  {formatTime(workout.startedAt)}
+                  {workout.completedAt && ` - ${formatTime(workout.completedAt)}`}
+                </p>
+              </div>
+              {workout.summary?.totalDurationMinutes && (
+                <div>
+                  <p className="text-muted-foreground">Duration</p>
+                  <p className="font-medium font-mono tabular-nums flex items-center gap-1">
+                    <Clock className="h-4 w-4" />
+                    {formatDuration(workout.summary.totalDurationMinutes)}
+                  </p>
+                </div>
+              )}
+              {displayedVolume > 0 && (
                 <div>
                   <p className="text-muted-foreground">Volume</p>
                   <p className="font-medium font-mono tabular-nums flex items-center gap-1">
                     <Weight className="h-4 w-4" />
-                    {Math.round(volume).toLocaleString()} {preferredUnit}
+                    {Math.round(displayedVolume).toLocaleString()} {preferredUnit}
                   </p>
                 </div>
-              ) : null;
-            })()}
-            {(() => {
-              const cardioDuration = workout.summary?.totalCardioDurationSeconds;
-              return cardioDuration && cardioDuration > 0 ? (
-                <div>
-                  <p className="text-muted-foreground">Cardio</p>
-                  <p className="font-medium font-mono tabular-nums flex items-center gap-1">
-                    <Timer className="h-4 w-4" />
-                    {formatCardioSummaryDuration(cardioDuration)}
-                  </p>
+              )}
+              {(() => {
+                const cardioDuration = workout.summary?.totalCardioDurationSeconds;
+                return cardioDuration && cardioDuration > 0 ? (
+                  <div>
+                    <p className="text-muted-foreground">Cardio</p>
+                    <p className="font-medium font-mono tabular-nums flex items-center gap-1">
+                      <Timer className="h-4 w-4" />
+                      {formatCardioSummaryDuration(cardioDuration)}
+                    </p>
+                  </div>
+                ) : null;
+              })()}
+              {(() => {
+                const distance = workout.summary?.totalDistanceKm;
+                return distance && distance > 0 ? (
+                  <div>
+                    <p className="text-muted-foreground">Distance</p>
+                    <p className="font-medium font-mono tabular-nums flex items-center gap-1">
+                      <Route className="h-4 w-4" />
+                      {formatDistance(distance)}
+                    </p>
+                  </div>
+                ) : null;
+              })()}
+            </div>
+            {workout.notes ? (
+              editable ? (
+                <button
+                  type="button"
+                  onClick={openWorkoutNotes}
+                  className="mt-4 w-full rounded-md border-t pt-4 text-left transition-colors hover:bg-muted/50 active:bg-muted"
+                >
+                  <p className="text-sm text-muted-foreground">Notes</p>
+                  <p className="text-sm">{workout.notes}</p>
+                </button>
+              ) : (
+                <div className="mt-4 border-t pt-4">
+                  <p className="text-sm text-muted-foreground">Notes</p>
+                  <p className="text-sm">{workout.notes}</p>
                 </div>
-              ) : null;
-            })()}
-            {(() => {
-              const distance = workout.summary?.totalDistanceKm;
-              return distance && distance > 0 ? (
-                <div>
-                  <p className="text-muted-foreground">Distance</p>
-                  <p className="font-medium font-mono tabular-nums flex items-center gap-1">
-                    <Route className="h-4 w-4" />
-                    {formatDistance(distance)}
-                  </p>
-                </div>
-              ) : null;
-            })()}
-          </div>
-          {workout.notes && (
-            <div className="mt-4 border-t pt-4">
-              <p className="text-sm text-muted-foreground">Notes</p>
-              <p className="text-sm">{workout.notes}</p>
+              )
+            ) : (
+              editable && (
+                <Button
+                  variant="ghost"
+                  size="sm"
+                  className="mt-2 self-start text-muted-foreground"
+                  onClick={openWorkoutNotes}
+                >
+                  <MessageSquare data-icon="inline-start" />
+                  Add notes
+                </Button>
+              )
+            )}
+          </Card>
+
+          {groupedExercises.length === 0 ? (
+            <Card className="p-6 text-center text-muted-foreground">
+              <p>No exercises logged in this workout.</p>
+            </Card>
+          ) : (
+            <div className="space-y-4">
+              {groupedExercises.map((exercise) => (
+                <WorkoutExerciseCard
+                  key={exercise.name}
+                  exercise={exercise}
+                  note={
+                    workout.exerciseNotes?.find(
+                      (n) => n.exerciseName === exercise.name
+                    )?.note
+                  }
+                  preferredUnit={preferredUnit}
+                  editable={editable}
+                  onEditSet={handleEditSet}
+                  onEditCardio={handleEditCardio}
+                  onEditNote={() => openExerciseNote(exercise.name)}
+                />
+              ))}
             </div>
           )}
-        </Card>
-
-        {groupedExercises.length === 0 ? (
-          <Card className="p-6 text-center text-muted-foreground">
-            <p>No exercises logged in this workout.</p>
-          </Card>
-        ) : (
-          <div className="space-y-4">
-            {groupedExercises.map((exercise) => {
-              const exerciseNote = workout.exerciseNotes?.find(
-                (n) => n.exerciseName === exercise.name
-              )?.note;
-
-              return (
-                <Card key={exercise.name} className="p-4">
-                  <h3 className="mb-3 font-semibold">{exercise.name}</h3>
-                  <div className="space-y-2">
-                    {exercise.entries.map((entry) => {
-                      if (entry.kind === "lifting" && entry.lifting) {
-                        return (
-                          <div
-                            key={entry._id}
-                            className="flex items-center justify-between rounded-md bg-muted/50 px-3 py-2 text-sm"
-                          >
-                            <span className="text-muted-foreground">
-                              Set {entry.lifting.setNumber}
-                              {entry.lifting.isWarmup && (
-                                <Badge variant="outline" className="ml-2 text-xs">
-                                  Warmup
-                                </Badge>
-                              )}
-                            </span>
-                            <div className="flex items-center gap-3">
-                              {entry.lifting.durationSeconds !== undefined ? (
-                                <span className="font-medium font-mono tabular-nums">
-                                  {formatCardioDuration(entry.lifting.durationSeconds)} hold
-                                </span>
-                              ) : (
-                                <>
-                                  <span className="font-medium font-mono tabular-nums">
-                                    {displayWeight(
-                                      entry.lifting.weight ?? 0,
-                                      entry.lifting.unit,
-                                      preferredUnit
-                                    )} {preferredUnit}
-                                  </span>
-                                  <span className="text-muted-foreground">x</span>
-                                  <span className="font-medium font-mono tabular-nums">
-                                    {entry.lifting.reps ?? 0} reps
-                                  </span>
-                                </>
-                              )}
-                              {entry.lifting.rpe && (
-                                <Badge variant="secondary" className="text-xs">
-                                  RPE {entry.lifting.rpe}
-                                </Badge>
-                              )}
-                            </div>
-                          </div>
-                        );
-                      }
-
-                      if (entry.kind === "cardio" && entry.cardio) {
-                        return (
-                          <div
-                            key={entry._id}
-                            className="flex items-center justify-between rounded-md bg-muted/50 px-3 py-2 text-sm"
-                          >
-                            <span className="text-muted-foreground capitalize">
-                              {entry.cardio.mode}
-                            </span>
-                            <div className="flex items-center gap-3">
-                              <span className="font-medium font-mono tabular-nums">
-                                {formatCardioDuration(entry.cardio.durationSeconds)}
-                              </span>
-                              {entry.cardio.intensity && (
-                                <Badge variant="secondary" className="text-xs">
-                                  Level {entry.cardio.intensity}
-                                </Badge>
-                              )}
-                              {entry.cardio.vestWeight !== undefined && (
-                                <span className="font-medium font-mono tabular-nums">
-                                  Vest {displayWeight(
-                                    entry.cardio.vestWeight,
-                                    entry.cardio.vestWeightUnit ?? "lb",
-                                    preferredUnit
-                                  )} {preferredUnit}
-                                </span>
-                              )}
-                            </div>
-                          </div>
-                        );
-                      }
-
-                      return null;
-                    })}
-                  </div>
-                  {exerciseNote && (
-                    <div className="mt-3 flex items-start gap-2 rounded-md bg-muted/30 px-3 py-2 text-sm">
-                      <MessageSquare className="h-4 w-4 mt-0.5 shrink-0 text-muted-foreground" />
-                      <span className="text-muted-foreground">{exerciseNote}</span>
-                    </div>
-                  )}
-                </Card>
-              );
-            })}
-          </div>
-        )}
+        </div>
       </main>
 
       <ExportWorkoutDialog
@@ -493,6 +688,46 @@ export default function WorkoutDetailsPage() {
           isSubmitting={isUpdatingTimes}
         />
       )}
+
+      <EditSetSheet
+        set={editingSet}
+        onOpenChange={(open) => {
+          if (!open) setEditingSet(null);
+        }}
+        onSave={handleUpdateSet}
+        onDelete={handleDeleteSet}
+      />
+
+      <EditCardioSheet
+        entry={editingCardio}
+        onOpenChange={(open) => {
+          if (!open) setEditingCardio(null);
+        }}
+        onSave={handleUpdateCardio}
+        onDelete={handleDeleteCardio}
+      />
+
+      <NoteSheet
+        open={noteExercise !== null}
+        onOpenChange={(open) => {
+          if (!open) setNoteExercise(null);
+        }}
+        exerciseName={noteExercise ?? ""}
+        note={
+          workout.exerciseNotes?.find((n) => n.exerciseName === noteExercise)
+            ?.note ?? ""
+        }
+        onSave={handleSaveExerciseNote}
+      />
+
+      <NoteSheet
+        open={showNotesSheet}
+        onOpenChange={setShowNotesSheet}
+        title="Workout notes"
+        exerciseName=""
+        note={workout.notes ?? ""}
+        onSave={handleSaveWorkoutNotes}
+      />
 
       <Dialog open={showDeleteConfirm} onOpenChange={setShowDeleteConfirm}>
         <DialogContent>

--- a/src/app/workout/active/page.tsx
+++ b/src/app/workout/active/page.tsx
@@ -47,6 +47,7 @@ import {
 import { getExerciseGroupKey } from "@/lib/workout-exercise-group";
 import {
 	buildRepLiftingUpdate,
+	buildTimedLiftingUpdate,
 	createEditableLiftingSet,
 } from "@/lib/workout-set-edit";
 import posthog from "posthog-js";
@@ -63,6 +64,7 @@ type EntryData = {
 		unit: "kg" | "lb";
 		isBodyweight?: boolean;
 		rpe?: number;
+		isWarmup?: boolean;
 	};
 	cardio?: {
 		durationSeconds: number;
@@ -792,12 +794,13 @@ export default function ActiveWorkoutPage() {
 			unit: "lb",
 			durationSeconds: set.durationSeconds,
 			rpe: set.rpe,
+			isWarmup: set.isWarmup,
 		});
 	};
 
 	const handleUpdateSet = async (
 		entryId: string,
-		data: { reps?: number; weight?: number; durationSeconds?: number; rpe?: number | null }
+		data: { reps?: number; weight?: number; durationSeconds?: number; rpe?: number | null; isWarmup?: boolean }
 	) => {
 		if (!editingSet) return;
 		try {
@@ -806,12 +809,7 @@ export default function ActiveWorkoutPage() {
 					entryId as unknown as import("../../../../convex/_generated/dataModel").Id<"entries">,
 				lifting:
 					data.durationSeconds !== undefined
-						? {
-								setNumber: editingSet.setNumber,
-								durationSeconds: data.durationSeconds,
-								unit: editingSet.unit,
-								rpe: data.rpe ?? undefined,
-							}
+						? buildTimedLiftingUpdate(editingSet, data)
 						: buildRepLiftingUpdate(editingSet, data),
 			});
 			vibrate("success");
@@ -1012,6 +1010,7 @@ export default function ActiveWorkoutPage() {
 									setNumber: entry.lifting!.setNumber,
 									durationSeconds: entry.lifting!.durationSeconds!,
 									rpe: entry.lifting!.rpe ?? null,
+									isWarmup: entry.lifting!.isWarmup,
 								}));
 
 							return (

--- a/src/components/workout/edit-cardio-sheet.tsx
+++ b/src/components/workout/edit-cardio-sheet.tsx
@@ -1,0 +1,165 @@
+"use client";
+
+import { useState } from "react";
+import { Button } from "@/components/ui/button";
+import {
+  Drawer,
+  DrawerContent,
+  DrawerDescription,
+  DrawerFooter,
+  DrawerHeader,
+  DrawerTitle,
+} from "@/components/ui/drawer";
+import { SetStepper } from "./set-stepper";
+import { Trash2 } from "lucide-react";
+import { Doc } from "../../../convex/_generated/dataModel";
+import { displayWeight } from "@/lib/units";
+
+export interface EditableCardio {
+  entryId: string;
+  exerciseName: string;
+  cardio: NonNullable<Doc<"entries">["cardio"]>;
+  displayVestUnit: "lb" | "kg";
+}
+
+interface EditCardioSheetProps {
+  entry: EditableCardio | null;
+  onOpenChange: (open: boolean) => void;
+  onSave: (
+    entryId: string,
+    data: { durationSeconds: number; intensity?: number; vestWeight?: number }
+  ) => void;
+  onDelete: (entryId: string) => void;
+}
+
+function EditCardioContent({
+  entry,
+  onOpenChange,
+  onSave,
+  onDelete,
+}: {
+  entry: EditableCardio;
+  onOpenChange: (open: boolean) => void;
+  onSave: (
+    entryId: string,
+    data: { durationSeconds: number; intensity?: number; vestWeight?: number }
+  ) => void;
+  onDelete: (entryId: string) => void;
+}) {
+  const hasIntensity = entry.cardio.intensity !== undefined;
+  const hasVest = entry.cardio.vestWeight !== undefined;
+
+  const initialMinutes = Math.max(
+    1,
+    Math.round(entry.cardio.durationSeconds / 60)
+  );
+  const [minutes, setMinutes] = useState(initialMinutes);
+  const [intensity, setIntensity] = useState(entry.cardio.intensity ?? 0);
+  const [vestWeight, setVestWeight] = useState(
+    displayWeight(
+      entry.cardio.vestWeight ?? 0,
+      entry.cardio.vestWeightUnit ?? "lb",
+      entry.displayVestUnit
+    )
+  );
+
+  const handleSave = () => {
+    onSave(entry.entryId, {
+      // Preserve second-precision durations when the minutes stepper is untouched.
+      durationSeconds:
+        minutes === initialMinutes ? entry.cardio.durationSeconds : minutes * 60,
+      intensity: hasIntensity ? intensity : undefined,
+      vestWeight: hasVest ? vestWeight : undefined,
+    });
+    onOpenChange(false);
+  };
+
+  const handleDelete = () => {
+    onDelete(entry.entryId);
+    onOpenChange(false);
+  };
+
+  return (
+    <DrawerContent className="flex flex-col">
+      <DrawerHeader>
+        <DrawerTitle>Edit Cardio</DrawerTitle>
+        <DrawerDescription>
+          {entry.exerciseName} — {minutes} min
+        </DrawerDescription>
+      </DrawerHeader>
+
+      <div className="flex-1 px-4 py-6">
+        <div className="flex flex-wrap items-end justify-center gap-6">
+          <SetStepper
+            label="Duration"
+            value={minutes}
+            onChange={setMinutes}
+            step={1}
+            min={1}
+            max={600}
+            unit="min"
+          />
+          {hasIntensity && (
+            <SetStepper
+              label="Intensity"
+              value={intensity}
+              onChange={setIntensity}
+              step={1}
+              min={1}
+              max={20}
+            />
+          )}
+          {hasVest && (
+            <SetStepper
+              label="Vest Weight"
+              value={vestWeight}
+              onChange={setVestWeight}
+              step={entry.displayVestUnit === "kg" ? 2.5 : 5}
+              min={0}
+              unit={entry.displayVestUnit}
+            />
+          )}
+        </div>
+
+        <Button
+          variant="ghost"
+          className="mt-8 w-full text-destructive hover:text-destructive hover:bg-destructive/10"
+          onClick={handleDelete}
+        >
+          <Trash2 className="mr-2 h-4 w-4" />
+          Delete Entry
+        </Button>
+      </div>
+
+      <DrawerFooter className="flex-row gap-2">
+        <Button variant="outline" className="flex-1" onClick={() => onOpenChange(false)}>
+          Cancel
+        </Button>
+        <Button className="flex-1" onClick={handleSave}>
+          Save
+        </Button>
+      </DrawerFooter>
+    </DrawerContent>
+  );
+}
+
+export function EditCardioSheet({
+  entry,
+  onOpenChange,
+  onSave,
+  onDelete,
+}: EditCardioSheetProps) {
+  return (
+    <Drawer open={!!entry} onOpenChange={onOpenChange}>
+      {entry && (
+        <EditCardioContent
+          key={entry.entryId}
+          entry={entry}
+          onOpenChange={onOpenChange}
+          onSave={onSave}
+          onDelete={onDelete}
+        />
+      )}
+    </Drawer>
+  );
+}

--- a/src/components/workout/edit-set-sheet.tsx
+++ b/src/components/workout/edit-set-sheet.tsx
@@ -12,6 +12,8 @@ import {
 } from "@/components/ui/drawer";
 import { SetStepper } from "./set-stepper";
 import { RpeSelector } from "./rpe-selector";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Label } from "@/components/ui/label";
 import { Trash2 } from "lucide-react";
 
 export interface EditableSet {
@@ -25,13 +27,14 @@ export interface EditableSet {
   storedWeight?: number;
   storedUnit?: "lb" | "kg";
   isBodyweight?: boolean;
+  isWarmup?: boolean;
   rpe?: number | null;
 }
 
 interface EditSetSheetProps {
   set: EditableSet | null;
   onOpenChange: (open: boolean) => void;
-  onSave: (entryId: string, data: { reps?: number; weight?: number; durationSeconds?: number; rpe?: number | null }) => void;
+  onSave: (entryId: string, data: { reps?: number; weight?: number; durationSeconds?: number; rpe?: number | null; isWarmup?: boolean }) => void;
   onDelete: (entryId: string) => void;
 }
 
@@ -43,20 +46,21 @@ function EditSetContent({
 }: {
   set: EditableSet;
   onOpenChange: (open: boolean) => void;
-  onSave: (entryId: string, data: { reps?: number; weight?: number; durationSeconds?: number; rpe?: number | null }) => void;
+  onSave: (entryId: string, data: { reps?: number; weight?: number; durationSeconds?: number; rpe?: number | null; isWarmup?: boolean }) => void;
   onDelete: (entryId: string) => void;
 }) {
   const [weight, setWeight] = useState(set.weight);
   const [reps, setReps] = useState(set.reps);
   const [durationSeconds, setDurationSeconds] = useState(set.durationSeconds ?? 30);
   const [rpe, setRpe] = useState<number | null>(set.rpe ?? null);
+  const [isWarmup, setIsWarmup] = useState(set.isWarmup ?? false);
 
   const handleSave = () => {
     onSave(
       set.entryId,
       set.durationSeconds !== undefined
-        ? { durationSeconds, rpe }
-        : { reps, weight, rpe }
+        ? { durationSeconds, rpe, isWarmup }
+        : { reps, weight, rpe, isWarmup }
     );
     onOpenChange(false);
   };
@@ -122,6 +126,17 @@ function EditSetContent({
           />
             </>
           )}
+        </div>
+
+        <div className="mt-6 flex items-center justify-center gap-2">
+          <Checkbox
+            id="edit-set-warmup"
+            checked={isWarmup}
+            onCheckedChange={(checked) => setIsWarmup(checked === true)}
+          />
+          <Label htmlFor="edit-set-warmup" className="text-muted-foreground">
+            Warmup set
+          </Label>
         </div>
 
         <div className="mt-6">

--- a/src/components/workout/note-sheet.tsx
+++ b/src/components/workout/note-sheet.tsx
@@ -16,6 +16,7 @@ interface NoteSheetProps {
   exerciseName: string;
   note: string;
   onSave: (note: string) => void;
+  title?: string;
 }
 
 function NoteSheetContent({
@@ -23,6 +24,7 @@ function NoteSheetContent({
   note,
   onOpenChange,
   onSave,
+  title,
 }: Omit<NoteSheetProps, "open">) {
   const [localNote, setLocalNote] = useState(note);
 
@@ -42,8 +44,10 @@ function NoteSheetContent({
   return (
     <DrawerContent className="flex flex-col">
       <DrawerHeader>
-        <DrawerTitle>Note</DrawerTitle>
-        <p className="text-sm text-muted-foreground">{exerciseName}</p>
+        <DrawerTitle>{title ?? "Note"}</DrawerTitle>
+        {exerciseName && (
+          <p className="text-sm text-muted-foreground">{exerciseName}</p>
+        )}
       </DrawerHeader>
 
       <div className="flex-1 px-4 py-4">
@@ -78,6 +82,7 @@ export function NoteSheet({
   exerciseName,
   note,
   onSave,
+  title,
 }: NoteSheetProps) {
   return (
     <Drawer open={open} onOpenChange={onOpenChange}>
@@ -87,6 +92,7 @@ export function NoteSheet({
           note={note}
           onOpenChange={onOpenChange}
           onSave={onSave}
+          title={title}
         />
       )}
     </Drawer>

--- a/src/components/workout/note-sheet.tsx
+++ b/src/components/workout/note-sheet.tsx
@@ -54,7 +54,11 @@ function NoteSheetContent({
         <textarea
           value={localNote}
           onChange={(e) => setLocalNote(e.target.value)}
-          placeholder="Add a note about this exercise..."
+          placeholder={
+            exerciseName
+              ? "Add a note about this exercise..."
+              : "Add a note about this workout..."
+          }
           className="w-full h-32 rounded-lg border bg-background px-3 py-2 text-sm placeholder:text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring resize-none"
           autoFocus
         />

--- a/src/components/workout/timed-exercise-accordion.tsx
+++ b/src/components/workout/timed-exercise-accordion.tsx
@@ -17,6 +17,7 @@ export interface TimedSetData {
 	setNumber: number;
 	durationSeconds: number;
 	rpe?: number | null;
+	isWarmup?: boolean;
 }
 
 interface TimedExerciseAccordionProps {

--- a/src/components/workout/workout-exercise-card.tsx
+++ b/src/components/workout/workout-exercise-card.tsx
@@ -81,7 +81,7 @@ function LiftingSetRow({
             </span>
           </>
         )}
-        {lifting.rpe && (
+        {lifting.rpe !== undefined && lifting.rpe > 0 && (
           <Badge variant="secondary" className="text-xs">
             RPE {lifting.rpe}
           </Badge>
@@ -113,7 +113,7 @@ function CardioEntryRow({
         <span className="font-medium font-mono tabular-nums">
           {formatHoldDuration(cardio.durationSeconds)}
         </span>
-        {cardio.intensity && (
+        {cardio.intensity !== undefined && cardio.intensity > 0 && (
           <Badge variant="secondary" className="text-xs">
             Level {cardio.intensity}
           </Badge>
@@ -132,6 +132,38 @@ function CardioEntryRow({
         {editable && <ChevronRight className="h-4 w-4 text-muted-foreground" />}
       </div>
     </RowWrapper>
+  );
+}
+
+function MobilityEntryRow({ entry }: { entry: Doc<"entries"> }) {
+  const mobility = entry.mobility;
+  if (!mobility) return null;
+
+  const parts: string[] = [];
+  if (mobility.sets !== undefined && mobility.sets > 1) {
+    parts.push(`${mobility.sets} sets`);
+  }
+  if (mobility.reps !== undefined && mobility.reps > 0) {
+    parts.push(`${mobility.reps} reps`);
+  }
+  if (mobility.holdSeconds !== undefined && mobility.holdSeconds > 0) {
+    parts.push(`${formatHoldDuration(mobility.holdSeconds)} hold`);
+  }
+
+  return (
+    <div className="flex w-full items-center justify-between rounded-md bg-muted/50 px-3 py-2 text-sm">
+      <span className="text-muted-foreground">
+        Mobility
+        {mobility.perSide && (
+          <Badge variant="outline" className="ml-2 text-xs">
+            Per side
+          </Badge>
+        )}
+      </span>
+      <span className="font-medium font-mono tabular-nums">
+        {parts.length > 0 ? parts.join(" · ") : "Done"}
+      </span>
+    </div>
   );
 }
 
@@ -192,6 +224,10 @@ export function WorkoutExerciseCard({
                 onEdit={() => onEditCardio(entry)}
               />
             );
+          }
+
+          if (entry.kind === "mobility" && entry.mobility) {
+            return <MobilityEntryRow key={entry._id} entry={entry} />;
           }
 
           return null;

--- a/src/components/workout/workout-exercise-card.tsx
+++ b/src/components/workout/workout-exercise-card.tsx
@@ -1,0 +1,218 @@
+"use client";
+
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+import { ChevronRight, MessageSquare } from "lucide-react";
+import { Doc } from "../../../convex/_generated/dataModel";
+import { displayWeight, type WeightUnit } from "@/lib/units";
+
+function formatHoldDuration(seconds: number) {
+  const mins = Math.floor(seconds / 60);
+  const secs = seconds % 60;
+  return secs > 0 ? `${mins}:${String(secs).padStart(2, "0")}` : `${mins}m`;
+}
+
+function RowWrapper({
+  editable,
+  onClick,
+  children,
+}: {
+  editable: boolean;
+  onClick: () => void;
+  children: React.ReactNode;
+}) {
+  const className =
+    "flex w-full items-center justify-between rounded-md bg-muted/50 px-3 py-2 text-sm";
+
+  if (!editable) {
+    return <div className={className}>{children}</div>;
+  }
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className={`${className} text-left transition-colors hover:bg-muted active:bg-muted`}
+    >
+      {children}
+    </button>
+  );
+}
+
+function LiftingSetRow({
+  entry,
+  preferredUnit,
+  editable,
+  onEdit,
+}: {
+  entry: Doc<"entries">;
+  preferredUnit: WeightUnit;
+  editable: boolean;
+  onEdit: () => void;
+}) {
+  const lifting = entry.lifting;
+  if (!lifting) return null;
+
+  return (
+    <RowWrapper editable={editable} onClick={onEdit}>
+      <span className="text-muted-foreground">
+        Set {lifting.setNumber}
+        {lifting.isWarmup && (
+          <Badge variant="outline" className="ml-2 text-xs">
+            Warmup
+          </Badge>
+        )}
+      </span>
+      <div className="flex items-center gap-3">
+        {lifting.durationSeconds !== undefined ? (
+          <span className="font-medium font-mono tabular-nums">
+            {formatHoldDuration(lifting.durationSeconds)} hold
+          </span>
+        ) : (
+          <>
+            <span className="font-medium font-mono tabular-nums">
+              {displayWeight(lifting.weight ?? 0, lifting.unit, preferredUnit)}{" "}
+              {preferredUnit}
+            </span>
+            <span className="text-muted-foreground">x</span>
+            <span className="font-medium font-mono tabular-nums">
+              {lifting.reps ?? 0} reps
+            </span>
+          </>
+        )}
+        {lifting.rpe && (
+          <Badge variant="secondary" className="text-xs">
+            RPE {lifting.rpe}
+          </Badge>
+        )}
+        {editable && <ChevronRight className="h-4 w-4 text-muted-foreground" />}
+      </div>
+    </RowWrapper>
+  );
+}
+
+function CardioEntryRow({
+  entry,
+  preferredUnit,
+  editable,
+  onEdit,
+}: {
+  entry: Doc<"entries">;
+  preferredUnit: WeightUnit;
+  editable: boolean;
+  onEdit: () => void;
+}) {
+  const cardio = entry.cardio;
+  if (!cardio) return null;
+
+  return (
+    <RowWrapper editable={editable} onClick={onEdit}>
+      <span className="text-muted-foreground capitalize">{cardio.mode}</span>
+      <div className="flex items-center gap-3">
+        <span className="font-medium font-mono tabular-nums">
+          {formatHoldDuration(cardio.durationSeconds)}
+        </span>
+        {cardio.intensity && (
+          <Badge variant="secondary" className="text-xs">
+            Level {cardio.intensity}
+          </Badge>
+        )}
+        {cardio.vestWeight !== undefined && (
+          <span className="font-medium font-mono tabular-nums">
+            Vest{" "}
+            {displayWeight(
+              cardio.vestWeight,
+              cardio.vestWeightUnit ?? "lb",
+              preferredUnit
+            )}{" "}
+            {preferredUnit}
+          </span>
+        )}
+        {editable && <ChevronRight className="h-4 w-4 text-muted-foreground" />}
+      </div>
+    </RowWrapper>
+  );
+}
+
+export function WorkoutExerciseCard({
+  exercise,
+  note,
+  preferredUnit,
+  editable,
+  onEditSet,
+  onEditCardio,
+  onEditNote,
+}: {
+  exercise: { name: string; entries: Doc<"entries">[] };
+  note?: string;
+  preferredUnit: WeightUnit;
+  editable: boolean;
+  onEditSet: (entry: Doc<"entries">) => void;
+  onEditCardio: (entry: Doc<"entries">) => void;
+  onEditNote: () => void;
+}) {
+  return (
+    <Card className="p-4">
+      <div className="mb-3 flex items-center justify-between gap-2">
+        <h3 className="font-semibold">{exercise.name}</h3>
+        {editable && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 shrink-0"
+            onClick={onEditNote}
+            aria-label={`Edit note for ${exercise.name}`}
+          >
+            <MessageSquare className="h-4 w-4 text-muted-foreground" />
+          </Button>
+        )}
+      </div>
+      <div className="space-y-2">
+        {exercise.entries.map((entry) => {
+          if (entry.kind === "lifting" && entry.lifting) {
+            return (
+              <LiftingSetRow
+                key={entry._id}
+                entry={entry}
+                preferredUnit={preferredUnit}
+                editable={editable}
+                onEdit={() => onEditSet(entry)}
+              />
+            );
+          }
+
+          if (entry.kind === "cardio" && entry.cardio) {
+            return (
+              <CardioEntryRow
+                key={entry._id}
+                entry={entry}
+                preferredUnit={preferredUnit}
+                editable={editable}
+                onEdit={() => onEditCardio(entry)}
+              />
+            );
+          }
+
+          return null;
+        })}
+      </div>
+      {note &&
+        (editable ? (
+          <button
+            type="button"
+            onClick={onEditNote}
+            className="mt-3 flex w-full items-start gap-2 rounded-md bg-muted/30 px-3 py-2 text-left text-sm transition-colors hover:bg-muted/50 active:bg-muted"
+          >
+            <MessageSquare className="h-4 w-4 mt-0.5 shrink-0 text-muted-foreground" />
+            <span className="text-muted-foreground">{note}</span>
+          </button>
+        ) : (
+          <div className="mt-3 flex items-start gap-2 rounded-md bg-muted/30 px-3 py-2 text-sm">
+            <MessageSquare className="h-4 w-4 mt-0.5 shrink-0 text-muted-foreground" />
+            <span className="text-muted-foreground">{note}</span>
+          </div>
+        ))}
+    </Card>
+  );
+}

--- a/src/lib/workout-set-edit.ts
+++ b/src/lib/workout-set-edit.ts
@@ -6,6 +6,7 @@ type StoredLiftingEntry = {
 	lifting?: {
 		weight?: number;
 		unit: WeightUnit;
+		isWarmup?: boolean;
 	};
 };
 
@@ -24,6 +25,7 @@ export type EditableLiftingSet = DisplayedLiftingSet & {
 	exerciseName: string;
 	storedWeight?: number;
 	storedUnit?: WeightUnit;
+	isWarmup?: boolean;
 };
 
 export function createEditableLiftingSet(
@@ -48,12 +50,13 @@ export function createEditableLiftingSet(
 		exerciseName,
 		storedWeight: storedSet?.weight,
 		storedUnit: storedSet?.unit,
+		isWarmup: storedSet?.isWarmup,
 	};
 }
 
 export function buildRepLiftingUpdate(
 	editingSet: EditableLiftingSet,
-	data: { reps?: number; weight?: number; rpe?: number | null }
+	data: { reps?: number; weight?: number; rpe?: number | null; isWarmup?: boolean }
 ) {
 	return {
 		setNumber: editingSet.setNumber,
@@ -71,5 +74,19 @@ export function buildRepLiftingUpdate(
 		unit: editingSet.storedUnit ?? editingSet.unit,
 		isBodyweight: editingSet.isBodyweight,
 		rpe: data.rpe ?? undefined,
+		isWarmup: data.isWarmup,
+	};
+}
+
+export function buildTimedLiftingUpdate(
+	editingSet: EditableLiftingSet,
+	data: { durationSeconds?: number; rpe?: number | null; isWarmup?: boolean }
+) {
+	return {
+		setNumber: editingSet.setNumber,
+		durationSeconds: data.durationSeconds,
+		unit: editingSet.storedUnit ?? editingSet.unit,
+		rpe: data.rpe ?? undefined,
+		isWarmup: data.isWarmup,
 	};
 }


### PR DESCRIPTION
## Summary

The workout detail page (`/workout/[id]`) previously limited editing to workout times and full-workout deletion. This makes logged workouts fully editable, mobile-first, reusing the active-flow edit components rather than forking them.

**Now editable on completed/cancelled workouts** (disabled while in progress — the active page owns that):

- **Workout title** — inline in the header (pencil → input, Enter/check commits, Escape cancels)
- **Workout notes** — add, edit, clear via NoteSheet
- **Lifting sets** — tap a row to edit weight, reps, hold duration, RPE, and warmup flag, or delete the set
- **Cardio entries** — tap to edit duration, intensity, vest weight, or delete the entry
- **Per-exercise notes** — header icon button + tappable note callout

## Implementation

- **Reuse over forking:** set editing reuses `EditSetSheet`/`SetStepper`/`RpeSelector` (extended with a warmup checkbox); notes reuse `NoteSheet` with a new optional `title` prop. New components: `EditCardioSheet` (modeled on `EditSetSheet`) and `WorkoutExerciseCard`, which extracts the page's previously duplicated set/cardio row markup. The page drops its hand-rolled entry types for generated `Doc<"entries">`.
- **Mobile-first:** rows are full-width tap targets opening vaul bottom drawers; `max-w-lg` centered container keeps desktop readable.
- **Backend:** new `updateWorkoutNotes` and `updateCardioEntry` mutations following existing ownership-check patterns, plus `convex/workoutSummary.ts` — a shared `recomputeWorkoutSummary` so entry edits/deletes keep `workout.summary` (volume/duration/cardio stats) fresh on completed workouts. In-progress/cancelled flows are untouched by the recompute.
- **Round-trip safety:** untouched-value guards preserve stored units on weight saves and second-precision cardio durations when only intensity/vest is edited; `isWarmup` is hydrated through the active page's edit paths so re-saving a set no longer risks clearing it.

## Known follow-up

Editing vest weight to 0 shows "Vest 0 lb" rather than clearing the vest — clearing needs a semantics decision in the update merge (was already reachable pre-change).

## Verification

- `bunx tsc --noEmit`: pass
- `bun run lint`: pass (7 pre-existing warnings in `convex/_generated` and `src/app/demo`, untouched)
- Adversarial review pass over the diff; both major findings (cardio duration truncation on untouched save, warmup-flag wipe on active-page re-save) fixed and re-verified
- Preserved behavior confirmed: export dialog, delete confirm, time editor, cancelled badge, loading/not-found states

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/house-of-giants/codesmith/opentrainer/pr/57"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789106187&installation_model_id=19704&pr_number=57&repository=house-of-giants%2Fopentrainer&return_to=https%3A%2F%2Fgithub.com%2Fhouse-of-giants%2Fopentrainer%2Fpull%2F57&signature=ddebd0ff071ae9396e6050ed9664857987086da73cc92abf44bc26a347965843"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Edit workout titles, notes, lifting sets, and cardio entries from workout details.
  * Update cardio duration, intensity, distance, and vest weight.
  * Mark lifting sets as warmups, including timed sets.
  * View workout summaries with volume, sets, exercise count, cardio duration, and distance.
  * Use improved exercise cards with clearer units and performance details.
* **Improvements**
  * Added validation, error messages, delete actions, and haptic feedback for editing.
  * Workout summaries refresh automatically after entry changes.
  * Editing controls are limited for active workouts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->