### PR TITLE
fix(mobile): dead card taps on history, AI swap, and smart-swap screens

### DIFF
--- a/apps/mobile/src/app/(app)/(tabs)/history.tsx
+++ b/apps/mobile/src/app/(app)/(tabs)/history.tsx
@@ -1,4 +1,5 @@
-import { FlatList, Pressable, Text, View } from "react-native";
+import { FlatList, Text, View } from "react-native";
+import { Pressable } from "react-native-gesture-handler";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { useQuery } from "convex/react";

--- a/apps/mobile/src/app/(app)/routines/new/ai.tsx
+++ b/apps/mobile/src/app/(app)/routines/new/ai.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, type ReactNode } from "react";
-import { ActivityIndicator, Pressable, ScrollView, Text, View } from "react-native";
+import { ActivityIndicator, ScrollView, Text, View } from "react-native";
+import { Pressable } from "react-native-gesture-handler";
 import { SafeAreaView } from "react-native-safe-area-context";
 import { useRouter } from "expo-router";
 import { useAction, useMutation, useQuery } from "convex/react";

--- a/apps/mobile/src/components/workout/smart-swap-sheet.tsx
+++ b/apps/mobile/src/components/workout/smart-swap-sheet.tsx
@@ -1,5 +1,6 @@
 import { useState, type ReactNode } from "react";
-import { Pressable, Text, View } from "react-native";
+import { Text, View } from "react-native";
+import { Pressable } from "react-native-gesture-handler";
 import { useRouter } from "expo-router";
 import { useAction, useMutation, useQuery } from "convex/react";
 import { api } from "@opentrainer/backend";


### PR DESCRIPTION
Dominic found history-workout cards don't respond to taps. Root cause is the same nested-pressable conflict fixed on the routines screens in b22e659, in a subtler costume: these cards are core RN Pressables wrapping a `Card` styled with `active:bg-muted/50` — and css-interop **upgrades** an `active:`-classed View into its own core Pressable to track pressed state. The hidden inner Pressable wins the responder negotiation and the outer `onPress` never fires.

A sweep for the exact pattern (core Pressable → child with `active:` class) found three sites, all now on the gesture-handler Pressable like `routines.tsx` (which is verified working on-device with the identical structure):

- `(tabs)/history.tsx` — the reported bug: history cards → workout detail
- `routines/new/ai.tsx` — swap-reason cards in the AI wizard
- `components/workout/smart-swap-sheet.tsx` — swap-reason cards mid-workout

Screens where `active:` sits on the Pressable itself (dashboard recent-workout cards, workout-detail notes, training-lab, profile rows) are structurally fine and untouched.

Mobile suite 137/137, tsc + eslint clean. Needs on-device confirmation via the dev client; ships to the App Store with the next build (no OTA).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/house-of-giants/codesmith/opentrainer/pr/65"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789572828&installation_model_id=19704&pr_number=65&repository=house-of-giants%2Fopentrainer&return_to=https%3A%2F%2Fgithub.com%2Fhouse-of-giants%2Fopentrainer%2Fpull%2F65&signature=8268ad1844906a9d3c6cd4f7ad7de3d23dcb48a2d87ec5fedb59c1fc330e55a5"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->