### PR TITLE
fix(mobile): keyboard handling pass — sheets, dialogs, scroll surfaces

### DIFF
--- a/apps/mobile/src/app/(app)/routines/[id]/edit.tsx
+++ b/apps/mobile/src/app/(app)/routines/[id]/edit.tsx
@@ -401,7 +401,11 @@ export default function EditRoutineScreen() {
         </Button>
       </View>
 
-      <NestableScrollContainer contentContainerStyle={{ paddingBottom: 96 }}>
+      <NestableScrollContainer
+        contentContainerStyle={{ paddingBottom: 96 }}
+        automaticallyAdjustKeyboardInsets
+        keyboardShouldPersistTaps="handled"
+      >
         <View className="gap-6 p-4">
           <View className="gap-4">
             <View className="gap-2">

--- a/apps/mobile/src/app/(app)/routines/new.tsx
+++ b/apps/mobile/src/app/(app)/routines/new.tsx
@@ -393,7 +393,11 @@ export default function NewRoutineScreen() {
         </Button>
       </View>
 
-      <NestableScrollContainer contentContainerStyle={{ paddingBottom: 96 }}>
+      <NestableScrollContainer
+        contentContainerStyle={{ paddingBottom: 96 }}
+        automaticallyAdjustKeyboardInsets
+        keyboardShouldPersistTaps="handled"
+      >
         <View className="gap-6 p-4">
           <Pressable
             accessibilityRole="button"

--- a/apps/mobile/src/app/(app)/routines/new/ai.tsx
+++ b/apps/mobile/src/app/(app)/routines/new/ai.tsx
@@ -468,7 +468,12 @@ export default function AIRoutineGeneratorScreen() {
         </View>
       </View>
 
-      <ScrollView className="flex-1" contentContainerClassName="p-4 pb-24">
+      <ScrollView
+        className="flex-1"
+        contentContainerClassName="p-4 pb-24"
+        automaticallyAdjustKeyboardInsets
+        keyboardShouldPersistTaps="handled"
+      >
         {step === "form" && (
           <View className="gap-6">
             <View className="mb-2 items-center">

--- a/apps/mobile/src/app/(app)/workout/[id].tsx
+++ b/apps/mobile/src/app/(app)/workout/[id].tsx
@@ -568,7 +568,12 @@ export default function WorkoutDetailsScreen() {
         )}
       </View>
 
-      <ScrollView className="flex-1" contentContainerClassName="p-4 pb-16">
+      <ScrollView
+        className="flex-1"
+        contentContainerClassName="p-4 pb-16"
+        automaticallyAdjustKeyboardInsets
+        keyboardShouldPersistTaps="handled"
+      >
         <Card className="mb-6 p-4">
           {editable && (
             <View className="mb-4 flex-row justify-end gap-2">

--- a/apps/mobile/src/app/(app)/workout/active.tsx
+++ b/apps/mobile/src/app/(app)/workout/active.tsx
@@ -974,6 +974,8 @@ export default function ActiveWorkoutScreen() {
         ref={scrollRef}
         className="flex-1"
         contentContainerClassName="pb-8"
+        automaticallyAdjustKeyboardInsets
+        keyboardShouldPersistTaps="handled"
       >
         <View className="px-4 pt-4">
           <SessionCommandCenter

--- a/apps/mobile/src/components/profile/edit-equipment-dialog.tsx
+++ b/apps/mobile/src/components/profile/edit-equipment-dialog.tsx
@@ -104,7 +104,11 @@ export function EditEquipmentDialog({
         </DialogDescription>
       </DialogHeader>
 
-      <ScrollView className="flex-shrink" contentContainerClassName="gap-4 py-4">
+      <ScrollView
+				className="flex-shrink"
+				contentContainerClassName="gap-4 py-4"
+				keyboardShouldPersistTaps="handled"
+			>
         <View className="gap-2">
           <Label>Gym Description</Label>
           <Input

--- a/apps/mobile/src/components/ui/dialog.tsx
+++ b/apps/mobile/src/components/ui/dialog.tsx
@@ -1,5 +1,14 @@
 import { ReactNode } from "react";
-import { Modal, Pressable, Text, TextProps, View, ViewProps } from "react-native";
+import {
+  KeyboardAvoidingView,
+  Modal,
+  Platform,
+  Pressable,
+  Text,
+  TextProps,
+  View,
+  ViewProps,
+} from "react-native";
 import { X } from "lucide-react-native";
 
 import { cn } from "@/lib/cn";
@@ -39,37 +48,54 @@ function Dialog({
           onPress={() => onOpenChange(false)}
           accessibilityLabel="Close dialog"
         />
-        <View className="flex-1 items-center justify-center p-6" pointerEvents="box-none">
+        {/* Keeps dialogs with inputs centered in the space above the iOS
+            keyboard instead of half-hidden behind it. */}
+        <KeyboardAvoidingView
+          behavior={Platform.OS === "ios" ? "padding" : undefined}
+          style={{ flex: 1 }}
+          pointerEvents="box-none"
+        >
           <View
-            className={cn(
-              "w-full max-w-md gap-4 rounded-xl border border-border bg-background p-6",
-              contentClassName,
-            )}
+            className="flex-1 items-center justify-center p-6"
+            pointerEvents="box-none"
           >
-            {children}
-            {!hideClose && (
-              <Pressable
-                className="absolute right-4 top-4 h-8 w-8 items-center justify-center"
-                onPress={() => onOpenChange(false)}
-                accessibilityRole="button"
-                accessibilityLabel="Close"
-                hitSlop={8}
-              >
-                <X size={18} color={colors.mutedForeground} />
-              </Pressable>
-            )}
+            <View
+              className={cn(
+                "w-full max-w-md gap-4 rounded-xl border border-border bg-background p-6",
+                contentClassName,
+              )}
+            >
+              {children}
+              {!hideClose && (
+                <Pressable
+                  className="absolute right-4 top-4 h-8 w-8 items-center justify-center"
+                  onPress={() => onOpenChange(false)}
+                  accessibilityRole="button"
+                  accessibilityLabel="Close"
+                  hitSlop={8}
+                >
+                  <X size={18} color={colors.mutedForeground} />
+                </Pressable>
+              )}
+            </View>
           </View>
-        </View>
+        </KeyboardAvoidingView>
       </View>
     </Modal>
   );
 }
 
-function DialogHeader({ className, ...props }: ViewProps & { className?: string }) {
+function DialogHeader({
+  className,
+  ...props
+}: ViewProps & { className?: string }) {
   return <View className={cn("gap-2", className)} {...props} />;
 }
 
-function DialogTitle({ className, ...props }: TextProps & { className?: string }) {
+function DialogTitle({
+  className,
+  ...props
+}: TextProps & { className?: string }) {
   return (
     <Text
       className={cn("text-lg font-semibold text-foreground", className)}
@@ -83,11 +109,17 @@ function DialogDescription({
   ...props
 }: TextProps & { className?: string }) {
   return (
-    <Text className={cn("text-sm text-muted-foreground", className)} {...props} />
+    <Text
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
   );
 }
 
-function DialogFooter({ className, ...props }: ViewProps & { className?: string }) {
+function DialogFooter({
+  className,
+  ...props
+}: ViewProps & { className?: string }) {
   return (
     <View className={cn("flex-row justify-end gap-2", className)} {...props} />
   );

--- a/apps/mobile/src/components/ui/sheet.tsx
+++ b/apps/mobile/src/components/ui/sheet.tsx
@@ -2,7 +2,9 @@ import { ReactNode, useCallback, useEffect, useRef, useState } from "react";
 import {
   Animated,
   Easing,
+  KeyboardAvoidingView,
   Modal,
+  Platform,
   Pressable,
   ScrollView,
   Text,
@@ -44,7 +46,8 @@ function heightFraction(snapPoints?: (string | number)[]): number {
   if (typeof last === "number" && last > 0 && last <= 1) return last;
   if (typeof last === "string") {
     const parsed = Number.parseFloat(last);
-    if (!Number.isNaN(parsed)) return Math.min(Math.max(parsed / 100, 0.2), 0.95);
+    if (!Number.isNaN(parsed))
+      return Math.min(Math.max(parsed / 100, 0.2), 0.95);
   }
   return 0.6;
 }
@@ -111,44 +114,68 @@ function Sheet({
 
   return (
     <Modal visible transparent animationType="none" onRequestClose={close}>
-      {/* Modal renders outside the ThemeProvider tree; re-apply theme vars. */}
-      <View style={themes[resolved]} className="flex-1 justify-end">
-        <Animated.View
-          style={{ opacity: backdrop }}
-          className="absolute inset-0 bg-black/50"
-        >
-          <Pressable
-            className="flex-1"
-            onPress={close}
-            accessibilityLabel="Close sheet"
-          />
-        </Animated.View>
-        <Animated.View
-          style={{ transform: [{ translateY }], maxHeight }}
-          className="rounded-t-2xl bg-card"
-        >
-          <View className="items-center py-2">
-            <View className="h-1 w-10 rounded-full bg-muted-foreground/40" />
-          </View>
-          <Body
-            className={scrollable ? undefined : cn("px-4 pb-8", contentClassName)}
-            contentContainerClassName={
-              scrollable ? cn("px-4 pb-8", contentClassName) : undefined
-            }
+      {/* Lifts the sheet above the iOS keyboard; Android resizes the window
+          itself (adjustResize). Plain style, not className — KAV sits outside
+          the re-themed subtree below. */}
+      <KeyboardAvoidingView
+        behavior={Platform.OS === "ios" ? "padding" : undefined}
+        style={{ flex: 1 }}
+      >
+        {/* Modal renders outside the ThemeProvider tree; re-apply theme vars. */}
+        <View style={themes[resolved]} className="flex-1 justify-end">
+          <Animated.View
+            style={{ opacity: backdrop }}
+            className="absolute inset-0 bg-black/50"
           >
-            {children}
-          </Body>
-        </Animated.View>
-      </View>
+            <Pressable
+              className="flex-1"
+              onPress={close}
+              accessibilityLabel="Close sheet"
+            />
+          </Animated.View>
+          <Animated.View
+            // flexShrink lets the sheet compress into the keyboard-reduced
+            // space instead of overflowing off the top of the screen; a
+            // scrollable Body then scrolls within the compressed height.
+            style={{ transform: [{ translateY }], maxHeight, flexShrink: 1 }}
+            className="rounded-t-2xl bg-card"
+          >
+            <View className="items-center py-2">
+              <View className="h-1 w-10 rounded-full bg-muted-foreground/40" />
+            </View>
+            <Body
+              className={
+                scrollable ? undefined : cn("px-4 pb-8", contentClassName)
+              }
+              contentContainerClassName={
+                scrollable ? cn("px-4 pb-8", contentClassName) : undefined
+              }
+              // First tap on a result/input lands while the keyboard is open
+              // instead of only dismissing it.
+              {...(scrollable
+                ? { keyboardShouldPersistTaps: "handled" as const }
+                : {})}
+            >
+              {children}
+            </Body>
+          </Animated.View>
+        </View>
+      </KeyboardAvoidingView>
     </Modal>
   );
 }
 
-function SheetHeader({ className, ...props }: ViewProps & { className?: string }) {
+function SheetHeader({
+  className,
+  ...props
+}: ViewProps & { className?: string }) {
   return <View className={cn("gap-1.5 py-2", className)} {...props} />;
 }
 
-function SheetTitle({ className, ...props }: TextProps & { className?: string }) {
+function SheetTitle({
+  className,
+  ...props
+}: TextProps & { className?: string }) {
   return (
     <Text
       className={cn("text-lg font-semibold text-foreground", className)}
@@ -162,7 +189,10 @@ function SheetDescription({
   ...props
 }: TextProps & { className?: string }) {
   return (
-    <Text className={cn("text-sm text-muted-foreground", className)} {...props} />
+    <Text
+      className={cn("text-sm text-muted-foreground", className)}
+      {...props}
+    />
   );
 }
 


### PR DESCRIPTION
Dominic's report: keyboard covers inputs when editing reps/weight, covers exercise-search results, and blocks scrolling to lower content (can't reach exercise 6 while editing exercise 1). The app had no keyboard strategy outside auth/onboarding.

Three mechanisms, all JavaScript-only:

1. **Sheet primitive** — a `KeyboardAvoidingView` (padding) inside its Modal lifts every bottom sheet above the keyboard; one fix covers edit-set, exercise search, notes, and every other sheet consumer. `flexShrink` lets tall sheets compress instead of overflowing offscreen, and scrollable sheet bodies get `keyboardShouldPersistTaps="handled"` so the first tap on a search result lands instead of just dismissing the keyboard.
2. **Dialog primitive** — same KAV treatment; input dialogs stay centered in the space above the keyboard.
3. **Screen scroll containers** (active workout, workout detail, AI wizard, routine builder + editor, equipment dialog) — `automaticallyAdjustKeyboardInsets` (iOS bottom inset while the keyboard is up, so the whole page stays scrollable) + `keyboardShouldPersistTaps="handled"` (switching between inputs works on the first tap).

Verifiable on the current dev client (no native changes); rides into 1.0.1 and is OTA-shippable after that. If any surface still feels rough on-device, the escalation path is react-native-keyboard-controller in a future build — deliberately not taken now since it needs a new native build just to test.

137/137 tests, tsc + eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/house-of-giants/codesmith/opentrainer/pr/67"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789584368&installation_model_id=19704&pr_number=67&repository=house-of-giants%2Fopentrainer&return_to=https%3A%2F%2Fgithub.com%2Fhouse-of-giants%2Fopentrainer%2Fpull%2F67&signature=db0ab13c1bfed822465bb21627063b8287d30dc85e79cd7bd91945b312350a5e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard handling across routine, workout, dialog, and sheet screens.
  * Content now adjusts to remain visible above the keyboard.
  * Taps on fields and scrollable content continue working while the keyboard is open.
  * Improved layout behavior for dialogs and sheets on iOS.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->