### PR TITLE
fix(mobile): numeric inputs start empty with old value as placeholder

### DIFF
--- a/apps/mobile/src/components/profile/edit-bodyweight-dialog.tsx
+++ b/apps/mobile/src/components/profile/edit-bodyweight-dialog.tsx
@@ -35,17 +35,23 @@ export function EditBodyweightDialog({
   const [isSaving, setIsSaving] = useState(false);
   const updatePreferences = useMutation(api.users.updatePreferences);
 
+  // The current weight is shown as a placeholder, not prefilled text:
+  // typing a new weight needs no clearing, and saving with the field left
+  // empty simply closes the dialog unchanged.
   useEffect(() => {
-    if (open && currentWeight !== undefined) {
-      const fromUnit = storedUnit ?? "lb";
-      const converted = displayWeight(currentWeight, fromUnit, preferredUnit);
-      setWeight(converted.toString());
-    } else if (open) {
-      setWeight("");
-    }
-  }, [open, currentWeight, storedUnit, preferredUnit]);
+    if (open) setWeight("");
+  }, [open]);
+
+  const placeholderWeight =
+    currentWeight !== undefined
+      ? displayWeight(currentWeight, storedUnit ?? "lb", preferredUnit).toString()
+      : undefined;
 
   const handleSave = async () => {
+    if (weight.trim() === "") {
+      onOpenChange(false);
+      return;
+    }
     const weightValue = parseFloat(weight);
     if (isNaN(weightValue) || weightValue <= 0) {
       toast.error("Please enter a valid weight");
@@ -80,7 +86,7 @@ export function EditBodyweightDialog({
         <View className="flex-row items-center justify-center gap-3">
           <Input
             keyboardType="decimal-pad"
-            placeholder="Enter weight"
+            placeholder={placeholderWeight ?? "Enter weight"}
             value={weight}
             onChangeText={setWeight}
             className="h-14 w-32 text-center text-2xl"

--- a/apps/mobile/src/components/workout/__tests__/set-stepper.test.tsx
+++ b/apps/mobile/src/components/workout/__tests__/set-stepper.test.tsx
@@ -91,11 +91,33 @@ describe("SetStepper", () => {
     await renderWithTheme(<Harness onChange={onChange} />);
 
     await fireEvent.press(screen.getByLabelText("Edit WEIGHT"));
-    const input = screen.getByDisplayValue("135");
+    // Edit mode starts empty (no clearing needed to type a new weight);
+    // the current value is the placeholder.
+    const input = screen.getByPlaceholderText("135");
     await fireEvent.changeText(input, "225");
     await fireEvent(input, "blur");
 
     expect(onChange).toHaveBeenCalledWith(225);
     expect(screen.getByText("225")).toBeOnTheScreen();
+  });
+
+  it("keeps the current value when edit mode is left empty", async () => {
+    const onChange = jest.fn();
+    await renderWithTheme(
+      <SetStepper
+        label="WEIGHT"
+        value={135}
+        onChange={onChange}
+        step={5}
+        unit="lb"
+      />
+    );
+
+    await fireEvent.press(screen.getByLabelText("Edit WEIGHT"));
+    const input = screen.getByPlaceholderText("135");
+    await fireEvent(input, "blur");
+
+    expect(onChange).not.toHaveBeenCalled();
+    expect(screen.getByText("135")).toBeOnTheScreen();
   });
 });

--- a/apps/mobile/src/components/workout/set-stepper.tsx
+++ b/apps/mobile/src/components/workout/set-stepper.tsx
@@ -49,7 +49,11 @@ export function SetStepper({
 
   const handleValuePress = () => {
     vibrate("light");
-    setInputValue(value.toString());
+    // Start empty with the current value as placeholder: typing a new
+    // weight needs no clearing, and blurring without typing keeps the old
+    // value (commitValue treats empty as no-op). selectTextOnFocus can't do
+    // this job — it silently fails on iOS when paired with autoFocus.
+    setInputValue("");
     setIsEditing(true);
   };
 
@@ -85,9 +89,9 @@ export function SetStepper({
           {isEditing ? (
             <Input
               autoFocus
-              selectTextOnFocus
               keyboardType="decimal-pad"
               returnKeyType="done"
+              placeholder={value.toString()}
               value={inputValue}
               onChangeText={setInputValue}
               onBlur={commitValue}

--- a/apps/mobile/src/components/workout/timed-exercise-accordion.tsx
+++ b/apps/mobile/src/components/workout/timed-exercise-accordion.tsx
@@ -226,6 +226,7 @@ export function TimedExerciseAccordion({
             <Input
               keyboardType="number-pad"
               returnKeyType="done"
+              selectTextOnFocus
               value={String(durationSeconds)}
               onChangeText={(text) => {
                 setError(null);


### PR DESCRIPTION
Dominic's report: changing weight mid-set means deleting the prefilled value every time.

The stepper already had `selectTextOnFocus`, but that prop silently fails on iOS when focus is programmatic (`autoFocus`) — a long-standing RN quirk. Instead of fighting it, edit mode now opens an **empty input with the current value as the placeholder**: typing a new weight needs zero clearing, and blurring without typing keeps the old value (the commit path already treated empty as a no-op). Same-weight-every-set flow is untouched — the value is still one tap-away-and-back.

Applied to the three prefilled numeric inputs:
- **SetStepper** (weight + reps, the reported case)
- **Bodyweight dialog** (was prefilled + autoFocus too; save with empty field just closes unchanged)
- **Timed accordion duration** gets `selectTextOnFocus` instead — focus is user-initiated there, where the prop genuinely works

138 tests (adds a keep-on-empty regression test), tsc + eslint clean. JS-only: verify on the dev client, OTA-shippable post-1.0.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/house-of-giants/codesmith/opentrainer/pr/68"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789585074&installation_model_id=19704&pr_number=68&repository=house-of-giants%2Fopentrainer&return_to=https%3A%2F%2Fgithub.com%2Fhouse-of-giants%2Fopentrainer%2Fpull%2F68&signature=25deb88448f36bd2d88ada17f85fee3d5ee60d1a7f3a4f7e6d829280b27def79"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->