### PR TITLE
fix(mobile): added exercises land at the bottom; edit custom exercises in the picker

### DIFF
--- a/apps/mobile/src/app/(app)/workout/active.tsx
+++ b/apps/mobile/src/app/(app)/workout/active.tsx
@@ -600,7 +600,17 @@ export default function ActiveWorkoutScreen() {
           console.error("Failed to create exercise:", error);
         }
       }
-      setPendingExercises((prev) => [...prev, exercise]);
+      setPendingExercises((prev) => {
+        // In workouts without a routine, already-logged exercises exist only
+        // as entry groups, which render AFTER pendings — so a bare append
+        // would put the new exercise above them. Freeze the current display
+        // order into the pending list first, then append.
+        const known = new Set(prev.map((p) => getExerciseGroupKey(p)));
+        const entryOnly = exerciseList
+          .filter(([key]) => !known.has(key))
+          .map(([, group]) => group.meta);
+        return [...prev, ...entryOnly, exercise];
+      });
     }
     setShowAddExercise(false);
   };

--- a/apps/mobile/src/components/workout/add-exercise-sheet.tsx
+++ b/apps/mobile/src/components/workout/add-exercise-sheet.tsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
-import { Pressable, Text, View } from "react-native";
-import { useQuery } from "convex/react";
+import { Text, View } from "react-native";
+import { Pressable } from "react-native-gesture-handler";
+import { useMutation, useQuery } from "convex/react";
 import { api } from "@opentrainer/backend";
