### PR TITLE
feat(mobile): carry RPE forward within an exercise

### DIFF
--- a/apps/mobile/src/components/workout/exercise-accordion.tsx
+++ b/apps/mobile/src/components/workout/exercise-accordion.tsx
@@ -379,7 +379,12 @@ export function ExerciseAccordion({
 
   const [weight, setWeight] = useState(initialWeight);
   const [reps, setReps] = useState(initialReps);
-  const [rpe, setRpe] = useState<number | null>(null);
+  // Effort carries forward within an exercise, like weight and reps: the
+  // selector starts at the last logged set's RPE and keeps the chosen value
+  // after each set instead of resetting.
+  const [rpe, setRpe] = useState<number | null>(
+    sets.length > 0 ? (sets[sets.length - 1].rpe ?? null) : null,
+  );
   const [hasEditedWeight, setHasEditedWeight] = useState(false);
   const [hasEditedReps, setHasEditedReps] = useState(false);
   const [isBodyweight, setIsBodyweight] = useState(
@@ -422,7 +427,6 @@ export function ExerciseAccordion({
       isBodyweight,
       rpe,
     });
-    setRpe(null);
   };
 
   const handleBodyweightToggle = () => {

--- a/apps/mobile/src/components/workout/timed-exercise-accordion.tsx
+++ b/apps/mobile/src/components/workout/timed-exercise-accordion.tsx
@@ -77,7 +77,11 @@ export function TimedExerciseAccordion({
   const [durationSeconds, setDurationSeconds] = useState(
     sets.at(-1)?.durationSeconds ?? targetDurationSeconds,
   );
-  const [rpe, setRpe] = useState<number | null>(null);
+  // Effort carries forward within an exercise: start at the last logged
+  // set's RPE and keep the chosen value after each set.
+  const [rpe, setRpe] = useState<number | null>(
+    sets.length > 0 ? (sets[sets.length - 1].rpe ?? null) : null,
+  );
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showNoteSheet, setShowNoteSheet] = useState(false);
@@ -96,7 +100,6 @@ export function TimedExerciseAccordion({
     setIsSubmitting(true);
     try {
       await onAddSet({ durationSeconds, rpe });
-      setRpe(null);
       vibrate("success");
     } catch {
       setError("This set could not be saved. Try again.");


### PR DESCRIPTION
The RPE selector reset to empty after every logged set, so a 4×8 at RPE 8 meant re-selecting the effort four times. It now behaves exactly like weight and reps already do: initialized from the last logged set's RPE and kept after each set. Applied to both the lifting and timed accordions. Adjusting mid-exercise still works — the selector just stops forgetting.

138/138 tests, tsc + eslint clean. JS-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/house-of-giants/codesmith/opentrainer/pr/69"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789587602&installation_model_id=19704&pr_number=69&repository=house-of-giants%2Fopentrainer&return_to=https%3A%2F%2Fgithub.com%2Fhouse-of-giants%2Fopentrainer%2Fpull%2F69&signature=0078e1b5a5f231c6d2b780bf7b70436ef0432522b8beb6f04486d16b7bba7a3f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->