### PR TITLE
feat(web): announce the iPhone app to signed-in users

### DIFF
--- a/apps/web/src/app/dashboard/page.tsx
+++ b/apps/web/src/app/dashboard/page.tsx
@@ -11,6 +11,7 @@ import { BottomNav } from "@/components/navigation/bottom-nav";
 import { StartWorkoutSheet } from "@/components/workout/start-workout-sheet";
 import { WeeklyStatsGrid, GoalSettingDialog } from "@/components/dashboard";
 import { DashboardBriefCard } from "@/components/dashboard/dashboard-brief-card";
+import { IosAppNotice } from "@/components/ios-app-notice";
 import { TrainingLabCard } from "@/components/training-lab/training-lab-card";
 import { AsciiLogo } from "@/components/ui/ascii-logo";
 import { formatDuration } from "@/lib/utils";
@@ -129,6 +130,8 @@ export default function DashboardPage() {
 
 			<main className="flex-1 space-y-4 p-4 pb-24">
 				<h1 className="sr-only">Dashboard</h1>
+
+				<IosAppNotice />
 
 				{dashboardStats && activeWorkout !== undefined && workoutHistory !== undefined ? (
 					<DashboardBriefCard

--- a/apps/web/src/app/layout.tsx
+++ b/apps/web/src/app/layout.tsx
@@ -22,6 +22,10 @@ export const metadata: Metadata = {
 	description:
 		"Minimalist, AI-first workout tracking. Log lifts and cardio with ease, get AI-powered routine suggestions and performance assessments.",
 	manifest: "/manifest.json",
+	// iOS Safari's native smart app banner ("GET — App Store") sitewide.
+	itunes: {
+		appId: "6800907584",
+	},
 	icons: {
 		icon: [
 			{ url: "/icon.svg", type: "image/svg+xml" },

--- a/apps/web/src/components/ios-app-notice.tsx
+++ b/apps/web/src/components/ios-app-notice.tsx
@@ -1,0 +1,92 @@
+"use client";
+
+import { useSyncExternalStore } from "react";
+import Image from "next/image";
+import { X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+
+const APP_STORE_URL = "https://apps.apple.com/app/id6800907584";
+const DISMISSED_KEY = "opentrainer:ios-app-notice:dismissed";
+
+// One-time App Store launch announcement for signed-in users. Unlike
+// version-update-notice this never re-arms: any dismissal (the ✕ or
+// following the badge) is permanent.
+let listeners: Array<() => void> = [];
+
+function subscribe(listener: () => void) {
+	listeners.push(listener);
+	return () => {
+		listeners = listeners.filter((l) => l !== listener);
+	};
+}
+
+function isDismissed(): boolean {
+	try {
+		return window.localStorage.getItem(DISMISSED_KEY) !== null;
+	} catch {
+		// Storage can be unavailable in private or restricted browsing
+		// contexts; skip the notice rather than re-showing it forever.
+		return true;
+	}
+}
+
+function dismiss() {
+	try {
+		window.localStorage.setItem(
+			DISMISSED_KEY,
+			JSON.stringify({ dismissedAt: Date.now() })
+		);
+	} catch {
+		// Ignore; without storage the notice was never shown anyway.
+	}
+	for (const listener of listeners) listener();
+}
+
+export function IosAppNotice() {
+	// Server snapshot says "dismissed" so SSR and hydration render nothing;
+	// the real storage read happens on the client.
+	const dismissed = useSyncExternalStore(subscribe, isDismissed, () => true);
+
+	if (dismissed) return null;
+
+	return (
+		<div
+			role="status"
+			className="relative flex flex-col gap-3 rounded-xl border bg-card p-4 pr-12 sm:flex-row sm:items-center sm:justify-between"
+		>
+			<div className="min-w-0">
+				<p className="text-sm font-semibold">OpenTrainer is now on iPhone</p>
+				<p className="text-sm text-muted-foreground">
+					Same account, same data — with rest-timer alerts on your lock
+					screen. Free on the App Store.
+				</p>
+			</div>
+			<a
+				href={APP_STORE_URL}
+				target="_blank"
+				rel="noopener noreferrer"
+				aria-label="Download OpenTrainer on the App Store"
+				className="shrink-0 self-start transition-opacity hover:opacity-80 sm:self-auto"
+				onClick={dismiss}
+			>
+				<Image
+					src="/images/app-store-badge.svg"
+					alt="Download on the App Store"
+					width={135}
+					height={40}
+					className="h-10 w-auto"
+				/>
+			</a>
+			<Button
+				type="button"
+				variant="ghost"
+				size="icon"
+				className="absolute right-2 top-2 size-8 text-muted-foreground"
+				onClick={dismiss}
+				aria-label="Dismiss iPhone app announcement"
+			>
+				<X className="size-4" aria-hidden="true" />
+			</Button>
+		</div>
+	);
+}


### PR DESCRIPTION
Follow-up to #63 — tells existing web users the app exists:

1. **iOS Safari smart app banner** sitewide: one `itunes` metadata field → `apple-itunes-app` meta tag. iPhone Safari users get the native 'GET — App Store' banner, natively dismissible, zero custom UI.
2. **One-time dashboard card** for everyone else: 'OpenTrainer is now on iPhone — same account, same data' with the App Store badge and an ✕. Dismissal is permanent, persisted in localStorage via `useSyncExternalStore` (server snapshot renders nothing, so SSR/hydration are clean). Clicking the badge also counts as dismissal.

Deliberately not a toast — toasts auto-dismiss before an announcement is read; this waits until acknowledged.

**Verification:** build + eslint clean; Playwright against a temporary harness route (removed before commit): renders in light and dark at 1024px and 390px, dismiss hides it immediately, reload keeps it hidden, storage key `opentrainer:ios-app-notice:dismissed` written.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/house-of-giants/codesmith/opentrainer/pr/64"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789571845&installation_model_id=19704&pr_number=64&repository=house-of-giants%2Fopentrainer&return_to=https%3A%2F%2Fgithub.com%2Fhouse-of-giants%2Fopentrainer%2Fpull%2F64&signature=11971ccaa361c631cae4c4832a4a849a67becf7c2c830abff66d51ae808bd646"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->