-import { Dumbbell, Heart, Plus, Search, X } from "lucide-react-native";
+import type { Id } from "@opentrainer/backend";
+import { Dumbbell, Heart, Pencil, Plus, Search, X } from "lucide-react-native";
 
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
@@ -40,7 +42,9 @@ export function AddExerciseSheet({
   const [customExercise, setCustomExercise] = useState("");
   const [searchQuery, setSearchQuery] = useState("");
   const [activeTab, setActiveTab] = useState<"lifting" | "cardio">("lifting");
-  const [selectedMuscleGroups, setSelectedMuscleGroups] = useState<string[]>([]);
+  const [selectedMuscleGroups, setSelectedMuscleGroups] = useState<string[]>(
+    [],
+  );
   const [showMuscleGroupPicker, setShowMuscleGroupPicker] = useState(false);
   const [customMeasurementType, setCustomMeasurementType] = useState<
     "reps" | "duration"
@@ -53,6 +57,77 @@ export function AddExerciseSheet({
     search: searchQuery || undefined,
   });
   const muscleGroups = useQuery(api.exercises.getMuscleGroups, {});
+  const updateExercise = useMutation(api.exercises.updateExercise);
+
+  // In-sheet edit mode for the user's own (non-system) exercises.
+  const [editing, setEditing] = useState<{
+    id: Id<"exercises">;
+    category: "lifting" | "cardio" | "mobility" | "other";
+  } | null>(null);
+  const [editName, setEditName] = useState("");
+  const [editMuscleGroups, setEditMuscleGroups] = useState<string[]>([]);
+  const [editMeasurementType, setEditMeasurementType] = useState<
+    "reps" | "duration"
+  >("reps");
+  const [editError, setEditError] = useState<string | null>(null);
+  const [editSaving, setEditSaving] = useState(false);
+
+  const startEdit = (exercise: {
+    _id: Id<"exercises">;
+    name: string;
+    category: "lifting" | "cardio" | "mobility" | "other";
+    muscleGroups?: string[];
+    measurementType?: "reps" | "duration";
+  }) => {
+    vibrate("light");
+    setEditing({ id: exercise._id, category: exercise.category });
+    setEditName(exercise.name);
+    setEditMuscleGroups(exercise.muscleGroups ?? []);
+    setEditMeasurementType(exercise.measurementType ?? "reps");
+    setEditError(null);
+  };
+
+  const saveEdit = async () => {
+    if (!editing) return;
+    const name = editName.trim();
+    if (!name) {
+      setEditError("Exercise name is required");
+      return;
+    }
+    if (editing.category === "lifting" && editMuscleGroups.length === 0) {
+      setEditError("Select at least one muscle group");
+      return;
+    }
+    setEditSaving(true);
+    try {
+      await updateExercise({
+        id: editing.id,
+        name,
+        ...(editing.category === "lifting"
+          ? {
+              muscleGroups: editMuscleGroups,
+              measurementType: editMeasurementType,
+            }
+          : {}),
+      });
+      vibrate("success");
+      setEditing(null);
+    } catch (error) {
+      setEditError(
+        error instanceof Error ? error.message : "Failed to update exercise",
+      );
+    } finally {
+      setEditSaving(false);
+    }
+  };
+
+  const toggleEditMuscleGroup = (muscle: string) => {
+    setEditMuscleGroups((prev) =>
+      prev.includes(muscle)
+        ? prev.filter((m) => m !== muscle)
+        : [...prev, muscle],
+    );
+  };
 
   const handleSelect = (exercise: ExerciseSelection) => {
     vibrate("medium");
@@ -85,7 +160,8 @@ export function AddExerciseSheet({
         name: customExercise.trim(),
         category: activeTab,
         primaryMetric: activeTab === "cardio" ? "duration" : undefined,
-        measurementType: activeTab === "lifting" ? customMeasurementType : undefined,
+        measurementType:
+          activeTab === "lifting" ? customMeasurementType : undefined,
         muscleGroups:
           selectedMuscleGroups.length > 0 ? selectedMuscleGroups : undefined,
       });
@@ -93,102 +169,46 @@ export function AddExerciseSheet({
   };
 
   return (
-    <Sheet open={open} onOpenChange={onOpenChange} snapPoints={["85%"]} scrollable>
+    <Sheet
+      open={open}
+      onOpenChange={(next) => {
+        if (!next) setEditing(null);
+        onOpenChange(next);
+      }}
+      snapPoints={["85%"]}
+      scrollable
+    >
       <SheetHeader>
-        <SheetTitle>Add Exercise</SheetTitle>
+        <SheetTitle>{editing ? "Edit Exercise" : "Add Exercise"}</SheetTitle>
         <SheetDescription>
-          Select an exercise or create a custom one
+          {editing
+            ? "Changes apply everywhere this exercise is used"
+            : "Select an exercise or create a custom one"}
         </SheetDescription>
       </SheetHeader>
 
-      <View className="gap-4 pb-8 pt-2">
-        <Tabs
-          value={activeTab}
-          onValueChange={(v) => setActiveTab(v as "lifting" | "cardio")}
-        >
-          <TabsList>
-            <TabsTrigger value="lifting">
-              <Dumbbell
-                size={16}
-                color={
-                  activeTab === "lifting"
-                    ? colors.foreground
-                    : colors.mutedForeground
-                }
-              />
-              <Text
-                className={
-                  activeTab === "lifting"
-                    ? "text-sm font-medium text-foreground"
-                    : "text-sm font-medium text-muted-foreground"
-                }
-              >
-                Lifting
-              </Text>
-            </TabsTrigger>
-            <TabsTrigger value="cardio">
-              <Heart
-                size={16}
-                color={
-                  activeTab === "cardio"
-                    ? colors.foreground
-                    : colors.mutedForeground
-                }
-              />
-              <Text
-                className={
-                  activeTab === "cardio"
-                    ? "text-sm font-medium text-foreground"
-                    : "text-sm font-medium text-muted-foreground"
-                }
-              >
-                Cardio
-              </Text>
-            </TabsTrigger>
-          </TabsList>
-        </Tabs>
-
-        <View className="relative justify-center">
-          <View className="absolute left-3 z-10">
-            <Search size={16} color={colors.mutedForeground} />
-          </View>
-          <Input
-            placeholder="Search exercises..."
-            value={searchQuery}
-            onChangeText={setSearchQuery}
-            className="h-12 pl-10"
-          />
-        </View>
-
-        <View className="gap-3">
-          <View className="flex-row gap-2">
+      {editing ? (
+        <View className="gap-4 pb-8 pt-2">
+          <View className="gap-2">
+            <Text className="text-sm font-medium text-foreground">Name</Text>
             <Input
-              placeholder={`Custom ${activeTab} exercise...`}
-              value={customExercise}
-              onChangeText={setCustomExercise}
-              className="h-12 flex-1"
+              value={editName}
+              onChangeText={setEditName}
+              className="h-12"
+              accessibilityLabel="Exercise name"
             />
-            <Button
-              size="lg"
-              className="h-12 px-4"
-              onPress={handleCustomSubmit}
-              disabled={!customExercise.trim()}
-              accessibilityLabel="Add custom exercise"
-            >
-              <Plus size={20} color={colors.primaryForeground} />
-            </Button>
           </View>
 
-          {customExercise.trim() && activeTab === "lifting" ? (
-            <View className="gap-2">
+          {editing.category === "lifting" && (
+            <>
               <View className="gap-2">
                 <Text className="text-sm font-medium text-foreground">
                   Measure By
                 </Text>
                 <Tabs
-                  value={customMeasurementType}
+                  value={editMeasurementType}
                   onValueChange={(value) =>
-                    setCustomMeasurementType(value as "reps" | "duration")
+                    setEditMeasurementType(value as "reps" | "duration")
                   }
                 >
                   <TabsList>
@@ -197,38 +217,18 @@ export function AddExerciseSheet({
                   </TabsList>
                 </Tabs>
               </View>
-              <View className="flex-row items-center justify-between">
+
+              <View className="gap-2">
                 <Text className="text-sm font-medium text-foreground">
-                  Muscle Groups{" "}
-                  {showMuscleGroupPicker && (
-                    <Text className="text-destructive">*</Text>
-                  )}
+                  Muscle Groups
                 </Text>
-                {selectedMuscleGroups.length > 0 && (
-                  <Pressable onPress={() => setSelectedMuscleGroups([])}>
-                    <Text className="text-xs text-muted-foreground">Clear</Text>
-                  </Pressable>
-                )}
-              </View>
-
-              {showMuscleGroupPicker && selectedMuscleGroups.length === 0 && (
-                <Text className="text-xs text-destructive">
-                  Please select at least one muscle group
-                </Text>
-              )}
-
-              <View className="flex-row flex-wrap gap-2">
-                {!muscleGroups ? (
-                  <Text className="text-sm text-muted-foreground">
-                    Loading muscle groups...
-                  </Text>
-                ) : (
-                  muscleGroups.map((muscle) => {
-                    const selected = selectedMuscleGroups.includes(muscle);
+                <View className="flex-row flex-wrap gap-2">
+                  {muscleGroups?.map((muscle) => {
+                    const selected = editMuscleGroups.includes(muscle);
                     return (
                       <Pressable
                         key={muscle}
-                        onPress={() => toggleMuscleGroup(muscle)}
+                        onPress={() => toggleEditMuscleGroup(muscle)}
                         accessibilityRole="button"
                         accessibilityState={{ selected }}
                       >
@@ -251,61 +251,252 @@ export function AddExerciseSheet({
                         </Badge>
                       </Pressable>
                     );
-                  })
-                )}
+                  })}
+                </View>
               </View>
-            </View>
-          ) : null}
-        </View>
+            </>
+          )}
 
-        <View className="gap-2">
-          {exercises?.map((exercise) => (
-            <Pressable
-              key={exercise._id}
-              className="h-14 flex-row items-center justify-between rounded-lg border border-border bg-card px-4 active:bg-muted/70"
-              onPress={() =>
-                handleSelect({
-                  name: exercise.name,
-                  category: exercise.category,
-                  primaryMetric: exercise.primaryMetric,
-                  measurementType: exercise.measurementType,
-                  equipment: exercise.equipment,
-                  muscleGroups: exercise.muscleGroups,
-                })
-              }
-              accessibilityRole="button"
+          {editError && (
+            <Text className="text-sm text-destructive">{editError}</Text>
+          )}
+
+          <View className="flex-row gap-2">
+            <Button
+              variant="outline"
+              className="flex-1"
+              onPress={() => setEditing(null)}
+              disabled={editSaving}
             >
-              <Text
-                numberOfLines={1}
-                className="flex-1 font-medium text-foreground"
-              >
-                {exercise.name}
-              </Text>
-              {exercise.category === "cardio" && (
-                <Text className="ml-2 shrink-0 text-xs text-muted-foreground">
-                  {exercise.primaryMetric === "distance" ? "Distance" : "Time"}
+              Cancel
+            </Button>
+            <Button className="flex-1" onPress={saveEdit} loading={editSaving}>
+              Save
+            </Button>
+          </View>
+        </View>
+      ) : (
+        <View className="gap-4 pb-8 pt-2">
+          <Tabs
+            value={activeTab}
+            onValueChange={(v) => setActiveTab(v as "lifting" | "cardio")}
+          >
+            <TabsList>
+              <TabsTrigger value="lifting">
+                <Dumbbell
+                  size={16}
+                  color={
+                    activeTab === "lifting"
+                      ? colors.foreground
+                      : colors.mutedForeground
+                  }
+                />
+                <Text
+                  className={
+                    activeTab === "lifting"
+                      ? "text-sm font-medium text-foreground"
+                      : "text-sm font-medium text-muted-foreground"
+                  }
+                >
+                  Lifting
                 </Text>
-              )}
-              {exercise.category === "lifting" &&
-                exercise.measurementType === "duration" && (
-                  <Text className="ml-2 shrink-0 text-xs text-muted-foreground">
-                    Time
+              </TabsTrigger>
+              <TabsTrigger value="cardio">
+                <Heart
+                  size={16}
+                  color={
+                    activeTab === "cardio"
+                      ? colors.foreground
+                      : colors.mutedForeground
+                  }
+                />
+                <Text
+                  className={
+                    activeTab === "cardio"
+                      ? "text-sm font-medium text-foreground"
+                      : "text-sm font-medium text-muted-foreground"
+                  }
+                >
+                  Cardio
+                </Text>
+              </TabsTrigger>
+            </TabsList>
+          </Tabs>
+
+          <View className="relative justify-center">
+            <View className="absolute left-3 z-10">
+              <Search size={16} color={colors.mutedForeground} />
+            </View>
+            <Input
+              placeholder="Search exercises..."
+              value={searchQuery}
+              onChangeText={setSearchQuery}
+              className="h-12 pl-10"
+            />
+          </View>
+
+          <View className="gap-3">
+            <View className="flex-row gap-2">
+              <Input
+                placeholder={`Custom ${activeTab} exercise...`}
+                value={customExercise}
+                onChangeText={setCustomExercise}
+                className="h-12 flex-1"
+              />
+              <Button
+                size="lg"
+                className="h-12 px-4"
+                onPress={handleCustomSubmit}
+                disabled={!customExercise.trim()}
+                accessibilityLabel="Add custom exercise"
+              >
+                <Plus size={20} color={colors.primaryForeground} />
+              </Button>
+            </View>
+
+            {customExercise.trim() && activeTab === "lifting" ? (
+              <View className="gap-2">
+                <View className="gap-2">
+                  <Text className="text-sm font-medium text-foreground">
+                    Measure By
+                  </Text>
+                  <Tabs
+                    value={customMeasurementType}
+                    onValueChange={(value) =>
+                      setCustomMeasurementType(value as "reps" | "duration")
+                    }
+                  >
+                    <TabsList>
+                      <TabsTrigger value="reps">Reps</TabsTrigger>
+                      <TabsTrigger value="duration">Time</TabsTrigger>
+                    </TabsList>
+                  </Tabs>
+                </View>
+                <View className="flex-row items-center justify-between">
+                  <Text className="text-sm font-medium text-foreground">
+                    Muscle Groups{" "}
+                    {showMuscleGroupPicker && (
+                      <Text className="text-destructive">*</Text>
+                    )}
+                  </Text>
+                  {selectedMuscleGroups.length > 0 && (
+                    <Pressable onPress={() => setSelectedMuscleGroups([])}>
+                      <Text className="text-xs text-muted-foreground">
+                        Clear
+                      </Text>
+                    </Pressable>
+                  )}
+                </View>
+
+                {showMuscleGroupPicker && selectedMuscleGroups.length === 0 && (
+                  <Text className="text-xs text-destructive">
+                    Please select at least one muscle group
                   </Text>
                 )}
-            </Pressable>
-          ))}
-          {exercises?.length === 0 && (
-            <View className="items-center py-8">
-              <Text className="text-sm text-muted-foreground">
-                No exercises found
-              </Text>
-              <Text className="mt-1 text-xs text-muted-foreground">
-                Add a custom exercise above
-              </Text>
-            </View>
-          )}
+
+                <View className="flex-row flex-wrap gap-2">
+                  {!muscleGroups ? (
+                    <Text className="text-sm text-muted-foreground">
+                      Loading muscle groups...
+                    </Text>
+                  ) : (
+                    muscleGroups.map((muscle) => {
+                      const selected = selectedMuscleGroups.includes(muscle);
+                      return (
+                        <Pressable
+                          key={muscle}
+                          onPress={() => toggleMuscleGroup(muscle)}
+                          accessibilityRole="button"
+                          accessibilityState={{ selected }}
+                        >
+                          <Badge
+                            variant={selected ? "default" : "outline"}
+                            className="h-10 px-4"
+                          >
+                            <Text
+                              className={
+                                selected
+                                  ? "text-sm font-medium capitalize text-primary-foreground"
+                                  : "text-sm font-medium capitalize text-foreground"
+                              }
+                            >
+                              {muscle}
+                            </Text>
+                            {selected && (
+                              <X size={14} color={colors.primaryForeground} />
+                            )}
+                          </Badge>
+                        </Pressable>
+                      );
+                    })
+                  )}
+                </View>
+              </View>
+            ) : null}
+          </View>
+
+          <View className="gap-2">
+            {exercises?.map((exercise) => (
+              <Pressable
+                key={exercise._id}
+                className="h-14 flex-row items-center justify-between rounded-lg border border-border bg-card px-4 active:bg-muted/70"
+                onPress={() =>
+                  handleSelect({
+                    name: exercise.name,
+                    category: exercise.category,
+                    primaryMetric: exercise.primaryMetric,
+                    measurementType: exercise.measurementType,
+                    equipment: exercise.equipment,
+                    muscleGroups: exercise.muscleGroups,
+                  })
+                }
+                accessibilityRole="button"
+              >
+                <Text
+                  numberOfLines={1}
+                  className="flex-1 font-medium text-foreground"
+                >
+                  {exercise.name}
+                </Text>
+                {exercise.category === "cardio" && (
+                  <Text className="ml-2 shrink-0 text-xs text-muted-foreground">
+                    {exercise.primaryMetric === "distance"
+                      ? "Distance"
+                      : "Time"}
+                  </Text>
+                )}
+                {exercise.category === "lifting" &&
+                  exercise.measurementType === "duration" && (
+                    <Text className="ml-2 shrink-0 text-xs text-muted-foreground">
+                      Time
+                    </Text>
+                  )}
+                {!exercise.isSystemExercise && (
+                  <Pressable
+                    onPress={() => startEdit(exercise)}
+                    hitSlop={8}
+                    accessibilityRole="button"
+                    accessibilityLabel={`Edit ${exercise.name}`}
+                    className="ml-2 h-9 w-9 shrink-0 items-center justify-center rounded-md active:bg-muted"
+                  >
+                    <Pencil size={15} color={colors.mutedForeground} />
+                  </Pressable>
+                )}
+              </Pressable>
+            ))}
+            {exercises?.length === 0 && (
+              <View className="items-center py-8">
+                <Text className="text-sm text-muted-foreground">
+                  No exercises found
+                </Text>
+                <Text className="mt-1 text-xs text-muted-foreground">
+                  Add a custom exercise above
+                </Text>
+              </View>
+            )}
+          </View>
         </View>
-      </View>
+      )}
     </Sheet>
   );
 }


### PR DESCRIPTION
Two items from Dominic's dogfooding:

**1. Mid-workout added exercises jumped to the top.** The display map seeds pending exercises before entry-only groups; in a workout without a routine everything already logged exists only as entries, so a new pending exercise rendered first — and shifted every index under `currentExerciseIndex`. `handleAddExercise` now freezes the current display order into the pending list before appending, so new exercises land at the bottom and existing indices are stable.

**2. Custom exercises are now editable from the add-exercise picker.** The backend `updateExercise` mutation (ownership-checked, dedupe-checked) already exists and web already calls it — but on both platforms the only UI entry point was the routine editor, so an ad-hoc custom exercise in no routine was uneditable. The picker now shows a pencil on non-system exercises; it flips the sheet into an edit form (name, measure-by, muscle groups). Rows move to the gesture-handler Pressable so the nested edit button doesn't swallow row taps (the b22e659 pattern).

No backend changes — the mutation is already live in prod (web depends on it). 138/138 tests, tsc + eslint clean. JS-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- codesmith:footer -->
---
<a href="https://app.blacksmith.sh/house-of-giants/codesmith/opentrainer/pr/70"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-light-v2.svg"><img alt="View with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/view-with-codesmith-dark-v2.svg"></picture></a> <a href="https://backend.blacksmith.sh/track/enable-autofix?expires=1789587950&installation_model_id=19704&pr_number=70&repository=house-of-giants%2Fopentrainer&return_to=https%3A%2F%2Fgithub.com%2Fhouse-of-giants%2Fopentrainer%2Fpull%2F70&signature=1a603f3577dc8508161c8097794c904616913289ab941a6817c1e17af252e421"><picture><source media="(prefers-color-scheme: dark)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-light.svg"><img alt="Autofix with [code]smith" src="https://pr-comments-assets.blacksmith.sh/codesmith/autofix-with-codesmith-dark.svg"></picture></a>
<sup>Need help on this PR? Tag <code>@codesmith-bot</code> with what you need. Autofix is disabled.</sup>

<!-- codesmith:autofix:disabled -->
<!-- /codesmith:footer -->